### PR TITLE
hotfix: num replicas for summarizer

### DIFF
--- a/lumigator/python/mzai/backend/api/deployments/summarizer_config_loader.py
+++ b/lumigator/python/mzai/backend/api/deployments/summarizer_config_loader.py
@@ -9,13 +9,13 @@ from mzai.summarizer.summarizer import SummarizerArgs
 
 
 class RayServeActorConfig(BaseModel):
-    num_cpus: float
+    num_cpus: float | None = None
     num_gpus: float | None = None
-    num_replicas: int | None = None
 
 
 class RayServeDeploymentConfig(BaseModel):
     name: str
+    num_replicas: int | None = None
     ray_actor_options: RayServeActorConfig
 
 
@@ -63,9 +63,7 @@ class SummarizerConfigLoader(ConfigLoader):
                         RayServeDeploymentConfig(
                             name="Summarizer",
                             num_replicas=num_replicas,
-                            ray_actor_options=RayServeActorConfig(
-                                num_cpus=1.0, num_gpus=num_gpus, num_replicas=num_replicas
-                            ),
+                            ray_actor_options=RayServeActorConfig(num_cpus=1.0, num_gpus=num_gpus),
                         )
                     ],
                 )


### PR DESCRIPTION
To follow config [YAML file](https://docs.ray.io/en/latest/serve/api/doc/ray.serve.deployment_decorator.html):

```
num_replicas – Number of replicas to run that handle requests to this deployment. Defaults to 1.
```

```
ray_actor_options – Options to pass to the Ray Actor decorator, such as resource requirements. Valid options are: accelerator_type, memory, num_cpus, num_gpus, resources, and runtime_env.
```
<img width="314" alt="Screenshot 2024-07-31 at 2 18 31 PM" src="https://github.com/user-attachments/assets/a8c11129-fe2f-448c-a5b5-8525961bc234">
