### PR TITLE
Fix local compose and summarizer config

### DIFF
--- a/.devcontainer/docker-compose-local.yaml
+++ b/.devcontainer/docker-compose-local.yaml
@@ -76,7 +76,7 @@ services:
       - S3_BUCKET=lumigator-storage
       - PYTHONPATH=/mzai/lumigator/python/mzai:/mzai/lumigator/python
       - RAY_DASHBOARD_PORT=8265
-      - RAY_HEAD_NODE_HOST=${RAY_HEAD_NODE_HOST}
+      - RAY_HEAD_NODE_HOST=ray
       - LOCAL_FSSPEC_S3_ENDPOINT_URL=${LOCAL_FSSPEC_S3_ENDPOINT_URL}
       - LOCAL_FSSPEC_S3_KEY=${LOCAL_FSSPEC_S3_KEY}
       - LOCAL_FSSPEC_S3_SECRET=${LOCAL_FSSPEC_S3_SECRET}

--- a/lumigator/python/mzai/backend/api/deployments/summarizer_config_loader.py
+++ b/lumigator/python/mzai/backend/api/deployments/summarizer_config_loader.py
@@ -11,12 +11,11 @@ from mzai.summarizer.summarizer import SummarizerArgs
 class RayServeActorConfig(BaseModel):
     num_cpus: float
     num_gpus: float | None = None
-    num_replicas: float | None = None
+    num_replicas: int | None = None
 
 
 class RayServeDeploymentConfig(BaseModel):
     name: str
-    num_replicas: int
     ray_actor_options: RayServeActorConfig
 
 


### PR DESCRIPTION
Some of the env variable changes we made broke local docker-compose, putting out a hotfix and also adjusting the summarizer config loader. 

To test locally:

```
curl -X POST http://127.0.0.1/api/v1/ground-truth/deployments -H "Content-Type: application/json" \
  -d '{
  "deployment_id": "",
  "deployment_type": "groundtruth",
  "args": {
    "num_replicas": 2,
    "num_gpus": 1.0
  },
  "description": "",
  "name": ""
}'``


```