### PR TITLE
Added support for eval using Mistral API (lm-buddy 0.12.0)

### DIFF
--- a/lumigator/python/mzai/backend/config_templates.py
+++ b/lumigator/python/mzai/backend/config_templates.py
@@ -55,4 +55,5 @@ config_template = {
     "oai://gpt-4o-mini": oai_template,
     "oai://gpt-4-turbo": oai_template,
     "oai://gpt-3.5-turbo-0125": oai_template,
+    "mistral://open-mistral-7b": oai_template,
 }

--- a/lumigator/python/mzai/backend/services/experiments.py
+++ b/lumigator/python/mzai/backend/services/experiments.py
@@ -82,13 +82,13 @@ class ExperimentService:
         # fill up model url with default openai url
         if request.model.startswith("oai://"):
             model_url = settings.OAI_API_URL
+        elif request.model.startswith("mistral://"):
+            model_url = settings.MISTRAL_API_URL
         else:
             model_url = request.model_url
 
         # provide a reasonable system prompt for services where none was specified
-        if request.system_prompt is None and (
-            request.model.startswith("oai://") or request.model.startswith("http://")
-        ):
+        if request.system_prompt is None and not request.model.startswith("hf://"):
             request.system_prompt = settings.DEFAULT_SUMMARIZER_PROMPT
 
         config_params = {
@@ -136,7 +136,7 @@ class ExperimentService:
             worker_gpus = int(os.environ.get(settings.RAY_WORKER_GPUS_ENV_VAR, 0))
 
         runtime_env = {
-            "pip": ["lm-buddy==0.10.10"],
+            "pip": ["lm-buddy[jobs]==0.12.0"],
             "env_vars": runtime_env_vars,
         }
         entrypoint = RayJobEntrypoint(

--- a/lumigator/python/mzai/backend/settings.py
+++ b/lumigator/python/mzai/backend/settings.py
@@ -37,11 +37,13 @@ class BackendSettings(BaseSettings):
         "LOCAL_FSSPEC_S3_ENDPOINT_URL",
         "HF_TOKEN",
         "OPENAI_API_KEY",
+        "MISTRAL_API_KEY",
     ]
     RAY_WORKER_GPUS_ENV_VAR: str = "RAY_WORKER_GPUS"
 
     # Served models
     OAI_API_URL: str = "https://api.openai.com/v1"
+    MISTRAL_API_URL: str = "https://api.mistral.ai/v1"
     DEFAULT_SUMMARIZER_PROMPT: str = "You are a helpful assistant, expert in text summarization. For every prompt you receive, provide a summary of its contents in at most two sentences."  # noqa: E501
 
     # Summarizer


### PR DESCRIPTION
Should be testable in notebooks on AWS with model name: `mistral://open-mistral-7b`