### PR TITLE
[LUMI-19] Coreweave s3 support

### DIFF
--- a/.devcontainer/docker-compose-local.yaml
+++ b/.devcontainer/docker-compose-local.yaml
@@ -79,12 +79,11 @@ services:
       - POSTGRES_USER=admin
       - POSTGRES_PASSWORD=password
       - POSTGRES_DB=lumigator
-      - AWS_HOST=localstack
+      - S3_ENDPOINT_URL=http://localstack:4566
       - AWS_ACCESS_KEY_ID=test
       - AWS_SECRET_ACCESS_KEY=test
       - AWS_DEFAULT_REGION=us-east-2
       - AWS_ENDPOINT_URL=http://localstack:4566
-      - S3_PORT=4566
       - S3_BUCKET=lumigator-storage
       - PYTHONPATH=/mzai/lumigator/python/mzai:/mzai/lumigator/python
       - RAY_DASHBOARD_PORT=8265

--- a/lumigator/infra/mzai/helm/lumigator/templates/deployment.yaml
+++ b/lumigator/infra/mzai/helm/lumigator/templates/deployment.yaml
@@ -36,6 +36,14 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           env:
+            - name: AWS_ACCESS_KEY
+              value: {{ .Values.AWSAccessKey | quote }}
+            - name: AWS_SECRET_KEY
+              value: {{ .Values.AWSSecretKey | quote }}
+            - name: AWS_HOST
+              value: {{ .Values.AWSHost | quote }}
+            - name: AWS_ENDPOINT_URL
+              value: {{ .Values.AWSEndpointURL | quote }}
             - name: S3_BUCKET
               value: {{ .Values.s3Bucket | quote }}
             - name: POSTGRES_DB

--- a/lumigator/infra/mzai/helm/lumigator/templates/deployment.yaml
+++ b/lumigator/infra/mzai/helm/lumigator/templates/deployment.yaml
@@ -40,8 +40,8 @@ spec:
               value: {{ .Values.AWSAccessKey | quote }}
             - name: AWS_SECRET_KEY
               value: {{ .Values.AWSSecretKey | quote }}
-            - name: AWS_HOST
-              value: {{ .Values.AWSHost | quote }}
+            - name: S3_ENDPOINT_URL
+              value: {{ .Values.s3EndpointURL | quote }}
             - name: AWS_ENDPOINT_URL
               value: {{ .Values.AWSEndpointURL | quote }}
             - name: S3_BUCKET

--- a/lumigator/infra/mzai/helm/lumigator/values.yaml
+++ b/lumigator/infra/mzai/helm/lumigator/values.yaml
@@ -7,17 +7,17 @@ replicaCount: 1
 s3Bucket: ""
 AWSAccessKey: ""
 AWSSecretKey: ""
-AWSHost: ""
+s3EndpointURL: ""
 AWSEndpointURL: ""
 
 postgresDb: ""
 postgresHost: ""
-postgresPort: ""
+postgresPort: "3306"
 postgresUser: ""
 postgresPassword: ""
 
 rayAddress: ""
-rayPort: ""
+rayPort: "3306"
 rayWorkerGPUs: ""
 
 serviceAccountName: ""
@@ -31,7 +31,7 @@ image:
   repository: "mzdotai/lumigator"
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "backend_dev"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/lumigator/infra/mzai/helm/lumigator/values.yaml
+++ b/lumigator/infra/mzai/helm/lumigator/values.yaml
@@ -5,6 +5,10 @@
 replicaCount: 1
 
 s3Bucket: ""
+AWSAccessKey: ""
+AWSSecretKey: ""
+AWSHost: ""
+AWSEndpointURL: ""
 
 postgresDb: ""
 postgresHost: ""

--- a/lumigator/infra/mzai/helm/lumigator/values.yaml
+++ b/lumigator/infra/mzai/helm/lumigator/values.yaml
@@ -12,12 +12,12 @@ AWSEndpointURL: ""
 
 postgresDb: ""
 postgresHost: ""
-postgresPort: "3306"
+postgresPort: ""
 postgresUser: ""
 postgresPassword: ""
 
 rayAddress: ""
-rayPort: "3306"
+rayPort: ""
 rayWorkerGPUs: ""
 
 serviceAccountName: ""
@@ -31,7 +31,7 @@ image:
   repository: "mzdotai/lumigator"
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "backend_dev"
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/lumigator/python/mzai/backend/settings.py
+++ b/lumigator/python/mzai/backend/settings.py
@@ -18,8 +18,7 @@ class BackendSettings(BaseSettings):
     POSTGRES_DB: str | None = None
 
     # AWS
-    AWS_HOST: str | None = None
-    S3_PORT: int = 4566
+    S3_ENDPOINT_URL: str | None = None
     S3_BUCKET: str = "lumigator-storage"
     S3_URL_EXPIRATION: int = 3600  # Time in seconds for pre-signed url expiration
     S3_DATASETS_PREFIX: str = "datasets"
@@ -53,13 +52,6 @@ class BackendSettings(BaseSettings):
 
     # Summarizer
     SUMMARIZER_WORK_DIR: str | None = None
-
-    @computed_field
-    @property
-    def S3_ENDPOINT_URL(self) -> str | None:  # noqa: N802
-        # Live AWS doesn't require this but LocalStack testing does, so it's optional
-        if self.AWS_HOST == "localstack":
-            return f"http://{self.AWS_HOST}:{self.S3_PORT}"
 
     @computed_field
     @property

--- a/lumigator/python/mzai/backend/settings.py
+++ b/lumigator/python/mzai/backend/settings.py
@@ -58,7 +58,7 @@ class BackendSettings(BaseSettings):
     @property
     def S3_ENDPOINT_URL(self) -> str | None:  # noqa: N802
         # Live AWS doesn't require this but LocalStack testing does, so it's optional
-        if self.AWS_HOST is not None:
+        if self.AWS_HOST == "localstack":
             return f"http://{self.AWS_HOST}:{self.S3_PORT}"
 
     @computed_field


### PR DESCRIPTION
- Modified settings.py to support s3,coreweave and localstack:
Currently if `AWS_HOST` value is set to any string our settings.py will concatenate `AWS_HOST` and `AWS_PORT`. This concatenation is only required for localstack(afaik) so the change I propose is to make it explicit, because to use coreweave s3 storage we need to set AWS_HOST to a specific coreweave URL 
 - Added Env Vars to the helm chart
 - Download doesn't fully work, but it's related to a bug that's being worked on in [207](https://github.com/mozilla-ai/lumigator/pull/207) . I've checked that the URL is created with the right format for coreweave
 - Currently S3_ENDPOINT_URL and AWS_ENDPOINT_URL. have the default same values, but they are used differently, one is passed onto ray and another one used to connect to s3 in lumigator, but I think that work should be done in [this](https://mzai.atlassian.net/browse/LUMI-53) ticket