### PR TITLE
[LUMI-21] Make required fields as `required` in chart

### DIFF
--- a/lumigator/infra/mzai/helm/lumigator/Chart.yaml
+++ b/lumigator/infra/mzai/helm/lumigator/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: ""
+appVersion: "0.1.0-alpha.1"

--- a/lumigator/infra/mzai/helm/lumigator/templates/_helpers.tpl
+++ b/lumigator/infra/mzai/helm/lumigator/templates/_helpers.tpl
@@ -31,6 +31,20 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Return lumigator repo
+*/}}
+{{- define "lumigator.repo" -}}
+{{- required "The repository for the Lumigator image is missing" .Values.image.repository }}
+{{- end }}
+
+{{/*
+Return lumigator tag
+*/}}
+{{- define "lumigator.tag" -}}
+{{- .Values.image.tag | default .Chart.AppVersion | required "The tag for the Lumigator image is missing" }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "lumigator.labels" -}}

--- a/lumigator/infra/mzai/helm/lumigator/templates/deployment.yaml
+++ b/lumigator/infra/mzai/helm/lumigator/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ required "The repository for the Lumigator image is missing" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/lumigator/infra/mzai/helm/lumigator/templates/deployment.yaml
+++ b/lumigator/infra/mzai/helm/lumigator/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ required "The repository for the Lumigator image is missing" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{- include "lumigator.repo" . }}:{{- include "lumigator.tag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/lumigator/infra/mzai/helm/lumigator/templates/deployment.yaml
+++ b/lumigator/infra/mzai/helm/lumigator/templates/deployment.yaml
@@ -45,25 +45,25 @@ spec:
             - name: AWS_ENDPOINT_URL
               value: {{ .Values.AWSEndpointURL | quote }}
             - name: S3_BUCKET
-              value: {{ .Values.s3Bucket | quote }}
+              value: {{ required "Missing S3 bucket name" .Values.s3Bucket | quote }}
             - name: POSTGRES_DB
-              value: {{ .Values.postgresDb | quote }}
+              value: {{ required "Missing PostgreSQL database name" .Values.postgresDb | quote }}
             - name: POSTGRES_HOST
-              value: {{ .Values.postgresHost | quote }}
+              value: {{ required "Missing PostgreSQL hostname" .Values.postgresHost | quote }}
             - name: POSTGRES_PORT
-              value: {{ .Values.postgresPort | quote }}
+              value: {{ required "Missing PostgreSQL port" .Values.postgresPort | quote }}
             - name: POSTGRES_USER
-              value: {{ .Values.postgresUser | quote }}
+              value: {{ required "Missing PostgreSQL user" .Values.postgresUser | quote }}
             - name: POSTGRES_PASSWORD
-              value: {{ .Values.postgresPassword | quote }}
+              value: {{ required "Missing PostgreSQL password" .Values.postgresPassword | quote }}
             - name: RAY_HEAD_NODE_HOST
-              value: {{ .Values.rayAddress | quote }}
+              value: {{ required "Missing Ray head node hostname" .Values.rayAddress | quote }}
             - name: RAY_DASHBOARD_PORT
-              value: {{ .Values.rayPort | quote }}
+              value: {{ required "Missing Ray dashboard node port" .Values.rayPort | quote }}
             - name: SUMMARIZER_WORK_DIR
-              value: {{ .Values.summarizerWorkDir | quote }}
+              value: {{ required "Missing Summarizer work directory name" .Values.summarizerWorkDir | quote }}
             - name: RAY_WORKER_GPUS
-              value: {{ .Values.rayWorkerGPUs | quote }}
+              value: {{ required "Missing Ray Worker GPU number" .Values.rayWorkerGPUs | quote }}
               # pragma: allowlist-nextline secret
             {{- if .Values.mistralSecretName }}
             - name: MISTRAL_API_KEY # kubectl create secret generic mistral-key --from-literal MISTRAL_API_KEY=value


### PR DESCRIPTION
Chart values that are needed for the Deployment env vars should be made `required`, and show an error if they are null-valued (following the Go template definition).