### PR TITLE
ran: `ruff check` for linting

### DIFF
--- a/lumigator/python/mzai/backend/api/deployments/summarizer_config_loader.py
+++ b/lumigator/python/mzai/backend/api/deployments/summarizer_config_loader.py
@@ -1,8 +1,8 @@
 from typing import Any
+from uuid import UUID
 
 from loguru import logger
 from pydantic import BaseModel
-from uuid import UUID
 
 from mzai.backend.api.deployments.configloader import ConfigLoader
 from mzai.backend.settings import settings
@@ -83,7 +83,7 @@ class SummarizerConfigLoader(ConfigLoader):
         return name
 
     def set_deployment_description(self, uuid: UUID):
-        """set the description to the Lumigator UUID."""
+        """Set the description to the Lumigator UUID."""
         self.config.applications[0].args.description = str(uuid)
 
     def get_deployment_description(self) -> str:

--- a/lumigator/python/mzai/backend/api/router.py
+++ b/lumigator/python/mzai/backend/api/router.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter
 
 from mzai.backend.api.routes import (
+    completions,
     datasets,
     experiments,
     groundtruth,
     health,
-    completions,
 )
 from mzai.backend.api.tags import Tags
 

--- a/lumigator/python/mzai/backend/api/routes/completions.py
+++ b/lumigator/python/mzai/backend/api/routes/completions.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
+
 from mzai.backend.api.deps import MistralCompletionServiceDep, OpenAICompletionServiceDep
 from mzai.schemas.completions import CompletionRequest
-from loguru import logger
 
 router = APIRouter()
 

--- a/lumigator/python/mzai/backend/api/routes/groundtruth.py
+++ b/lumigator/python/mzai/backend/api/routes/groundtruth.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
 from fastapi import APIRouter, status
+from loguru import logger
 
 from mzai.backend.api.deps import GroundTruthServiceDep
 from mzai.schemas.extras import ListingResponse
@@ -10,7 +11,6 @@ from mzai.schemas.groundtruth import (
     GroundTruthDeploymentResponse,
     GroundTruthQueryRequest,
 )
-from loguru import logger
 
 router = APIRouter()
 

--- a/lumigator/python/mzai/backend/api/routes/health.py
+++ b/lumigator/python/mzai/backend/api/routes/health.py
@@ -1,13 +1,12 @@
+import json
+from uuid import UUID
+
+import requests
 from fastapi import APIRouter
 
 from mzai.backend.settings import settings
 from mzai.schemas.extras import HealthResponse
 from mzai.schemas.jobs import JobSubmissionResponse
-import requests
-import json
-from uuid import UUID
-from mzai.backend.settings import settings
-from typing import List
 
 router = APIRouter()
 
@@ -33,12 +32,12 @@ def get_job_metadata(job_id: UUID) -> JobSubmissionResponse:
 
 
 @router.get("/jobs/")
-def get_all_jobs() -> List[JobSubmissionResponse]:
+def get_all_jobs() -> list[JobSubmissionResponse]:
     resp = requests.get(f"{settings.RAY_DASHBOARD_URL}/api/jobs/")
     if resp.status_code == 200:
         try:
             metadata = json.loads(resp.text)
