### PR TITLE
Parametrized job submission

### DIFF
--- a/lumigator/python/mzai/backend/backend/jobs/submission.py
+++ b/lumigator/python/mzai/backend/backend/jobs/submission.py
@@ -16,11 +16,9 @@ class RayJobEntrypoint(ABC):
     memory: int | float | None = None
 
     @property
-    def command(self) -> str:
+    def command_with_params(self) -> str:
         """A generic command which is passed some optional args and submitted as a ray job.
 
-        It likely will be a ptyhon module used via cli (e.g. `python -m evaluator evaluate ...`)
-        or a different kind of command as long as it is executable.
         Note that parameters can either be passed as config.args (a dictionary containing
         parameter names as keys and parameter values as values) or directly with the command
         string.
@@ -35,9 +33,9 @@ class RayJobEntrypoint(ABC):
 
 
 def submit_ray_job(client: JobSubmissionClient, entrypoint: RayJobEntrypoint) -> str:
-    loguru.logger.info(f"Submitting {entrypoint.command}...{entrypoint.runtime_env}")
+    loguru.logger.info(f"Submitting {entrypoint.command_with_params}...{entrypoint.runtime_env}")
     return client.submit_job(
-        entrypoint=entrypoint.command,
+        entrypoint=entrypoint.command_with_params,
         entrypoint_num_cpus=entrypoint.num_cpus,
         entrypoint_num_gpus=entrypoint.num_gpus,
         entrypoint_memory=entrypoint.memory,

--- a/lumigator/python/mzai/backend/backend/jobs/submission.py
+++ b/lumigator/python/mzai/backend/backend/jobs/submission.py
@@ -9,13 +9,6 @@ from schemas.jobs import JobConfig
 
 @dataclass(kw_only=True)
 class RayJobEntrypoint(ABC):
-    """A generic command which is passed a config and submitted as a ray job.
-
-    Currently the command is passed as a parameter. It likely will be a ptyhon module used via cli
-    (e.g. `lm-buddy evaluate lm-harness`, `lm-buddy finetune`, etc) or even different commands.
-    Note parameters of this command can either be passed in a config file, or left empty.
-    """
-
     config: JobConfig
     runtime_env: dict[str, Any] | None = None
     num_cpus: int | float | None = None
@@ -24,6 +17,14 @@ class RayJobEntrypoint(ABC):
 
     @property
     def command(self) -> str:
+        """A generic command which is passed some optional args and submitted as a ray job.
+
+        It likely will be a ptyhon module used via cli (e.g. `python -m evaluator evaluate ...`)
+        or a different kind of command as long as it is executable.
+        Note that parameters can either be passed as config.args (a dictionary containing
+        parameter names as keys and parameter values as values) or directly with the command
+        string.
+        """
         full_command = self.config.command
 
         if self.config.args:

--- a/lumigator/python/mzai/backend/backend/services/experiments.py
+++ b/lumigator/python/mzai/backend/backend/services/experiments.py
@@ -114,14 +114,17 @@ class ExperimentService:
             # (which works with seq2seq models too except it does not use pipeline)
             config_template = config_templates.causal_template
 
+        # eval_config_args is used to map input configuration parameters with
+        # command parameters provided via command line to the ray job.
+        # To do this, we use a dict where keys are parameter names as they'd
+        # appear on the command line and the values are the respective params.
         eval_config_args = {
             "--config": config_template.format(**config_params),
         }
 
         # Prepare the job configuration that will be sent to submit the ray job.
         # This includes both the command that is going to be executed and its
-        # arguments (a dict where keys are parameter names and the values are
-        # strings that will be provided after the parameters)
+        # arguments defined in eval_config_args
         ray_config = JobConfig(
             job_id=record.id,
             job_type=JobType.EXPERIMENT,

--- a/lumigator/python/mzai/backend/schemas/jobs.py
+++ b/lumigator/python/mzai/backend/schemas/jobs.py
@@ -20,7 +20,8 @@ class JobStatus(str, Enum):
 class JobConfig(BaseModel):
     job_id: UUID
     job_type: JobType
-    args: dict[str, Any]
+    command: str
+    args: dict[str, Any] | None = None
 
 
 class JobEvent(BaseModel):


### PR DESCRIPTION
## What's changing
Minor update to parametrize job submission. jobs/submission.py now gets a `command` parameter (string) and optional `args` (dictionary with k = --parameter_name and v = parameter_value) so it is possible to run jobs either by directly passing the command as a single string or just the base command + params (eventually everything becomes one string anyway at submission time but perhaps it saves a bit of hassle, especially if we decide to move back to structured configs and bring serialization into submission.py so developers won't have to be bothered by that).

## How to test it
curl directly hitting the API to run an experiment

## Related Jira Ticket
https://mzai.atlassian.net/browse/LUMI-87
