### PR TITLE
Adding a Ray service to local Docker compose

### DIFF
--- a/.devcontainer/docker-compose-local.yaml
+++ b/.devcontainer/docker-compose-local.yaml
@@ -24,7 +24,7 @@ services:
       # https://docs.localstack.cloud/references/init-hooks/
       - ./localstack:/etc/localstack/init/ready.d
 
-  ray-head:
+  ray:
     image: rayproject/ray:nightly-py311-cpu-aarch64
     ports:
       - "6379:6379"


### PR DESCRIPTION


1. Pull branch
2. `make local-up`
3. You should now see four services, including Ray: 
<img width="323" alt="Screenshot 2024-06-25 at 9 44 20 AM" src="https://github.com/mozilla-ai/mzai-platform/assets/3837836/3c8e23b0-ca92-4942-985b-28f3fcfb1f2a">

4. test accessing the service from the web app by accessing `http://127.0.0.1/api/v1/finetuning/jobs`, you should get an OK response 
<img width="358" alt="Screenshot 2024-06-25 at 9 45 05 AM" src="https://github.com/mozilla-ai/mzai-platform/assets/3837836/dae74867-7acd-4807-b9be-635f85da046b">

