### PR TITLE
Add HOME Build Arg for docker builds

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -45,6 +45,10 @@ use_rust_parser = true
 [ruff]
 config = "ruff.toml"
 
+[docker]
+use_buildx = true
+build_args = ["HOME"]
+
 [docker.registries.dockerhub]
 address = "docker.io"
 default = true


### PR DESCRIPTION
Docker on mac seems to require this to complete the build successfully