### PR TITLE
Davide/datasets fix

### DIFF
--- a/.devcontainer/docker-compose-local.yaml
+++ b/.devcontainer/docker-compose-local.yaml
@@ -20,7 +20,7 @@ services:
     image: localstack/localstack:3.4.0
     platform: linux/amd64
     ports:
-      - "0.0.0.0:4566:4566"
+      - 4566:4566
     environment:
       - SERVICES=s3:4566
       - CREATE_BUCKETS=lumigator-storage
@@ -61,6 +61,13 @@ services:
       - LD_PRELOAD=/tmp/ray/session_latest/runtime_resources/pip/3aad1b9393df933f711013a7d9650bb9821e891c/virtualenv/lib/python3.11/site-packages/scikit_learn.libs/libgomp-d22c30c5.so.1.0.0
     volumes:
       - ../lumigator/python/mzai/summarizer/summarizer.py:/home/ray/summarizer.py
+    # NOTE: to keep AWS_ENDPOINT_URL as http://localhost:4566 both on the host system
+    #       and inside containers, we map localhost to the host gateway IP.
+    #       This currently works properly, but might be the cause of networking
+    #       issues down the line. This should be used only for local, development
+    #       deployments.
+    extra_hosts:
+      - "localhost:host-gateway"
 
   backend:
     build:
@@ -97,6 +104,11 @@ services:
       - RAY_WORKER_GPUS_FRACTION=0
     volumes:
       - ../:/mzai
+    # NOTE: to keep AWS_ENDPOINT_URL as http://localhost:4566 both on the host system
+    #       and inside containers, we map localhost to the host gateway IP.
+    #       This currently works properly, but might be the cause of networking
+    #       issues down the line. This should be used only for local, development
+    #       deployments.
     extra_hosts:
       - "localhost:host-gateway"
 

--- a/lumigator/python/mzai/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/services/datasets.py
@@ -136,6 +136,15 @@ class DatasetService:
             dataset_path = f"s3://{ Path(settings.S3_BUCKET) / dataset_key }"
             dataset_hf.save_to_disk(dataset_path, fs=self.s3_filesystem)
 
+        except Exception as e:
+            # if a record was already created, delete it from the DB
+            if record is not None:
+                self.dataset_repo.delete(record.id)
+
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
+            ) from e
+
         finally:
             # Cleanup temp file
             Path(temp.name).unlink()

--- a/lumigator/python/mzai/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/services/datasets.py
@@ -4,12 +4,12 @@ from tempfile import NamedTemporaryFile
 from typing import BinaryIO
 from uuid import UUID
 
-import s3fs
 from datasets import load_dataset
 from fastapi import HTTPException, UploadFile, status
 from loguru import logger
 from mypy_boto3_s3.client import S3Client
 from pydantic import ByteSize
+from s3fs import S3FileSystem
 
 from mzai.backend.records.datasets import DatasetRecord
 from mzai.backend.repositories.datasets import DatasetRepository
@@ -84,10 +84,12 @@ def validate_experiment_dataset(filename: str):
 
 
 class DatasetService:
-    def __init__(self, dataset_repo: DatasetRepository, s3_client: S3Client):
+    def __init__(
+        self, dataset_repo: DatasetRepository, s3_client: S3Client, s3_filesystem: S3FileSystem
+    ):
         self.dataset_repo = dataset_repo
         self.s3_client = s3_client
-        self.s3_filesystem = s3fs.S3FileSystem()
+        self.s3_filesystem = s3_filesystem
 
     def _raise_not_found(self, dataset_id: UUID) -> None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dataset '{dataset_id}' not found.")

--- a/lumigator/python/mzai/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/services/datasets.py
@@ -1,5 +1,4 @@
 import csv
-import json
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import BinaryIO

--- a/lumigator/python/mzai/backend/tests/api/routes/test_datasets.py
+++ b/lumigator/python/mzai/backend/tests/api/routes/test_datasets.py
@@ -93,10 +93,11 @@ def test_presigned_download(app_client: TestClient, valid_experiment_dataset):
     download_model = DatasetDownloadResponse.model_validate(download_response.json())
     assert download_model.id == created_dataset.id
 
-    # Original filename is included in the presigned download URL
+    # Original filename is included in all the presigned download URLs
     # (not as a content disposition header)
-    parse_result = urlparse(download_model.download_url)
-    assert parse_result.path.endswith(upload_filename)
+    for download_url in download_model.download_urls:
+        parse_result = urlparse(download_url)
+        assert upload_filename in parse_result.path
 
 
 def test_experiment_format_validation(

--- a/lumigator/python/mzai/schemas/datasets.py
+++ b/lumigator/python/mzai/schemas/datasets.py
@@ -11,7 +11,7 @@ class DatasetFormat(str, Enum):
 
 class DatasetDownloadResponse(BaseModel):
     id: UUID
-    download_url: str
+    download_urls: list[str]
 
 
 class DatasetResponse(BaseModel, from_attributes=True):


### PR DESCRIPTION
## What's changing

- added s3 filesystem to deps (similarly to what we had with s3_client)
- fixed dataset upload issue (when S3 broke a record was still saved on the DB)
- fixed dataset deletion for full directories, added exception handling
- fixed dataset download for multiple-file datasets, now a list of signed URLs is returned to the client for downloading

## How to test it

- different methods can be tested from the API

## Related Jira Ticket
https://mzai.atlassian.net/browse/LUMI-41


## I already...

- [x] added some tests for any new functionality (updated unit tests to work with current code)
