### PR TITLE
chore: ray image for local container depends on OS

### DIFF
--- a/.devcontainer/docker-compose-local.yaml
+++ b/.devcontainer/docker-compose-local.yaml
@@ -34,7 +34,7 @@ services:
       - localstack-data:/var/lib/localstack
 
   ray:
-    image: rayproject/ray:2.30.0-py311-cpu${ARCH}
+    image: rayproject/ray:2.30.0-py311-cpu${RAY_ARCH_SUFFIX}
     ports:
       - "6379:6379"
       - "8265:8265"

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,11 @@ CUDA_AVAILABLE := $(shell nvidia-smi &> /dev/null; echo $$?)
 PANTS_INSTALLED := $(shell pants --version &> /dev/null; echo $$?)
 PYTHON :=
 #used in docker-compose to choose the right Ray image
-ARCH := 
+ARCH := $(shell uname -m)
+RAY_ARCH_SUFFIX :=
 
-ifeq ($(UNAME), Darwin)
-	ARCH := -aarch64
+ifeq ($(ARCH), arm64)
+	RAY_ARCH_SUFFIX := -aarch64
 endif
 
 ifndef PYTHON
@@ -77,7 +78,7 @@ LOCAL_DOCKERCOMPOSE_FILE:= .devcontainer/docker-compose-local.yaml
 	pants run 3rdparty/python:gen_requirements_python_linux_cpu
 
 local-up: 3rdparty/python/requirements_python_linux_cpu.txt
-	ARCH=$(ARCH) docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d --build
+	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d --build
 	rm 3rdparty/python/requirements_python_linux_cpu.txt
 
 local-down:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can build the local project using `pants` and `docker-compose` on Mac or Lin
 ## Local Requirements
 
 + [Docker](https://docs.docker.com/engine/install/)
-    + On Linux, please also follow the [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/)
+    + On Linux, please also follow the [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/).
 + System Python (that is: no version manager, such as pyenv, should be active).
 
 ## Local Development Setup (either Mac or Linux)


### PR DESCRIPTION
## What's changing
Users on a local Linux currently need to manually change the docker compose file to point to the right Ray image. This small change does it for them, so neither Mac nor Linux users need to do anything other than cloning, make bootstrap..., make local-up.

## How to test it
On a Linux machine, follow the procedure stated in the updated documentation. Ideally, having Pants installed, the usual
```
make bootstrap-dev-environment && source mzaivenv/bin/activate
make local-up
```


## Related Jira Ticket
[LUMI-36](https://mzai.atlassian.net/browse/LUMI-36)

## Additional notes for reviewers

## I already...

- [ ] added some tests for any new functionality;
- [ x] updated the documentation.

[LUMI-36]: https://mzai.atlassian.net/browse/LUMI-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