### PR TITLE
SDK: Add 'experiments'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,4 @@ cython_debug/
 .ruff_cache
 
 .ijwb
+*.db

--- a/lumigator/python/mzai/backend/schemas/experiments.py
+++ b/lumigator/python/mzai/backend/schemas/experiments.py
@@ -2,6 +2,7 @@ import datetime
 from uuid import UUID
 
 from pydantic import BaseModel
+from typing import Optional
 
 from schemas.jobs import JobStatus
 
@@ -23,7 +24,7 @@ class ExperimentResponse(BaseModel, from_attributes=True):
     description: str
     status: JobStatus
     created_at: datetime.datetime
-    updated_at: datetime.datetime | None
+    updated_at: Optional[datetime.datetime] = None
 
 
 class ExperimentResultResponse(BaseModel, from_attributes=True):

--- a/lumigator/python/mzai/sdk/experiments.py
+++ b/lumigator/python/mzai/sdk/experiments.py
@@ -1,0 +1,77 @@
+from uuid import UUID
+from http import HTTPMethod
+from json import dumps
+
+from schemas.experiments import (
+    ExperimentCreate,
+    ExperimentResponse,
+    ExperimentResultDownloadResponse,
+    ExperimentResultResponse,
+)
+from schemas.extras import ListingResponse
+
+from client import ApiClient
+
+
+class Experiments:
+    EXPERIMENTS_ROUTE = "experiments"
+
+    def __init__(self, c: ApiClient):
+        self.__client = c
+
+    def create_experiment(self, experiment: ExperimentCreate) -> ExperimentResponse:
+        """Creates a new experiment."""
+        response = self.__client.get_response(
+            self.EXPERIMENTS_ROUTE, HTTPMethod.POST, dumps(experiment)
+        )
+
+        if not response:
+            return []
+
+        data = response.json()
+        return ExperimentResponse(**data)
+
+    def get_experiment(self, experiment_id: UUID) -> ExperimentResponse:
+        """Returns information on the experiment for the specified ID."""
+        response = self.__client.get_response(f"{self.EXPERIMENTS_ROUTE}/{experiment_id}")
+
+        if not response:
+            return []
+
+        data = response.json()
+        return ExperimentResponse(**data)
+
+    def get_experiments(
+        self, skip: int = 0, limit: int = 100
+    ) -> ListingResponse[ExperimentResponse]:
+        """Returns information on all experiments."""
+        response = self.__client.get_response(self.EXPERIMENTS_ROUTE)
+
+        if not response:
+            return []
+
+        return [ExperimentResponse(**args) for args in response.json()]
+
+    def get_experiment_result(self, experiment_id: UUID) -> ExperimentResultResponse:
+        """Returns the result of the experiment for the specified ID."""
+        response = self.__client.get_response(f"{self.EXPERIMENTS_ROUTE}/{experiment_id}/result")
+
+        if not response:
+            return []
+
+        data = response.json()
+        return ExperimentResultResponse(**data)
+
+    def get_experiment_result_download(
+        self, experiment_id: UUID
+    ) -> ExperimentResultDownloadResponse:
+        """Returns the result of the experiment for the specified ID."""
+        response = self.__client.get_response(
+            f"{self.EXPERIMENTS_ROUTE}/{experiment_id}/result/download"
+        )
+
+        if not response:
+            return []
+
+        data = response.json()
+        return ExperimentResultDownloadResponse(**data)

--- a/lumigator/python/mzai/sdk/experiments.py
+++ b/lumigator/python/mzai/sdk/experiments.py
@@ -1,5 +1,5 @@
 from uuid import UUID
-from http import HTTPMethod
+from http import HTTPMethod, HTTPStatus
 from json import dumps
 
 from schemas.experiments import (
@@ -31,12 +31,12 @@ class Experiments:
         data = response.json()
         return ExperimentResponse(**data)
 
-    def get_experiment(self, experiment_id: UUID) -> ExperimentResponse:
+    def get_experiment(self, experiment_id: UUID) -> ExperimentResponse | None:
         """Returns information on the experiment for the specified ID."""
         response = self.__client.get_response(f"{self.EXPERIMENTS_ROUTE}/{experiment_id}")
 
-        if not response:
-            return []
+        if not response or response.status_code != HTTPStatus.OK:
+            return None
 
         data = response.json()
         return ExperimentResponse(**data)
@@ -52,26 +52,26 @@ class Experiments:
 
         return [ExperimentResponse(**args) for args in response.json()]
 
-    def get_experiment_result(self, experiment_id: UUID) -> ExperimentResultResponse:
+    def get_experiment_result(self, experiment_id: UUID) -> ExperimentResultResponse | None:
         """Returns the result of the experiment for the specified ID."""
         response = self.__client.get_response(f"{self.EXPERIMENTS_ROUTE}/{experiment_id}/result")
 
-        if not response:
-            return []
+        if not response or response.status_code != HTTPStatus.OK:
+            return None
 
         data = response.json()
         return ExperimentResultResponse(**data)
 
     def get_experiment_result_download(
         self, experiment_id: UUID
-    ) -> ExperimentResultDownloadResponse:
+    ) -> ExperimentResultDownloadResponse | None:
         """Returns the result of the experiment for the specified ID."""
         response = self.__client.get_response(
             f"{self.EXPERIMENTS_ROUTE}/{experiment_id}/result/download"
         )
 
