### PR TITLE
Hotfix: fix status in groundtruth

### DIFF
--- a/lumigator/python/mzai/backend/services/groundtruth.py
+++ b/lumigator/python/mzai/backend/services/groundtruth.py
@@ -58,7 +58,7 @@ class GroundTruthService:
             response = requests.post(base_url, headers=headers, json={"text": [request.text]})
             return GroundTruthDeploymentQueryResponse(deployment_response=response.json())
         except Exception as e:
-            raise HTTPException(status.INTERNAL_SERVER_ERROR, detail=str(e)) from e
+            raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)) from e
 
     def _get_deployment_record(self, deployment_id: UUID) -> GroundTruthDeploymentRecord:
         record = self.deployment_repo.get(deployment_id)


### PR DESCRIPTION
Was not raising the correct `starlette` status, `status.HTTP_500_INTERNAL_SERVER_ERROR`