-            submissions: List[JobSubmissionResponse] = [
+            submissions: list[JobSubmissionResponse] = [
                 JobSubmissionResponse(**item) for item in metadata
             ]
             return submissions

--- a/lumigator/python/mzai/backend/main.py
+++ b/lumigator/python/mzai/backend/main.py
@@ -1,16 +1,15 @@
 import contextlib
+import os
+import sys
 
 from fastapi import FastAPI
+from loguru import logger
 from sqlalchemy import Engine
 
 from mzai.backend.api.router import api_router
 from mzai.backend.api.tags import TAGS_METADATA
 from mzai.backend.db import engine
 from mzai.backend.records.base import BaseRecord
-
-from loguru import logger
-import sys
-import os
 
 
 def create_app(engine: Engine) -> FastAPI:

--- a/lumigator/python/mzai/backend/services/completions.py
+++ b/lumigator/python/mzai/backend/services/completions.py
@@ -1,12 +1,12 @@
+from abc import ABC, abstractmethod
+
 import mistralai.client
 from mistralai.client import MistralClient
 from mistralai.models.chat_completion import ChatMessage
 from openai import OpenAI
-from abc import ABC, abstractmethod
-import os
-from mzai.backend.settings import settings
 
-from mzai.schemas.completions import CompletionResponse, CompletionRequest
+from mzai.backend.settings import settings
+from mzai.schemas.completions import CompletionRequest, CompletionResponse
 
 
 class CompletionService(ABC):

--- a/lumigator/python/mzai/backend/services/experiments.py
+++ b/lumigator/python/mzai/backend/services/experiments.py
@@ -132,9 +132,7 @@ class ExperimentService:
             worker_gpus = settings.RAY_WORKER_GPUS
 
         runtime_env = {
-            # "pip": settings.PIP_REQS,
-            "pip": "requirements.txt",
-            # "working_dir": "lumigator/python/mzai/evaluator/",
+            "pip": settings.PIP_REQS,
             "working_dir": "lumigator/python/mzai/evaluator/",
             "env_vars": runtime_env_vars,
         }

--- a/lumigator/python/mzai/backend/services/experiments.py
+++ b/lumigator/python/mzai/backend/services/experiments.py
@@ -1,5 +1,4 @@
 import json
-import os
 from pathlib import Path
 from uuid import UUID
 
@@ -133,7 +132,9 @@ class ExperimentService:
             worker_gpus = settings.RAY_WORKER_GPUS
 
         runtime_env = {
-            "pip": settings.PIP_REQS,
+            # "pip": settings.PIP_REQS,
+            "pip": "requirements.txt",
+            # "working_dir": "lumigator/python/mzai/evaluator/",
             "working_dir": "lumigator/python/mzai/evaluator/",
             "env_vars": runtime_env_vars,
         }

--- a/lumigator/python/mzai/backend/settings.py
+++ b/lumigator/python/mzai/backend/settings.py
@@ -1,11 +1,12 @@
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
 from pydantic import ByteSize, computed_field
 from pydantic_settings import BaseSettings
 from sqlalchemy.engine import URL
-from pathlib import Path
-import os
 
 from mzai.schemas.extras import DeploymentType
-from collections.abc import Mapping
 
 
 class BackendSettings(BaseSettings):

--- a/lumigator/python/mzai/backend/tests/fakes/groundtruth_service.py
+++ b/lumigator/python/mzai/backend/tests/fakes/groundtruth_service.py
@@ -1,5 +1,5 @@
-from mzai.backend.services.groundtruth import GroundTruthService
 from mzai.backend.repositories.groundtruth import GroundTruthDeploymentRepository
+from mzai.backend.services.groundtruth import GroundTruthService
 
 
 class FakeRayServe:

--- a/lumigator/python/mzai/backend/tests/services/test_groundtruth.py
+++ b/lumigator/python/mzai/backend/tests/services/test_groundtruth.py
@@ -1,13 +1,12 @@
 import pytest
 
-
+from mzai.backend.api.routes import groundtruth
 from mzai.backend.repositories.groundtruth import (
-    GroundTruthDeploymentRepository,
     GroundTruthDeploymentRecord,
+    GroundTruthDeploymentRepository,
 )
 from mzai.backend.tests.fakes.groundtruth_service import FakeGroundTruthService
 from mzai.schemas.extras import ListingResponse
-from mzai.backend.api.routes import groundtruth
 
 
 @pytest.fixture

--- a/lumigator/python/mzai/evaluator/configs/huggingface.py
+++ b/lumigator/python/mzai/evaluator/configs/huggingface.py
@@ -1,14 +1,15 @@
 import dataclasses
 from typing import Any
 
+from peft import PeftConfig, PeftType, TaskType
+from pydantic import field_validator, model_validator
+from transformers import BitsAndBytesConfig
+
 from mzai.evaluator.configs.common import (
     EvaluatorConfig,
     SerializableTorchDtype,
 )
 from mzai.evaluator.paths import AssetPath, PathPrefix
-from peft import PeftConfig, PeftType, TaskType
-from pydantic import field_validator, model_validator
-from transformers import BitsAndBytesConfig
 
 DEFAULT_TEXT_FIELD: str = "text"
 

--- a/lumigator/python/mzai/evaluator/configs/jobs/__init__.py
+++ b/lumigator/python/mzai/evaluator/configs/jobs/__init__.py
@@ -1,8 +1,6 @@
 from mzai.evaluator.configs.jobs.common import JobConfig
-
 from mzai.evaluator.configs.jobs.hf_evaluate import HuggingFaceEvalJobConfig
 from mzai.evaluator.configs.jobs.lm_harness import LMHarnessJobConfig
-
 
 EvaluationJobConfig = LMHarnessJobConfig | HuggingFaceEvalJobConfig
 

--- a/lumigator/python/mzai/evaluator/configs/wandb.py
+++ b/lumigator/python/mzai/evaluator/configs/wandb.py
@@ -1,10 +1,11 @@
 import os
 import warnings
 
-from mzai.evaluator.configs.common import EvaluatorConfig
 from pydantic import model_validator
 from wandb.apis.public import Run
 from wandb.util import random_string
+
+from mzai.evaluator.configs.common import EvaluatorConfig
 
 
 class WandbRunConfig(EvaluatorConfig):

--- a/lumigator/python/mzai/evaluator/evaluator.py
+++ b/lumigator/python/mzai/evaluator/evaluator.py
@@ -8,7 +8,6 @@ from mzai.evaluator.configs.jobs import (
 )
 from mzai.evaluator.jobs.common import (
     EvaluationResult,
-    FinetuningResult,
     JobType,
 )
 from mzai.evaluator.jobs.evaluation.hf_evaluate import run_hf_evaluation

--- a/lumigator/python/mzai/evaluator/jobs/asset_loader.py
+++ b/lumigator/python/mzai/evaluator/jobs/asset_loader.py
@@ -4,17 +4,6 @@ import torch
 from accelerate import Accelerator
 from datasets import Dataset, DatasetDict, load_dataset, load_from_disk
 from loguru import logger
-from mzai.evaluator.configs.huggingface import (
-    AutoModelConfig,
-    AutoTokenizerConfig,
-    DatasetConfig,
-    QuantizationConfig,
-)
-from mzai.evaluator.paths import AssetPath, PathPrefix, strip_path_prefix
-from mzai.evaluator.tracking.artifact_utils import (
-    get_artifact_directory,
-    get_artifact_from_api,
-)
 from peft import PeftConfig
 from transformers import (
     AutoConfig,
@@ -28,6 +17,18 @@ from transformers import (
 from transformers.models.auto.modeling_auto import (
     MODEL_FOR_CAUSAL_LM_MAPPING_NAMES,
     MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING_NAMES,
+)
+
+from mzai.evaluator.configs.huggingface import (
+    AutoModelConfig,
+    AutoTokenizerConfig,
+    DatasetConfig,
+    QuantizationConfig,
+)
+from mzai.evaluator.paths import AssetPath, PathPrefix, strip_path_prefix
+from mzai.evaluator.tracking.artifact_utils import (
+    get_artifact_directory,
+    get_artifact_from_api,
 )
 
 

--- a/lumigator/python/mzai/evaluator/jobs/evaluation/hf_evaluate.py
+++ b/lumigator/python/mzai/evaluator/jobs/evaluation/hf_evaluate.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import s3fs
 from loguru import logger
+from tqdm import tqdm
+
 from mzai.evaluator.configs.jobs.hf_evaluate import HuggingFaceEvalJobConfig
 from mzai.evaluator.configs.vllm import VLLMCompletionsConfig
 from mzai.evaluator.constants import EVALUATOR_RESULTS_PATH
@@ -23,7 +25,6 @@ from mzai.evaluator.jobs.model_clients import (
     SummarizationPipelineModelClient,
 )
 from mzai.evaluator.jobs.utils import timer
-from tqdm import tqdm
 
 
 @timer

--- a/lumigator/python/mzai/evaluator/jobs/model_clients.py
+++ b/lumigator/python/mzai/evaluator/jobs/model_clients.py
@@ -3,6 +3,11 @@ from abc import abstractmethod
 
 import torch
 from loguru import logger
+from mistralai.client import MistralClient
+from openai import OpenAI, OpenAIError
+from openai.types import Completion
+from transformers import pipeline
+
 from mzai.evaluator.configs.common import EvaluatorConfig
 from mzai.evaluator.configs.jobs.hf_evaluate import HuggingFaceEvalJobConfig
 from mzai.evaluator.configs.vllm import VLLMCompletionsConfig
@@ -10,10 +15,6 @@ from mzai.evaluator.jobs.asset_loader import (
     HuggingFaceModelLoader,
     HuggingFaceTokenizerLoader,
 )
-from mistralai.client import MistralClient
-from openai import OpenAI, OpenAIError
-from openai.types import Completion
-from transformers import pipeline
 
 
 class BaseModelClient:

--- a/lumigator/python/mzai/evaluator/tests/conftest.py
+++ b/lumigator/python/mzai/evaluator/tests/conftest.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+
 from mzai.evaluator.tracking.artifact_utils import (
     ArtifactType,
     build_directory_artifact,

--- a/lumigator/python/mzai/evaluator/tests/integration/conftest.py
+++ b/lumigator/python/mzai/evaluator/tests/integration/conftest.py
@@ -1,5 +1,4 @@
-"""
-LM Buddy integration test suite.
+"""LM Buddy integration test suite.
 
 These tests generally require a running Ray cluster/W&B environment.
 """

--- a/lumigator/python/mzai/evaluator/tests/unit/configs/jobs/test_lm_harness_config.py
+++ b/lumigator/python/mzai/evaluator/tests/unit/configs/jobs/test_lm_harness_config.py
@@ -1,5 +1,6 @@
 import pytest
 from pydantic import ValidationError
+from tests.test_utils import copy_pydantic_json
 
 from mzai.evaluator.configs.jobs.lm_harness import (
     LMHarnessEvaluationConfig,
@@ -7,7 +8,6 @@ from mzai.evaluator.configs.jobs.lm_harness import (
     LocalChatCompletionsConfig,
 )
 from mzai.evaluator.configs.vllm import InferenceServerConfig
-from tests.test_utils import copy_pydantic_json
 
 
 @pytest.fixture

--- a/lumigator/python/mzai/evaluator/tests/unit/configs/test_quantization_config.py
+++ b/lumigator/python/mzai/evaluator/tests/unit/configs/test_quantization_config.py
@@ -1,8 +1,8 @@
 import pytest
 import torch
+from tests.test_utils import copy_pydantic_json
 
 from mzai.evaluator.configs.huggingface import QuantizationConfig
-from tests.test_utils import copy_pydantic_json
 
 
 @pytest.fixture

--- a/lumigator/python/mzai/evaluator/tests/unit/configs/test_run_config.py
+++ b/lumigator/python/mzai/evaluator/tests/unit/configs/test_run_config.py
@@ -3,9 +3,9 @@ from unittest import mock
 
 import pytest
 from pydantic import ValidationError
+from tests.test_utils import copy_pydantic_json
 
 from mzai.evaluator.configs.wandb import WandbRunConfig
-from tests.test_utils import copy_pydantic_json
 
 
 @pytest.fixture

--- a/lumigator/python/mzai/schemas/completions.py
+++ b/lumigator/python/mzai/schemas/completions.py
@@ -1,4 +1,3 @@
-
 from pydantic import BaseModel
 
 

--- a/lumigator/python/mzai/schemas/completions.py
+++ b/lumigator/python/mzai/schemas/completions.py
@@ -1,6 +1,3 @@
-import datetime
-from enum import Enum
-from uuid import UUID
 
 from pydantic import BaseModel
 

--- a/lumigator/python/mzai/schemas/jobs.py
+++ b/lumigator/python/mzai/schemas/jobs.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -32,15 +32,15 @@ class JobEvent(BaseModel):
 
 class JobSubmissionResponse(BaseModel):
     type: str | None = None
-    job_id: Optional[str] = None
+    job_id: str | None = None
     submission_id: str | None = None
-    driver_info: Optional[str] = None
+    driver_info: str | None = None
     status: str | None = None
     entrypoint: str | None = None
     message: str | None = None
-    error_type: Optional[str] = None
-    start_time: Optional[datetime] = None
-    end_time: Optional[datetime] = None
+    error_type: str | None = None
+    start_time: datetime | None = None
+    end_time: datetime | None = None
     metadata: dict = Field(default_factory=dict)
     runtime_env: dict = Field(default_factory=dict)
     driver_agent_http_address: str | None = None

--- a/lumigator/python/mzai/summarizer/summarizer.py
+++ b/lumigator/python/mzai/summarizer/summarizer.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 from ray import serve
 from ray.serve import Application
 from starlette.requests import Request
-from transformers import AutoModelForSeq2SeqLM, pipeline, AutoTokenizer
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer, pipeline
 
 logger = logging.getLogger("ray.serve")
 

--- a/notebooks/lumigator_demo.py
+++ b/notebooks/lumigator_demo.py
@@ -1,13 +1,13 @@
 """Common definitions and methods for the lumigator demo notebook."""
 
 import io
+import json
 import os
 from pathlib import Path
 from typing import Any, Dict  # noqa: UP035
 from uuid import UUID
-import json
-import numpy as np
 
+import numpy as np
 import pandas as pd
 import requests
 
@@ -263,7 +263,6 @@ def runs_to_eval_table(job_ids):
 
 def show_best_worst(job_ids, model_name, metric_name):
     """Shows best and worst results for a given model and metric."""
-
     found = 0
     for job_id in job_ids:
         result = experiments_result_download(job_id)


### PR DESCRIPTION
## What's changing

Running `ruff check` from the lumigator root gives these results.

Change seem to mostly be reordering of imports to follow: https://peps.python.org/pep-0008/#imports

> Imports should be grouped in the following order:
>
> * Standard library imports.
> * Related third party imports.
> * Local application/library specific imports.
> 
> You should put a blank line between each group of imports.

Two things that stood out:

1. [List => list](https://github.com/mozilla-ai/lumigator/compare/linting/ruff-check?expand=1#diff-c68d57f3b4b654e42bf8551142c047800cdcbd4d2a08c0ea1aa857f9dc26335aL41) - [List deprecated](https://docs.python.org/3/library/typing.html#typing.List)
2. [Optional[str] => None](https://github.com/mozilla-ai/lumigator/compare/linting/ruff-check?expand=1#diff-a91541141b02fd65436aa3a336b17b04b35de436dddb8b7216e27b21254a6a61L35-L43) - seems to be the preferred way [PEP-0604](https://peps.python.org/pep-0604/)