### PR TITLE
Add endpoint to query Ray Job status directly via Lumigator

### DIFF
--- a/lumigator/python/mzai/backend/api/routes/health.py
+++ b/lumigator/python/mzai/backend/api/routes/health.py
@@ -7,13 +7,15 @@ import requests
 import json
 from uuid import UUID
 from mzai.backend.settings import settings
-from typing import  List
+from typing import List
+
 router = APIRouter()
 
 
 @router.get("/")
 def get_health() -> HealthResponse:
     return HealthResponse(deployment_type=settings.DEPLOYMENT_TYPE, status="OK")
+
 
 @router.get("/jobs/{job_id}")
 def get_job_metadata(job_id: UUID) -> JobSubmissionResponse:
@@ -29,13 +31,16 @@ def get_job_metadata(job_id: UUID) -> JobSubmissionResponse:
     else:
         return {"error": f"HTTP error {resp.status_code}"}
 
+
 @router.get("/jobs/")
 def get_all_jobs() -> List[JobSubmissionResponse]:
     resp = requests.get(f"{settings.RAY_DASHBOARD_URL}/api/jobs/")
     if resp.status_code == 200:
         try:
             metadata = json.loads(resp.text)
-            submissions: List[JobSubmissionResponse] = [JobSubmissionResponse(**item) for item in metadata]
+            submissions: List[JobSubmissionResponse] = [
+                JobSubmissionResponse(**item) for item in metadata
+            ]
             return submissions
         except json.JSONDecodeError as e:
             print(f"JSON decode error: {e}")

--- a/lumigator/python/mzai/schemas/jobs.py
+++ b/lumigator/python/mzai/schemas/jobs.py
@@ -1,10 +1,10 @@
+from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, Optional
 from uuid import UUID
 
-from pydantic import BaseModel,Field
-from typing import Optional,Literal, Union
-from datetime import datetime
+from pydantic import BaseModel, Field
+
 
 class JobType(str, Enum):
     EXPERIMENT = "experiment"
@@ -30,6 +30,7 @@ class JobEvent(BaseModel):
     status: JobStatus
     detail: str | None = None
 
+
 class JobSubmissionResponse(BaseModel):
     type: str | None = None
     job_id: Optional[str] = None
@@ -37,7 +38,7 @@ class JobSubmissionResponse(BaseModel):
     driver_info: Optional[str] = None
     status: str | None = None
     entrypoint: str | None = None
-    message:str | None = None
+    message: str | None = None
     error_type: Optional[str] = None
     start_time: Optional[datetime] = None
     end_time: Optional[datetime] = None

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 
 src = ["lumigator"]
-target-version = "py310"
+target-version = "py311"
 # Group violations by containing file
 output-format = "grouped"
 


### PR DESCRIPTION
Add ability to get job status directly from Ray cluster following example here https://docs.ray.io/en/latest/cluster/running-applications/job-submission/rest.html