-        if not response:
-            return []
+        if not response or response.status_code != HTTPStatus.OK:
+            return None
 
         data = response.json()
         return ExperimentResultDownloadResponse(**data)

--- a/lumigator/python/mzai/sdk/lumigator.py
+++ b/lumigator/python/mzai/sdk/lumigator.py
@@ -1,5 +1,6 @@
 from client import ApiClient
 from completions import Completions
+from experiments import Experiments
 from health import Health
 
 
@@ -8,4 +9,5 @@ class LumigatorClient:
         self.client = ApiClient(api_host)
 
         self.completions = Completions(self.client)
+        self.experiments = Experiments(self.client)
         self.health = Health(self.client)

--- a/lumigator/python/mzai/sdk/tests/BUILD.pants
+++ b/lumigator/python/mzai/sdk/tests/BUILD.pants
@@ -1,4 +1,4 @@
-python_sources(name="sdk_test_sources", sources=["**/*.py"])
+python_test_utils(name="sdk_test_utils", sources=["conftest.py", "helpers.py"])
 
 python_tests(
     name="sdk_tests",

--- a/lumigator/python/mzai/sdk/tests/conftest.py
+++ b/lumigator/python/mzai/sdk/tests/conftest.py
@@ -51,3 +51,28 @@ def json_data_jobs() -> Traversable:
 @pytest.fixture(scope="session")
 def json_data_job() -> Traversable:
     return json_data_path() / "job.json"
+
+
+@pytest.fixture(scope="session")
+def json_data_experiments() -> Traversable:
+    return json_data_path() / "experiments.json"
+
+
+@pytest.fixture(scope="session")
+def json_data_experiment() -> Traversable:
+    return json_data_path() / "experiment.json"
+
+
+@pytest.fixture(scope="session")
+def json_data_experiment_post_response() -> Traversable:
+    return json_data_path() / "experiment-post-response.json"
+
+
+@pytest.fixture(scope="session")
+def json_data_experiment_post_simple() -> Traversable:
+    return json_data_path() / "experiment-post-simple.json"
+
+
+@pytest.fixture(scope="session")
+def json_data_experiment_post_all() -> Traversable:
+    return json_data_path() / "experiment-post-all.json"

--- a/lumigator/python/mzai/sdk/tests/conftest.py
+++ b/lumigator/python/mzai/sdk/tests/conftest.py
@@ -83,3 +83,13 @@ def json_data_experiment_post_simple() -> Traversable:
 @pytest.fixture(scope="session")
 def json_data_experiment_post_all() -> Traversable:
     return json_data_path() / "experiment-post-all.json"
+
+
+@pytest.fixture(scope="session")
+def json_data_experiment_result() -> Traversable:
+    return json_data_path() / "experiment-result.json"
+
+
+@pytest.fixture(scope="session")
+def json_data_experiment_result_download() -> Traversable:
+    return json_data_path() / "experiment-download.json"

--- a/lumigator/python/mzai/sdk/tests/conftest.py
+++ b/lumigator/python/mzai/sdk/tests/conftest.py
@@ -27,14 +27,13 @@ def mock_requests(mock_requests_response):
 
 @pytest.fixture(scope="session")
 def lumi_client() -> LumigatorClient:
-    lumi_c = None
     with mock.patch("requests.request") as req_mock:
         with mock.patch("requests.Response") as resp_mock:
             resp_mock.status_code = 200
             resp_mock.json = lambda: json.loads('["openai", "mistral"]')
             req_mock.return_value = resp_mock
             lumi_c = LumigatorClient(LUMI_HOST)
-    return lumi_c
+            return lumi_c
 
 
 @pytest.fixture(scope="session")

--- a/lumigator/python/mzai/sdk/tests/conftest.py
+++ b/lumigator/python/mzai/sdk/tests/conftest.py
@@ -71,6 +71,11 @@ def json_data_experiment() -> Traversable:
 
 
 @pytest.fixture(scope="session")
+def json_data_experiment_missing() -> Traversable:
+    return json_data_path() / "experiment-missing.json"
+
+
+@pytest.fixture(scope="session")
 def json_data_experiment_post_response() -> Traversable:
     return json_data_path() / "experiment-post-response.json"
 
@@ -91,5 +96,15 @@ def json_data_experiment_result() -> Traversable:
 
 
 @pytest.fixture(scope="session")
+def json_data_experiment_result_missing() -> Traversable:
+    return json_data_path() / "experiment-result-no-experiment.json"
+
+
+@pytest.fixture(scope="session")
 def json_data_experiment_result_download() -> Traversable:
     return json_data_path() / "experiment-download.json"
+
+
+@pytest.fixture(scope="session")
+def json_data_experiment_result_download_missing() -> Traversable:
+    return json_data_path() / "experiment-download-no-experiment.json"

--- a/lumigator/python/mzai/sdk/tests/conftest.py
+++ b/lumigator/python/mzai/sdk/tests/conftest.py
@@ -1,10 +1,9 @@
-import importlib.resources
+from pathlib import Path
 import unittest.mock as mock
 
 import pytest
 import json
 
-from importlib.resources.abc import Traversable
 from lumigator import LumigatorClient
 
 LUMI_HOST = "localhost"
@@ -40,70 +39,70 @@ def mock_vendor_data() -> str:
     return '["openai", "mistral"]'
 
 
-def json_data_path() -> Traversable:
-    return importlib.resources.files("sdk.tests") / "data"
+def resources_dir() -> Path:
+    return Path(__file__).parent / "data"
 
 
 @pytest.fixture(scope="session")
-def json_data_deployments() -> Traversable:
-    return json_data_path() / "deployments.json"
+def json_data_deployments() -> Path:
+    return resources_dir() / "deployments.json"
 
 
 @pytest.fixture(scope="session")
-def json_data_jobs() -> Traversable:
-    return json_data_path() / "jobs.json"
+def json_data_jobs() -> Path:
+    return resources_dir() / "jobs.json"
 
 
 @pytest.fixture(scope="session")
-def json_data_job() -> Traversable:
-    return json_data_path() / "job.json"
+def json_data_job() -> Path:
+    return resources_dir() / "job.json"
 
 
 @pytest.fixture(scope="session")
-def json_data_experiments() -> Traversable:
-    return json_data_path() / "experiments.json"
+def json_data_experiments() -> Path:
+    return resources_dir() / "experiments.json"
 
 
 @pytest.fixture(scope="session")
-def json_data_experiment() -> Traversable:
-    return json_data_path() / "experiment.json"
+def json_data_experiment() -> Path:
+    return resources_dir() / "experiment.json"
 
 
 @pytest.fixture(scope="session")
-def json_data_experiment_missing() -> Traversable:
-    return json_data_path() / "experiment-missing.json"
+def json_data_experiment_missing() -> Path:
+    return resources_dir() / "experiment-missing.json"
 
 
 @pytest.fixture(scope="session")
-def json_data_experiment_post_response() -> Traversable:
-    return json_data_path() / "experiment-post-response.json"
+def json_data_experiment_post_response() -> Path:
+    return resources_dir() / "experiment-post-response.json"
 
 
 @pytest.fixture(scope="session")
-def json_data_experiment_post_simple() -> Traversable:
-    return json_data_path() / "experiment-post-simple.json"
+def json_data_experiment_post_simple() -> Path:
+    return resources_dir() / "experiment-post-simple.json"
 
 
 @pytest.fixture(scope="session")
-def json_data_experiment_post_all() -> Traversable:
-    return json_data_path() / "experiment-post-all.json"
+def json_data_experiment_post_all() -> Path:
+    return resources_dir() / "experiment-post-all.json"
 
 
 @pytest.fixture(scope="session")
-def json_data_experiment_result() -> Traversable:
-    return json_data_path() / "experiment-result.json"
+def json_data_experiment_result() -> Path:
+    return resources_dir() / "experiment-result.json"
 
 
 @pytest.fixture(scope="session")
-def json_data_experiment_result_missing() -> Traversable:
-    return json_data_path() / "experiment-result-no-experiment.json"
+def json_data_experiment_result_missing() -> Path:
+    return resources_dir() / "experiment-result-no-experiment.json"
 
 
 @pytest.fixture(scope="session")
-def json_data_experiment_result_download() -> Traversable:
-    return json_data_path() / "experiment-download.json"
+def json_data_experiment_result_download() -> Path:
+    return resources_dir() / "experiment-download.json"
 
 
 @pytest.fixture(scope="session")
-def json_data_experiment_result_download_missing() -> Traversable:
-    return json_data_path() / "experiment-download-no-experiment.json"
+def json_data_experiment_result_download_missing() -> Path:
+    return resources_dir() / "experiment-download-no-experiment.json"

--- a/lumigator/python/mzai/sdk/tests/conftest.py
+++ b/lumigator/python/mzai/sdk/tests/conftest.py
@@ -32,8 +32,7 @@ def lumi_client() -> LumigatorClient:
             resp_mock.status_code = 200
             resp_mock.json = lambda: json.loads('["openai", "mistral"]')
             req_mock.return_value = resp_mock
-            lumi_c = LumigatorClient(LUMI_HOST)
-            return lumi_c
+            return LumigatorClient(LUMI_HOST)
 
 
 @pytest.fixture(scope="session")

--- a/lumigator/python/mzai/sdk/tests/conftest.py
+++ b/lumigator/python/mzai/sdk/tests/conftest.py
@@ -2,6 +2,7 @@ import importlib.resources
 import unittest.mock as mock
 
 import pytest
+import json
 
 from importlib.resources.abc import Traversable
 from lumigator import LumigatorClient
@@ -26,7 +27,14 @@ def mock_requests(mock_requests_response):
 
 @pytest.fixture(scope="session")
 def lumi_client() -> LumigatorClient:
-    return LumigatorClient(LUMI_HOST)
+    lumi_c = None
+    with mock.patch("requests.request") as req_mock:
+        with mock.patch("requests.Response") as resp_mock:
+            resp_mock.status_code = 200
+            resp_mock.json = lambda: json.loads('["openai", "mistral"]')
+            req_mock.return_value = resp_mock
+            lumi_c = LumigatorClient(LUMI_HOST)
+    return lumi_c
 
 
 @pytest.fixture(scope="session")

--- a/lumigator/python/mzai/sdk/tests/data/experiment-download-no-experiment.json
+++ b/lumigator/python/mzai/sdk/tests/data/experiment-download-no-experiment.json
@@ -1,0 +1,3 @@
+{
+  "detail": "No result available for experiment 'string' (status = 'JobStatus.CREATED')."
+}

--- a/lumigator/python/mzai/sdk/tests/data/experiment-download.json
+++ b/lumigator/python/mzai/sdk/tests/data/experiment-download.json
@@ -1,0 +1,4 @@
+{
+    "id": "1e23ed9f-b193-444e-8427-e2119a08b0d8",
+    "download_url": "http://mozilla.ai/results/some-result.csv?X-Key=ABCDEF"
+}

--- a/lumigator/python/mzai/sdk/tests/data/experiment-missing.json
+++ b/lumigator/python/mzai/sdk/tests/data/experiment-missing.json
@@ -1,0 +1,3 @@
+{
+  "detail": "Experiment e3be6e4b-dd1e-43b7-a97b-0d47dcc49a11 not found."
+}

--- a/lumigator/python/mzai/sdk/tests/data/experiment-post-all.json
+++ b/lumigator/python/mzai/sdk/tests/data/experiment-post-all.json
@@ -1,0 +1,8 @@
+{
+    "name": "experiment",
+    "description": "test experiment",
+    "model": "hf://facebook/bart-large-cnn",
+    "dataset": "daab39ac-be9f-4de9-87c0-c4c94b297a97",
+    "max_samples": 1000,
+    "system_prompt": "This is a test template. Just generate something interesting."
+}

--- a/lumigator/python/mzai/sdk/tests/data/experiment-post-response.json
+++ b/lumigator/python/mzai/sdk/tests/data/experiment-post-response.json
@@ -1,0 +1,8 @@
+{
+    "id": "daab39ac-be9f-4de9-87c0-c4c94b297a97",
+    "name": "experiment",
+    "description": "test experiment",
+    "status": "created",
+    "created_at": "2024-10-01T19:01:45.080000Z",
+    "updated_at": null
+}

--- a/lumigator/python/mzai/sdk/tests/data/experiment-post-simple.json
+++ b/lumigator/python/mzai/sdk/tests/data/experiment-post-simple.json
@@ -1,0 +1,6 @@
+{
+    "name": "experiment",
+    "description": "test experiment",
+    "model": "hf://facebook/bart-large-cnn",
+    "dataset": "daab39ac-be9f-4de9-87c0-c4c94b297a97"
+}

--- a/lumigator/python/mzai/sdk/tests/data/experiment-result-no-experiment.json
+++ b/lumigator/python/mzai/sdk/tests/data/experiment-result-no-experiment.json
@@ -1,0 +1,3 @@
+{
+  "detail": "Experiment 71aaf905-4bea-4d19-ad06-214202165814 not found."
+}

--- a/lumigator/python/mzai/sdk/tests/data/experiment-result.json
+++ b/lumigator/python/mzai/sdk/tests/data/experiment-result.json
@@ -1,0 +1,4 @@
+{
+    "id": "e3be6e4b-dd1e-43b7-a97b-0d47dcc49a4f",
+    "experiment_id": "1e23ed9f-b193-444e-8427-e2119a08b0d8"
+}

--- a/lumigator/python/mzai/sdk/tests/data/experiment.json
+++ b/lumigator/python/mzai/sdk/tests/data/experiment.json
@@ -1,0 +1,7 @@
+{
+    "id": "daab39ac-be9f-4de9-87c0-c4c94b297a97",
+    "name": "exp1",
+    "description": "experiment without update",
+    "status": "created",
+    "created_at": "2024-10-01T19:01:45.080000Z"
+}

--- a/lumigator/python/mzai/sdk/tests/data/experiments.json
+++ b/lumigator/python/mzai/sdk/tests/data/experiments.json
@@ -1,0 +1,18 @@
+[
+    {
+        "id": "daab39ac-be9f-4de9-87c0-c4c94b297a97",
+        "name": "exp1",
+        "description": "experiment without update",
+        "status": "created",
+        "created_at": "2024-10-01T19:01:45.080000Z",
+        "updated_at": null
+    },
+    {
+        "id": "e3be6e4b-dd1e-43b7-a97b-0d47dcc49a4f",
+        "name": "exp2",
+        "description": "experiment with update",
+        "status": "failed",
+        "created_at": "2024-10-01T19:01:45.080000Z",
+        "updated_at": "2024-10-01T19:05:45.080000Z"
+    }
+]

--- a/lumigator/python/mzai/sdk/tests/helpers.py
+++ b/lumigator/python/mzai/sdk/tests/helpers.py
@@ -1,26 +1,24 @@
 import unittest.mock as mock
 import importlib.resources
 import json
-from importlib.resources.abc import Traversable
 from pathlib import Path
+from importlib.resources.abc import Traversable
+
 
 LUMI_HOST = "localhost"
 
 
-def load_response(mock_requests_response: mock.Mock, data_path: Traversable):
-    with importlib.resources.as_file(data_path) as path:
-        with Path.open(path) as file:
-            data = json.load(file)
-            mock_requests_response.json = lambda: data
-
-
-def load_request(data_path: Traversable) -> str:
-    with importlib.resources.as_file(data_path) as path:
+def load_json(datafile: Traversable) -> str:
+    with importlib.resources.as_file(datafile) as path:
         with Path.open(path) as file:
             return json.load(file)
 
 
-def check_url(check_url, **kwargs):
-    print(f'the url used is {check_url} vs {kwargs["url"]}')
-    assert check_url == kwargs["url"]
+def check_url(is_url, **kwargs):
+    assert is_url == kwargs["url"]
+    return mock.DEFAULT
+
+
+def check_method(is_method, **kwargs):
+    assert is_method == kwargs["method"]
     return mock.DEFAULT

--- a/lumigator/python/mzai/sdk/tests/helpers.py
+++ b/lumigator/python/mzai/sdk/tests/helpers.py
@@ -1,0 +1,24 @@
+import unittest.mock as mock
+import importlib.resources
+import json
+from pathlib import Path
+
+LUMI_HOST = "localhost"
+
+
+def load_response(mock_requests_response: mock.Mock, datafile: str):
+    with importlib.resources.as_file(datafile) as path:
+        with Path.open(path) as file:
+            data = json.load(file)
+            mock_requests_response.json = lambda: data
+
+
+def load_request(datafile: str) -> str:
+    with importlib.resources.as_file(datafile) as path:
+        with Path.open(path) as file:
+            return json.load(file)
+
+
+def check_url(check_url, **kwargs):
+    assert check_url == kwargs["url"]
+    return mock.DEFAULT

--- a/lumigator/python/mzai/sdk/tests/helpers.py
+++ b/lumigator/python/mzai/sdk/tests/helpers.py
@@ -1,17 +1,14 @@
 import unittest.mock as mock
-import importlib.resources
 import json
 from pathlib import Path
-from importlib.resources.abc import Traversable
 
 
 LUMI_HOST = "localhost"
 
 
-def load_json(datafile: Traversable) -> str:
-    with importlib.resources.as_file(datafile) as path:
-        with Path.open(path) as file:
-            return json.load(file)
+def load_json(path: Path) -> str:
+    with Path.open(path) as file:
+        return json.load(file)
 
 
 def check_url(is_url, **kwargs):

--- a/lumigator/python/mzai/sdk/tests/helpers.py
+++ b/lumigator/python/mzai/sdk/tests/helpers.py
@@ -1,24 +1,26 @@
 import unittest.mock as mock
 import importlib.resources
 import json
+from importlib.resources.abc import Traversable
 from pathlib import Path
 
 LUMI_HOST = "localhost"
 
 
-def load_response(mock_requests_response: mock.Mock, datafile: str):
-    with importlib.resources.as_file(datafile) as path:
+def load_response(mock_requests_response: mock.Mock, data_path: Traversable):
+    with importlib.resources.as_file(data_path) as path:
         with Path.open(path) as file:
             data = json.load(file)
             mock_requests_response.json = lambda: data
 
 
-def load_request(datafile: str) -> str:
-    with importlib.resources.as_file(datafile) as path:
+def load_request(data_path: Traversable) -> str:
+    with importlib.resources.as_file(data_path) as path:
         with Path.open(path) as file:
             return json.load(file)
 
 
 def check_url(check_url, **kwargs):
+    print(f'the url used is {check_url} vs {kwargs["url"]}')
     assert check_url == kwargs["url"]
     return mock.DEFAULT

--- a/lumigator/python/mzai/sdk/tests/test_experiments.py
+++ b/lumigator/python/mzai/sdk/tests/test_experiments.py
@@ -71,3 +71,32 @@ def test_create_experiment_ok_all(
     assert str(experiment_ret.id) == "daab39ac-be9f-4de9-87c0-c4c94b297a97"
     assert experiment_ret.name == "experiment"
     assert experiment_ret.status == "created"
+
+
+def test_get_experiment_result_ok(
+    mock_requests_response, mock_requests, lumi_client, json_data_experiment_result
+):
+    mock_requests_response.status_code = 200
+    data = load_json(json_data_experiment_result)
+    mock_requests_response.json = lambda: data
+
+    experiment_id = "1e23ed9f-b193-444e-8427-e2119a08b0d8"
+    response = lumi_client.experiments.get_experiment_result(experiment_id)
+    assert response is not None
+    assert str(response.experiment_id) == experiment_id
+    assert str(response.id) == "e3be6e4b-dd1e-43b7-a97b-0d47dcc49a4f"
+
+
+def test_get_experiment_result_download_ok(
+    mock_requests_response, mock_requests, lumi_client, json_data_experiment_result_download
+):
+    mock_requests_response.status_code = 200
+    data = load_json(json_data_experiment_result_download)
+    mock_requests_response.json = lambda: data
+
+    experiment_id = "1e23ed9f-b193-444e-8427-e2119a08b0d8"
+    response = lumi_client.experiments.get_experiment_result_download(experiment_id)
+    assert response is not None
+
+    assert str(response.download_url) == "http://mozilla.ai/results/some-result.csv?X-Key=ABCDEF"
+    assert str(response.id) == experiment_id

--- a/lumigator/python/mzai/sdk/tests/test_experiments.py
+++ b/lumigator/python/mzai/sdk/tests/test_experiments.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-from schemas.experiments import ExperimentResponse
 from tests.helpers import load_json
 
 

--- a/lumigator/python/mzai/sdk/tests/test_experiments.py
+++ b/lumigator/python/mzai/sdk/tests/test_experiments.py
@@ -1,11 +1,13 @@
-from helpers import load_request, load_response
+from tests.helpers import load_json
 
 
 def test_get_experiments_ok(
     mock_requests_response, mock_requests, lumi_client, json_data_experiments
 ):
     mock_requests_response.status_code = 200
-    load_response(mock_requests_response, json_data_experiments)
+    data = load_json(json_data_experiments)
+    mock_requests_response.json = lambda: data
+
     experiments_ret = lumi_client.experiments.get_experiments()
     assert experiments_ret is not None
 
@@ -14,7 +16,8 @@ def test_get_experiment_ok(
     mock_requests_response, mock_requests, lumi_client, json_data_experiment
 ):
     mock_requests_response.status_code = 200
-    load_response(mock_requests_response, json_data_experiment)
+    data = load_json(json_data_experiment)
+    mock_requests_response.json = lambda: data
     experiment_ret = lumi_client.experiments.get_experiment("daab39ac-be9f-4de9-87c0-c4c94b297a97")
     assert experiment_ret is not None
 
@@ -27,10 +30,11 @@ def test_create_experiment_ok_simple(
     json_data_experiment_post_simple,
 ):
     mock_requests_response.status_code = 200
-    load_response(mock_requests_response, json_data_experiment_post_response)
-    experiment_ret = lumi_client.experiments.create_experiment(
-        load_request(json_data_experiment_post_simple)
-    )
+    data = load_json(json_data_experiment_post_response)
+    mock_requests_response.json = lambda: data
+
+    experiment_json = load_json(json_data_experiment_post_simple)
+    experiment_ret = lumi_client.experiments.create_experiment(experiment_json)
     assert experiment_ret is not None
 
 
@@ -42,8 +46,10 @@ def test_create_experiment_ok_all(
     json_data_experiment_post_all,
 ):
     mock_requests_response.status_code = 200
-    load_response(mock_requests_response, json_data_experiment_post_response)
-    experiment_ret = lumi_client.experiments.create_experiment(
-        load_request(json_data_experiment_post_all)
-    )
+    data = load_json(json_data_experiment_post_response)
+    mock_requests_response.json = lambda: data
+
+    experiment_json = load_json(json_data_experiment_post_all)
+    experiment_ret = lumi_client.experiments.create_experiment(experiment_json)
+
     assert experiment_ret is not None

--- a/lumigator/python/mzai/sdk/tests/test_experiments.py
+++ b/lumigator/python/mzai/sdk/tests/test_experiments.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+from schemas.experiments import ExperimentResponse
 from tests.helpers import load_json
 
 
@@ -10,6 +12,15 @@ def test_get_experiments_ok(
 
     experiments_ret = lumi_client.experiments.get_experiments()
     assert experiments_ret is not None
+    assert len(experiments_ret) == 2
+    assert any(
+        str(x.id) == "daab39ac-be9f-4de9-87c0-c4c94b297a97" and x.name == "exp1"
+        for x in experiments_ret
+    )
+    assert any(
+        str(x.id) == "e3be6e4b-dd1e-43b7-a97b-0d47dcc49a4f" and x.name == "exp2"
+        for x in experiments_ret
+    )
 
 
 def test_get_experiment_ok(
@@ -20,6 +31,9 @@ def test_get_experiment_ok(
     mock_requests_response.json = lambda: data
     experiment_ret = lumi_client.experiments.get_experiment("daab39ac-be9f-4de9-87c0-c4c94b297a97")
     assert experiment_ret is not None
+    assert str(experiment_ret.id) == "daab39ac-be9f-4de9-87c0-c4c94b297a97"
+    assert experiment_ret.name == "exp1"
+    assert experiment_ret.status == "created"
 
 
 def test_create_experiment_ok_simple(
@@ -36,6 +50,9 @@ def test_create_experiment_ok_simple(
     experiment_json = load_json(json_data_experiment_post_simple)
     experiment_ret = lumi_client.experiments.create_experiment(experiment_json)
     assert experiment_ret is not None
+    assert str(experiment_ret.id) == "daab39ac-be9f-4de9-87c0-c4c94b297a97"
+    assert experiment_ret.name == "experiment"
+    assert experiment_ret.status == "created"
 
 
 def test_create_experiment_ok_all(
@@ -53,3 +70,6 @@ def test_create_experiment_ok_all(
     experiment_ret = lumi_client.experiments.create_experiment(experiment_json)
 
     assert experiment_ret is not None
+    assert str(experiment_ret.id) == "daab39ac-be9f-4de9-87c0-c4c94b297a97"
+    assert experiment_ret.name == "experiment"
+    assert experiment_ret.status == "created"

--- a/lumigator/python/mzai/sdk/tests/test_experiments.py
+++ b/lumigator/python/mzai/sdk/tests/test_experiments.py
@@ -34,6 +34,16 @@ def test_get_experiment_ok(
     assert experiment_ret.status == "created"
 
 
+def test_get_experiment_missing(
+    mock_requests_response, mock_requests, lumi_client, json_data_experiment_missing
+):
+    mock_requests_response.status_code = 404
+    data = load_json(json_data_experiment_missing)
+    mock_requests_response.json = lambda: data
+    experiment_ret = lumi_client.experiments.get_experiment("daab39ac-be9f-4de9-87c0-c4c94b297a97")
+    assert experiment_ret is None
+
+
 def test_create_experiment_ok_simple(
     mock_requests_response,
     mock_requests,
@@ -87,6 +97,23 @@ def test_get_experiment_result_ok(
     assert str(response.id) == "e3be6e4b-dd1e-43b7-a97b-0d47dcc49a4f"
 
 
+def test_get_experiment_result_no_experiment(
+    mock_requests_response, mock_requests, lumi_client, json_data_experiment_result_missing
+):
+    mock_requests_response.status_code = 404
+    data = load_json(json_data_experiment_result_missing)
+    mock_requests_response.json = lambda: data
+
+    # TODO: The return from the API at the time of creating the test is
+    # incorrect and contains malformed error details.
+    # Once the API bug is corrected the associated data for this test should
+    # be updated.
+    # See: data/experiment-download-no-experiment.json
+    experiment_id = "1e23ed9f-b193-444e-8427-e2119a08b0d8"
+    response = lumi_client.experiments.get_experiment_result(experiment_id)
+    assert response is None
+
+
 def test_get_experiment_result_download_ok(
     mock_requests_response, mock_requests, lumi_client, json_data_experiment_result_download
 ):
@@ -100,3 +127,15 @@ def test_get_experiment_result_download_ok(
 
     assert str(response.download_url) == "http://mozilla.ai/results/some-result.csv?X-Key=ABCDEF"
     assert str(response.id) == experiment_id
+
+
+def test_get_experiment_result_download_no_experiment(
+    mock_requests_response, mock_requests, lumi_client, json_data_experiment_result_download_missing
+):
+    mock_requests_response.status_code = 404
+    data = load_json(json_data_experiment_result_download_missing)
+    mock_requests_response.json = lambda: data
+
+    experiment_id = "1e23ed9f-b193-444e-8427-e2119a08b0d8"
+    response = lumi_client.experiments.get_experiment_result_download(experiment_id)
+    assert response is None

--- a/lumigator/python/mzai/sdk/tests/test_experiments.py
+++ b/lumigator/python/mzai/sdk/tests/test_experiments.py
@@ -1,0 +1,49 @@
+from helpers import load_request, load_response
+
+
+def test_get_experiments_ok(
+    mock_requests_response, mock_requests, lumi_client, json_data_experiments
+):
+    mock_requests_response.status_code = 200
+    load_response(mock_requests_response, json_data_experiments)
+    experiments_ret = lumi_client.experiments.get_experiments()
+    assert experiments_ret is not None
+
+
+def test_get_experiment_ok(
+    mock_requests_response, mock_requests, lumi_client, json_data_experiment
+):
+    mock_requests_response.status_code = 200
+    load_response(mock_requests_response, json_data_experiment)
+    experiment_ret = lumi_client.experiments.get_experiment("daab39ac-be9f-4de9-87c0-c4c94b297a97")
+    assert experiment_ret is not None
+
+
+def test_create_experiment_ok_simple(
+    mock_requests_response,
+    mock_requests,
+    lumi_client,
+    json_data_experiment_post_response,
+    json_data_experiment_post_simple,
+):
+    mock_requests_response.status_code = 200
+    load_response(mock_requests_response, json_data_experiment_post_response)
+    experiment_ret = lumi_client.experiments.create_experiment(
+        load_request(json_data_experiment_post_simple)
+    )
+    assert experiment_ret is not None
+
+
+def test_create_experiment_ok_all(
+    mock_requests_response,
+    mock_requests,
+    lumi_client,
+    json_data_experiment_post_response,
+    json_data_experiment_post_all,
+):
+    mock_requests_response.status_code = 200
+    load_response(mock_requests_response, json_data_experiment_post_response)
+    experiment_ret = lumi_client.experiments.create_experiment(
+        load_request(json_data_experiment_post_all)
+    )
+    assert experiment_ret is not None


### PR DESCRIPTION
## What's changing

This PR adds support for the Experiments API in the SDK.

## How to test it

Run the PyTest tests locally in your IDE, or `pants test lumigator/python/mzai/sdk:: -- -s`

## Additional notes for reviewers

## I already...

- [x] added some tests for any new functionality;
- [ ] updated the documentation.