### PR TITLE
Make evaluator work dir configurable for different environments

### DIFF
--- a/.devcontainer/docker-compose-local.yaml
+++ b/.devcontainer/docker-compose-local.yaml
@@ -93,6 +93,7 @@ services:
       - AWS_ENDPOINT_URL=http://localhost:4566
       - S3_BUCKET=lumigator-storage
       - PYTHONPATH=/mzai/lumigator/python/mzai/backend
+      - EVALUATOR_WORK_DIR=/mzai/lumigator/python/mzai
       - RAY_DASHBOARD_PORT=8265
       - RAY_HEAD_NODE_HOST=ray
       - LOCAL_FSSPEC_S3_ENDPOINT_URL=${LOCAL_FSSPEC_S3_ENDPOINT_URL}

--- a/lumigator/python/mzai/backend/backend/services/experiments.py
+++ b/lumigator/python/mzai/backend/backend/services/experiments.py
@@ -144,7 +144,7 @@ class ExperimentService:
 
         runtime_env = {
             "pip": settings.PIP_REQS,
-            "working_dir": "/mzai/lumigator/python/mzai",
+            "working_dir": settings.EVALUATOR_WORK_DIR,
             "env_vars": runtime_env_vars,
         }
 

--- a/lumigator/python/mzai/backend/backend/settings.py
+++ b/lumigator/python/mzai/backend/backend/settings.py
@@ -56,6 +56,9 @@ class BackendSettings(BaseSettings):
     # Summarizer
     SUMMARIZER_WORK_DIR: str | None = None
 
+    # Eval
+    EVALUATOR_WORK_DIR: str | None = None
+
     def inherit_ray_env(self, runtime_env_vars: Mapping[str, str]):
         for env_var_name in self.RAY_WORKER_ENV_VARS:
             env_var = os.environ.get(env_var_name, None)


### PR DESCRIPTION
## What's changing
This allows evaluator working_dir to be passed in dymanically based on different environments.

## How to test it

run `make local-up` and then run an evaluation, it should function as normal.

## Related Jira Ticket

## Additional notes for reviewers

## I already...

- [ ] added some tests for any new functionality;
- [ ] updated the documentation.