### PR TITLE
Added updated notebook and deps

### DIFF
--- a/.devcontainer/docker-compose-local.yaml
+++ b/.devcontainer/docker-compose-local.yaml
@@ -58,7 +58,7 @@ services:
       # NOTE: the following path contains a hash which needs to be updated whenever
       # the list of libraries installed in backend/services/experiments.py changes.
       # This is a temporary solution, see https://github.com/mozilla-ai/lumigator/pull/186
-      - LD_PRELOAD=/tmp/ray/session_latest/runtime_resources/pip/96de31139e548d3e8200d1e4b2575b77d5695312/virtualenv/lib/python3.11/site-packages/scikit_learn.libs/libgomp-d22c30c5.so.1.0.0
+      - LD_PRELOAD=/tmp/ray/session_latest/runtime_resources/pip/43b9b8b429ea9ef2b7b388371c223b0dacf13906/virtualenv/lib/python3.11/site-packages/scikit_learn.libs/libgomp-d22c30c5.so.1.0.0
     volumes:
       - ../lumigator/python/mzai/summarizer/summarizer.py:/home/ray/summarizer.py
 

--- a/lumigator/python/mzai/backend/services/experiments.py
+++ b/lumigator/python/mzai/backend/services/experiments.py
@@ -138,7 +138,7 @@ class ExperimentService:
         # NOTE: Whenever the list of libraries below change, the LD_PRELOAD line in
         # `docker-compose-local.yaml` has to be updated with a new hash value
         runtime_env = {
-            "pip": ["nltk==3.8.1", "lm-buddy[jobs]==0.12.1"],
+            "pip": ["nltk==3.8.1", "datasets==2.20.0", "lm-buddy[jobs]==0.12.1"],
             "env_vars": runtime_env_vars,
         }
         entrypoint = RayJobEntrypoint(

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -12,28 +12,3 @@ The notebook runs on Jupyter. If you don't yet have Jupyter set up:
 
 A new browser window will open pointing at your new jupyterlab. From there, open the `walkthrough.ipynb` file.
 
-
-## Running through the notebook
-
-The notebook currently has some references to dataset/job UUIDs which are stale. 
-The easiest way to get started with an evaluation job is the following:
-
-+ all cells until the Generating Data for Ground Truth Evaluation section are tested and working 
-+ when you get to the point where the input dataset is loaded from the platform, use an alternative one. One example could be `knkarthick/dialogsum` which contains some short dialogues summarized in the ground truth. You can load it as follows:
-
-```python
-dataset='knkarthick/dialogsum'
-ds = load_dataset(dataset, split='validation')
-ds = ds.remove_columns(["id", "topic"])
-ds = ds.rename_column("dialogue", "examples")
-ds = ds.rename_column("summary", "ground_truth")
-dataset_name = "dialogsum_converted.csv"
-ds.to_csv(dataset_name)
-```
-and then save it on Lumigator with:
-
-```python
-r = ld.dataset_upload(dataset_name)
-# show ds info
-dataset_id = ld.get_resource_id(r)
-```

--- a/notebooks/walkthrough.ipynb
+++ b/notebooks/walkthrough.ipynb
@@ -349,7 +349,7 @@
    "outputs": [],
    "source": [
     "# inspect our data\n",
-    "df[:3]"
+    "df.head(n=3)"
    ]
   },
   {
@@ -653,28 +653,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "enc_dec_models = [\n",
-    "    'hf://facebook/bart-large-cnn',\n",
-    "    'hf://mikeadimech/longformer-qmsum-meeting-summarization', \n",
-    "    'hf://mrm8488/t5-base-finetuned-summarize-news',\n",
-    "    'hf://Falconsai/text_summarization',\n",
-    "]\n",
-    "\n",
-    "dec_models = [\n",
-    "    'mistral://open-mistral-7b',\n",
-    "]\n",
-    "\n",
-    "gpts = [\n",
-    "    \"oai://gpt-4o-mini\",\n",
-    "    \"oai://gpt-4-turbo\",\n",
-    "    \"oai://gpt-3.5-turbo-0125\"  \n",
-    "]\n",
-    "\n",
+    "# Here follows a list of models we have tested for summarization:\n",
+    "# feel free to add any of them in the \"models\" list below\n",
+    "#\n",
+    "# Encoder-Decoder models\n",
+    "#    'hf://facebook/bart-large-cnn',\n",
+    "#    'hf://mikeadimech/longformer-qmsum-meeting-summarization', \n",
+    "#    'hf://mrm8488/t5-base-finetuned-summarize-news',\n",
+    "#    'hf://Falconsai/text_summarization',\n",
+    "#\n",
+    "# Decoder models\n",
+    "#    'mistral://open-mistral-7b',\n",
+    "#\n",
+    "# GPTs\n",
+    "#    \"oai://gpt-4o-mini\",\n",
+    "#    \"oai://gpt-4-turbo\",\n",
+    "#    \"oai://gpt-3.5-turbo-0125\",\n",
+    "#\n",
     "models = [\n",
-    "    enc_dec_models[0],\n",
-    "]\n",
-    "\n",
-    "models"
+    "    'hf://facebook/bart-large-cnn',\n",
+    "]"
    ]
   },
   {

--- a/notebooks/walkthrough.ipynb
+++ b/notebooks/walkthrough.ipynb
@@ -222,7 +222,8 @@
    "source": [
     "# Understanding the Lumigator App and API \n",
     "\n",
-    " The app itself consists of an API, which you can access and test out methods in the [OpenAPI spec](https://swagger.io/specification/), at the platform URL, under docs. \n",
+    "The app itself consists of an API, which you can access and test out methods in the [OpenAPI spec](https://swagger.io/specification/), at the platform URL, under docs.\n",
+    "If you are running Lumigator as a local installation, you can directly access the API at [this URL](http://localhost/docs#/).\n",
     "\n",
     "<img src=\"https://raw.githubusercontent.com/mozilla-ai/lumigator/main/notebooks/assets/openapi.png\" alt=\"drawing\" width=\"200\"/>"
    ]
@@ -276,7 +277,9 @@
   {
    "cell_type": "markdown",
    "id": "f33e80b64bad99e0",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
    "source": [
     "## Ground Truth for Models\n",
     "\n",
@@ -284,10 +287,7 @@
     "\n",
     "The **best ground truth is human-generated** but building it is a very expensive task.\n",
     "One recent trend is to rely on large language models but (as you will see later) they have their own pitfalls.\n",
-    "An intermediate approach uses different LLMs to provide ground truth \"candidates\" which are then subject to human pairwise evaluation.\n",
-    "For the sake of explanation, we will generate our ground truth by performing inference against existing models that are trained for summarization.\n",
-    "\n",
-    "\n"
+    "An intermediate approach uses different LLMs to provide ground truth \"candidates\" which are then subject to human pairwise evaluation."
    ]
   },
   {
@@ -297,85 +297,37 @@
    "source": [
     "## Our Input data\n",
     "\n",
-    "Let's take a look at the [data we'll be using first from the Thunderbird public mailing list.](https://thunderbird.topicbox.com/groups/addons/T18e84db141355abd-M4cca8e3f9e4fee9ae14b9dbb/self-hosted-version-of-extension-is-incorrectly-appearing-in-atn)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b5f5c03ad9e04a50",
-   "metadata": {},
-   "source": [
-    "## Generating Data for Ground Truth Evaluation\n",
+    "The data we'll be using in this walkthrough comes from [DialogSum](https://github.com/cylnlp/DialogSum), a large-scale\n",
+    "labeled dialogue summarization dataset which comes with ground truth provided by human annotators.\n",
     "\n",
-    "In order to generate a ground truth summary for our data, we first need an input dataset. In this case we use threads from the [Thunderbird public mailing list](https://thunderbird.topicbox.com/latest).\n",
+    "For the sake of explanation, in the next section we will show how Lumigator allows one to generate a ground truth candidate with the help of a language model. However, in the following evaluation section we will compare against the original, human-provided, annotations.\n",
     "\n",
-    "Our selection criteria: \n",
-    "\n",
-    "+ Collect 100 recent and \"complete\" email threads for evaluation\n",
-    "+ Clean them of email formatting such as `>`\n",
-    "+ BART, the baseline model we're using, accepts up to a 1024-token-long context window as input. This means that we have to have input email threads that are ~ approximately 1000 words, so keeping on the conservative side for smaller models. \n",
-    "\n",
-    "Once we've collected them, we'd like to take a look at the data before we generate summaries. "
+    "Here follows a brief description of DialogSum."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a6c637d7457fa99",
+   "id": "65af6945-bd5d-4506-af3c-144683779d58",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# show information about the Thunderbird dataset\n",
-    "dataset_id = \"db7ff8c2-a255-4d75-915d-77ba73affc53\"\n",
-    "r = ld.dataset_info(dataset_id)"
+    "# The dataset is available at https://huggingface.co/datasets/knkarthick/dialogsum\n",
+    "# and can be directly downloaded with the `load_dataset` method\n",
+    "dataset='knkarthick/dialogsum'\n",
+    "ds = load_dataset(dataset, split='validation')\n",
+    "df = ds.to_pandas()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5eee6cd83653af7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# download the dataset into a pandas dataframe\n",
-    "df = ld.dataset_download(dataset_id)\n",
-    "df.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b2ecd7004b401f7d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# We'd like to make sure our data is clean for LLM input\n",
-    "# This is often not necessary since most LLMs are trained on internet-formatted data\n",
-    "# But we'll be careful here\n",
-    "\n",
-    "import re\n",
-    "from string import punctuation\n",
-    "\n",
-    "def preprocess_text(text:str):\n",
-    "    text = text.lower()  # Lowercase text\n",
-    "    text = re.sub(f\"[{re.escape(punctuation)}]\", \"\", text)  # Remove punctuation\n",
-    "    text = \" \".join(text.split())  # Remove extra spaces, tabs, and new lines\n",
-    "    text = re.sub(r\"\\b[0-9]+\\b\\s*\", \"\", text)\n",
-    "    return text\n",
-    "\n",
-    "df[\"examples\"].map(preprocess_text)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f615c2f79e3ede00",
+   "id": "3cb05409-aad2-42e2-bc23-743575ad924e",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Examine a single sample \n",
-    "# we define the data with examples\n",
-    "df['examples'].iloc[0]"
+    "df['dialogue'].iloc[0]"
    ]
   },
   {
@@ -386,7 +338,7 @@
    "outputs": [],
    "source": [
     "# Add a function to do some simple character counts for model input\n",
-    "df['char_count'] = df['examples'].str.len()"
+    "df['char_count'] = df['dialogue'].str.len()"
    ]
   },
   {
@@ -397,7 +349,7 @@
    "outputs": [],
    "source": [
     "# inspect our data\n",
-    "df.head"
+    "df[:3]"
    ]
   },
   {
@@ -438,17 +390,27 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "dcc4643b-d6b4-40e8-97d1-c6b9cb50d7ae",
+   "metadata": {},
+   "source": [
+    "## Ground Truth Generation with Mistral\n",
+    "\n",
+    "In the following we will use [Mistral API](https://docs.mistral.ai/api/) to generate candidate ground truth. Note that for the following code to work, you need to have a valid mistral API key (no worries if you don't, the next section shows another methods which relies on an opensource model running locally on your computer)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "6f676203834ab1b6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Perform Ground Truth Generation with Mistral \n",
+    "# Perform Ground Truth Generation with Mistral\n",
     "\n",
     "mistral_responses = []\n",
     "\n",
-    "for sample in df['examples'][0:10]:\n",
+    "for sample in df['dialogue'][0:10]:\n",
     "    res = ld.get_mistral_ground_truth(sample)\n",
     "    print(f\"Mistral Summary:\", res)\n",
     "    mistral_responses.append((sample, res['text']))"
@@ -457,13 +419,48 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8cf9d239eb86eb08",
+   "id": "e0528d0e-ffd9-422d-ac54-9d49403b7e4c",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Let's create a result set we can look at\n",
     "mistral_results_df = pd.DataFrame(mistral_responses, columns=['examples', 'mistral_response'])\n",
     "mistral_results_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26242adc-c1e1-4f30-8397-4e7cd935f0f7",
+   "metadata": {},
+   "source": [
+    "## Ground Truth Generation with a local model\n",
+    "\n",
+    "In this section we will use a local model to generate ground truth.\n",
+    "\n",
+    "To do this, you will spin up a new _ray deployment_ from Lumigator's API. You can do it manually by connecting to the API and submitting the following JSON to the `/api/v1/ground-truth/deployments` endpoint:\n",
+    "\n",
+    "```\n",
+    "{\n",
+    "  \"num_gpus\": 0,\n",
+    "  \"num_cpus\": 1,\n",
+    "  \"num_replicas\": 1\n",
+    "}\n",
+    "```\n",
+    "... or you can copy and paste the following into your terminal to send the same request to the API via `curl`:\n",
+    "\n",
+    "```\n",
+    "curl -X 'POST' \\\n",
+    "  'http://localhost/api/v1/ground-truth/deployments' \\\n",
+    "  -H 'accept: application/json' \\\n",
+    "  -H 'Content-Type: application/json' \\\n",
+    "  -d '{\n",
+    "  \"num_gpus\": 0,\n",
+    "  \"num_cpus\": 1,\n",
+    "  \"num_replicas\": 1\n",
+    "}'\n",
+    "```\n",
+    "\n",
+    "After this, you can run the following cell to see information about your new deployment. Also note that you can get more details about it on your [ray dashboard](http://localhost:8265/#/actors)."
    ]
   },
   {
@@ -490,7 +487,7 @@
     "\n",
     "bart_responses = []\n",
     "\n",
-    "for prompt in df['examples'][0:10]:\n",
+    "for prompt in df['dialogue'][0:10]:\n",
     "    response = ld.get_bart_ground_truth(deployment_id, prompt)\n",
     "    response_dict = json.loads(response.text)\n",
     "    results = response_dict.get('deployment_response', {}).get('result', 'No result found')\n",
@@ -523,13 +520,45 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "378251f3-4145-4fa6-b933-564a91101c44",
+   "metadata": {},
+   "source": [
+    "## Save and upload datasets\n",
+    "\n",
+    "Now that you have seen the different available options to generate ground truth, let us save all datasets and make them available to lumigator for further experiments.\n",
+    "\n",
+    "For each example (dialogsum original dataset, bart-generated gt, mistral-generated gt) we will perform the following operations:\n",
+    "\n",
+    "1. Make sure that the two main fields (original text and ground truth) are called `examples` and `ground_truth`, which are the names internally used by Lumigator to refer to them, and save the datasets as CSV files.\n",
+    "\n",
+    "2. Make the dataset available to Lumigator with the `dataset_upload` method. If you are running locally the term \"upload\" might not make much sense to you, but it does if you think about it as a system which can work in a distributed fashion: with this method, your data is accessed locally or on a remote S3 store depending on the setup, in a way which is consistent and transparent to users."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e0f300c-9651-473b-aca9-1f147a3f2f2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = ds.remove_columns([\"id\", \"topic\"])\n",
+    "ds = ds.rename_column(\"dialogue\", \"examples\")\n",
+    "ds = ds.rename_column(\"summary\", \"ground_truth\")\n",
+    "dataset_name = \"dialogsum_converted.csv\"\n",
+    "ds.to_csv(dataset_name)\n",
+    "res = ld.dataset_upload(dataset_name)\n",
+    "dialogsum_dataset_id = json.loads(res.content)['id']\n",
+    "print(res)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "ad81836193f9ed45",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Now that we have the data, let's save it to the cluster so we can use it later on\n",
     "bart_results_df = bart_results_df.rename(columns={\"bart_response\": \"ground_truth\"})\n",
     "bart_results_df.to_csv('bart_ground_truth.csv', index=False)\n",
     "ld.dataset_upload(\"bart_ground_truth.csv\")"
@@ -563,27 +592,7 @@
    "id": "1b3019b45b211087",
    "metadata": {},
    "source": [
-    "# Experiments\n",
-    "Let's start by creating a team name for our experiments to organize our data, pick a team name below and run the cell. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3f82534586c1bfd8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Let's create an ID for our experiments \n",
-    "alphabet = string.ascii_lowercase + string.digits\n",
-    "su = shortuuid.ShortUUID(alphabet=alphabet)\n",
-    "\n",
-    "def shortuuid_random():\n",
-    "    return su.random(length=8)\n",
-    "\n",
-    "short_guid = shortuuid_random()\n",
-    "team_name = f\"gator_{short_guid}\"\n",
-    "team_name"
+    "# Experiments\n"
    ]
   },
   {
@@ -601,9 +610,7 @@
    "source": [
     "After generating the ground truth (either manually or with the aid of some models) and uploading the dataset to lumigator, we are ready to start evaluating models on it.\n",
     "\n",
-    "Note that when you uploaded your datasets you were returned some information that included a `dataset_id`. This is a unique identifier to your own dataset that you can reuse across different experiment. Please add your dataset identifier in the cell below to use it from now on.\n",
-    "\n",
-    "Note that we have also provided a few pre-generated datasets below, in the same format as the one you just generated. If you want to try one of them you can just remove the `YOUR_DATASET_ID` line and uncomment (by removing the trailing `#` character) the one with the dataset you want."
+    "Note that when you uploaded your datasets you were returned some information that included a `dataset_id`. This is a unique identifier to your own dataset that you can reuse across different experiment. We added `dialogsum_dataset_id` as the default identifier to use, but feel free to add a custom one if you prefer."
    ]
   },
   {
@@ -613,12 +620,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_id = YOUR_DATASET_ID\n",
-    "# dataset_id = \"fd454e33-e0c1-4c3b-a5f3-151a2be8beaa\" # Mistral GT - 10 samples\n",
-    "# dataset_id = \"daaa63ae-84fc-4557-a301-97d71b4ca7fe\" # Bart GT - 10 samples\n",
-    "# dataset_id = \"1bc65c24-5f28-4ede-9578-f56e4cbdeb5f\" # Mistral-API GT - 100 samples\n",
-    "# dataset_id = \"6bb9378a-012f-486b-afac-01b56f00456e\" # Bart GT - 100 samples\n",
-    "# dataset_id = \"a36061aa-b18a-4abc-a7de-d652670ed971\" # Mistral-llamafile GT - 100 samples\n",
+    "dataset_id = dialogsum_dataset_id\n",
     "\n",
     "# now look for the dataset on lumigator\n",
     "r = ld.dataset_info(dataset_id)\n",
@@ -633,7 +635,9 @@
     "## Model Selection\n",
     "\n",
     "What you see below are different lists of models we have already tested for the summarization task.\n",
-    "The `models` variable at the end provides you with a selection, but you can choose any combination of them.\n",
+    "The `models` variable at the end provides you with a selection, but you can choose any combination of them:\n",
+    "the default is a single local model (`facebook/bart-large-cnn`), but depending on your setup you can choose\n",
+    "more and/or add different APIs.\n",
     "\n",
     "Note that different model types are specified with different prefixes:\n",
     "\n",
@@ -668,8 +672,6 @@
     "\n",
     "models = [\n",
     "    enc_dec_models[0],\n",
-    "    dec_models[0],\n",
-    "    gpts[0]\n",
     "]\n",
     "\n",
     "models"
@@ -697,7 +699,9 @@
    "outputs": [],
    "source": [
     "# set this value to limit the evaluation to the first max_samples items (0=all)\n",
-    "max_samples = 0\n",
+    "max_samples = 10\n",
+    "# team_name is a way to group jobs together under the same namespace, feel free to customize it\n",
+    "team_name = \"lumigator_enthusiasts\"\n",
     "\n",
     "responses = []\n",
     "for model in models:\n",
@@ -830,26 +834,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "c668b05ab180fdde",
-   "metadata": {},
-   "source": [
-    "### See the samples with the best and worst values for a given model and metric\n",
-    "\n",
-    "Sometimes an individual average score is hard to interpret and to get some sense of it one wants to look into the data. With the following you can get more insights from the best and worst predictions for a given model and metric."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8f40f8db2d080c8d",
+   "id": "133c21f4-e61a-4f07-975f-052ccdead1da",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "ids = [ld.experiments_result_download(job_id) for job_id in job_ids]\n",
-    "\n",
-    "ld.show_best_worst(ids, \"hf://facebook/bart-large-cnn\", \"bertscore/f1\")"
-   ]
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## What's changing

Main change is the notebook itself. It now relies on dialogsum for the walkthrough.
A few days ago `datasets` deprecated the use of `use_auth_token` which now breaks our current code, this is fixed by freezing `datasets` version in lumigator (we can then update lm-buddy deps when the task of including it into lumigator is completed)

## How to test it
Run the notebook. Note that you'll need mistral api if you want to generate GT with it

## Related Jira Ticket
https://mzai.atlassian.net/browse/LUMI-40

## Additional notes for reviewers

## I already...

- [x] added some tests for any new functionality;
- [x] updated the documentation.