### PR TITLE
Adding num_replicas to summarizer

### DIFF
--- a/lumigator/python/mzai/backend/api/deployments/summarizer_config_loader.py
+++ b/lumigator/python/mzai/backend/api/deployments/summarizer_config_loader.py
@@ -64,7 +64,9 @@ class SummarizerConfigLoader(ConfigLoader):
                         RayServeDeploymentConfig(
                             name="Summarizer",
                             num_replicas=num_replicas,
-                            ray_actor_options=RayServeActorConfig(num_cpus=1.0, num_gpus=num_gpus),
+                            ray_actor_options=RayServeActorConfig(
+                                num_cpus=1.0, num_gpus=num_gpus, num_replicas=num_replicas
+                            ),
                         )
                     ],
                 )

--- a/lumigator/python/mzai/backend/services/groundtruth.py
+++ b/lumigator/python/mzai/backend/services/groundtruth.py
@@ -24,9 +24,7 @@ class GroundTruthService:
         self.ray_client = ray_serve_client
 
     def create_deployment(self, request: GroundTruthDeploymentCreate):
-        conf = SummarizerConfigLoader(
-            num_gpus=request.num_gpus, num_instances=request.num_instances
-        )
+        conf = SummarizerConfigLoader(num_gpus=request.num_gpus, num_replicas=request.num_replicas)
         deployment_args = conf.get_config_dict()
         deployment_name = conf.get_deployment_name()
         deployment_description = conf.get_deployment_description()

--- a/lumigator/python/mzai/schemas/groundtruth.py
+++ b/lumigator/python/mzai/schemas/groundtruth.py
@@ -8,7 +8,7 @@ from mzai.schemas.deployments import DeploymentStatus
 
 class GroundTruthDeploymentCreate(BaseModel):
     num_gpus: float | None = None
-    num_instances: int | None = None
+    num_replicas: int | None = None
 
 
 class GroundTruthDeploymentUpdate(BaseModel):


### PR DESCRIPTION
Builds on  https://github.com/mozilla-ai/lumigator/pull/87 to enable scaling of summarizer to multiple users 


> num_replicas - [Controls the number of replicas](https://docs.ray.io/en/latest/serve/configure-serve-deployment.html) to run that handle requests to this deployment. This can be a positive integer, in which case the number of replicas stays constant, or auto, in which case the number of replicas will autoscale with a default configuration (see [Ray Serve Autoscaling](https://docs.ray.io/en/latest/serve/autoscaling-guide.html#serve-autoscaling) for more). Defaults to 1.