### PR TITLE
Tiny 🐊 for Lumigator homepage

### DIFF
--- a/lumigator/python/mzai/backend/main.py
+++ b/lumigator/python/mzai/backend/main.py
@@ -11,8 +11,6 @@ from mzai.backend.records.base import BaseRecord
 from loguru import logger
 import sys
 import os
-from fastapi.staticfiles import StaticFiles
-from pathlib import Path
 
 
 def create_app(engine: Engine) -> FastAPI:


### PR DESCRIPTION
Our current main API route and homepage are sad, since we have a human-readable URL makes sense to spruce it up a little. Now whenever you hit "/", you'll get a lumigator. 

Now: 
<img width="586" alt="Screenshot 2024-08-01 at 7 22 42 AM" src="https://github.com/user-attachments/assets/222f6e32-77cc-4a92-9d26-6949eaf5602b">

Future: 
<img width="412" alt="Screenshot 2024-08-01 at 7 24 09 AM" src="https://github.com/user-attachments/assets/0ad1fe2d-e28d-4268-bf08-1c392469017c">



