### PR TITLE
Updates bootstrapping scripts for platform detection and pants parametrization

### DIFF
--- a/.pants.bootstrap
+++ b/.pants.bootstrap
@@ -9,16 +9,9 @@
 # git hash and state for docker images
 # and to do platform/cuda specific setup.
 #####
-
-REPOVERSION=$(git describe --tags --dirty --match "[0-9\.]*" --always)
-export REPOVERSION
-
-PLAT=$(uname -o)
+. ./devtools/shell/common.sh
 
 
-# echo "***bootstrapping pants***"
-
-###
 if [[ "$PLAT" == "Darwin" ]]; then
  indexes="+[]"
 else
@@ -34,16 +27,19 @@ else
     docker_tools="+['pass','docker-credential-pass']"
     export PANTS_DOCKER_TOOLS="$docker_tools"
   fi
-  if [[ $(command -v nvcc >/dev/null 2>&1) ]]; then
+	if [[ "$CUDA_AVAILABLE" != 0 ]]; then
     echo "Running on Linux and found nvcc; setting env var to use the linux_cuda python lockfile."
     echo "if you cannot use cuda in pytorch/etc., there might be an issue with how pants sees the resolves."
     PANTS_PYTHON_RESOLVES="linux_cuda"
     export PANTS_PYTHON_RESOLVES
     # TODO - dynamic cuda version
-    indexes="+['https://download.pytorch.org/whl/cuda118/']"
+    indexes="+['https://download.pytorch.org/whl/cuda${TORCH_CUDA_VERSION}']"
   else
     indexes="+['https://download.pytorch.org/whl/cpu']"
   fi
 fi
+
 PANTS_PYTHON_REPOS_INDEXES=$indexes
 export PANTS_PYTHON_REPOS_INDEXES
+REPOVERSION=$(git describe --tags --dirty --match "[0-9\.]*" --always)
+export REPOVERSION

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ endif
 
 $(PYTHON):
 	@echo "Installing python and configuring venv"
-	bash pants_tools/bootstrap_python.sh
+	bash devtools/shell/bootstrap_python.sh
 
 $(VENV): $(PYTHON)
 

--- a/devtools/shell/bootstrap_python.sh
+++ b/devtools/shell/bootstrap_python.sh
@@ -1,28 +1,25 @@
 #!/usr/bin/env bash
-set -eou pipefail
-
 # Requires curl.
+set -eou pipefail
+# note that this is mostly ran from the repo root, so this is a relative path from there.
+if [[ -f "devtools/shell/common.sh" ]]; then
+  source devtools/shell/common.sh
+elif [[ -f "common.sh" ]]; then
+  source common.sh
+else
+  echo "cannot find common.sh; exiting"
+  exit 1
+fi
 
-function check_if_installed() {
-	tool=$1
-	test=$(command -v "$tool")
-	if [[ -z $test ]]; then
-		echo "0"
-	else
-		echo "$test"
-	fi
-}
 
 PLAT=$(uname -o)
-
 PY_VERSION=${MZAI_PY_VERISON:-3.11.9}
+# from common.sh
 PYTHON_INSTALLED=$(check_if_installed python)
 CUDA_AVAILABLE=$(check_if_installed nvcc)
-TORCH_VERSION="2.4.0"
-TORCH_CUDA_VERSION="cu121"
 UV_INSTALLED=$(check_if_installed uv)
 VENVNAME="mzaivenv"
-UV_ARGS=("--override" "tmp_overrides.txt")
+UV_ARGS=("--override" "tmp_overrides.txt" "--index-strategy=unsafe-best-match")
 
 if [[ $PLAT == 'Darwin' ]]; then
 	echo "Darwin setup"
@@ -35,6 +32,7 @@ else
 	PY_NAME=cpython-3.11.9-linux-x86_64-gnu
 	if [[ "$CUDA_AVAILABLE" != 0 ]]; then
 		echo "nvcc found; configuring with CUDA"
+		# versions found in common.sh
 		echo "torch[cuda]==${TORCH_VERSION}+${TORCH_CUDA_VERSION}" >tmp_overrides.txt
 		UV_ARGS+=("--extra-index-url" "https://download.pytorch.org/whl/${TORCH_CUDA_VERSION}")
 	else

--- a/devtools/shell/common.sh
+++ b/devtools/shell/common.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+# Requires curl.
+
+
+function check_if_installed() {
+	tool=$1
+	test=$(command -v "$tool")
+	# return a 0 if this is not found; command output is nil if the tool isn't there
+	if [[ -z $test ]]; then
+		echo "0"
+	else
+		echo "$test"
+	fi
+}
+
+PLAT=$(uname -o)
+CUDA_AVAILABLE=$(check_if_installed nvcc)
+TORCH_VERSION="2.4.0"
+TORCH_CUDA_VERSION="cu121"
+LUMIGATOR_PATH="${HOME}/workspace/lumigator"
+
+export PLAT
+export CUDA_AVAILABLE
+export TORCH_VERSION
+export TORCH_CUDA_VERSION
+export LUMIGATOR_PATH

--- a/devtools/shell/pants.sh
+++ b/devtools/shell/pants.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
+set -eou pipefail
 # this script is to help ease using parametrization in Pants.
 # most targets will take a parametrize argument and this will ensure
 # that a command is used with a _single_ parametrization, not multiple.
 
-function check_if_installed() {
-	tool=$1
-	test=$(command -v "$tool")
-	# return a 0 if this is not found; command output is nil if the tool isn't there
-	if [[ -z $test ]]; then
-		echo "0"
-	else
-		echo "$test"
-	fi
-}
 
+if [[ -f "devtools/shell/common.sh" ]]; then
+  source devtools/shell/common.sh
+elif [[ -f "common.sh" ]]; then
+  source common.sh
+else
+  echo "cannot find common.sh; exiting"
+  exit 1
+fi
 
+# sourced from common
 CUDA_AVAILABLE=$(check_if_installed nvcc)
 PLAT=$(uname -o)
 
@@ -33,18 +33,23 @@ fi
 if [[ "$#" == 0 ]]; then
   echo "no goal or target"
 else
+  pushd "${LUMIGATOR_PATH}"
   echo "~~~~ pants platform parametrizer ~~~~"
   echo "running the following pants command:"
   echo "$(which pants)" "${*}@parametrize=${PARAMETRIZE}"
   echo "~~~~~~~~"
   echo ""
-  $(which pants) ${*}@parametrize=${PARAMETRIZE}
-  # shellcheck disable=SC2181
-  if [[ "$?" != 0 ]]; then
+  pants_finished_file=".pants_complete.lock"
+  touch ${pants_finished_file}
+  $(which pants) ${*}@parametrize=${PARAMETRIZE} && rm ${pants_finished_file}
+  if [[ -f ${pants_finished_file} ]]; then
+    rm ${pants_finished_file}
     echo "~~~~ pants platform parametrizer ~~~~"
-    echo "it's possible you don't need to use this script - run your pants command again without it like:"
+    echo "previous invocation failed - running your pants command again without it like:"
     echo ""
     echo pants "${*}"
     echo "~~~~~~~"
+    $(which pants) ${*}
   fi
+  popd
 fi


### PR DESCRIPTION
Addresses the hotfix from #178. 

Makes a few changes in how these scripts are handled. 

- moves them to one folder
- adds a `common.sh` that can be sourced from others which provides a few small utilities
- cleaned up the `pants.sh` script to retry your command on failure; could add more explicit checking/handling.