### PR TITLE
Mock requests before instantiating test client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ ci-fmt: ci-lint
 ci-tests:
 	@echo "running tests with parametrized platform: $(PARAMETRIZE)"
 	pants test lumigator/python/mzai/backend/backend/tests:backend_tests@parametrize=$(PARAMETRIZE)
+	pants test lumigator/python/mzai/sdk/tests:sdk_tests@parametrize=$(PARAMETRIZE)
 
 ci-publish-images:
 	pants package publish lumigator/python/mzai/backend:lumigator

--- a/lumigator/python/mzai/sdk/tests/BUILD.pants
+++ b/lumigator/python/mzai/sdk/tests/BUILD.pants
@@ -1,4 +1,4 @@
-python_sources(name="sdk_test_sources", sources=["**/*.py"])
+python_test_utils(name="sdk_test_utils", sources=["conftest.py"])
 
 python_tests(
     name="sdk_tests",

--- a/lumigator/python/mzai/sdk/tests/conftest.py
+++ b/lumigator/python/mzai/sdk/tests/conftest.py
@@ -2,6 +2,7 @@ import importlib.resources
 import unittest.mock as mock
 
 import pytest
+import json
 
 from importlib.resources.abc import Traversable
 from lumigator import LumigatorClient
@@ -26,7 +27,12 @@ def mock_requests(mock_requests_response):
 
 @pytest.fixture(scope="session")
 def lumi_client() -> LumigatorClient:
-    return LumigatorClient(LUMI_HOST)
+    with mock.patch("requests.request") as req_mock:
+        with mock.patch("requests.Response") as resp_mock:
+            resp_mock.status_code = 200
+            resp_mock.json = lambda: json.loads('["openai", "mistral"]')
+            req_mock.return_value = resp_mock
+            return LumigatorClient(LUMI_HOST)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## What's changing

Before the SDK tests instantiate the client, the `requests`package needs to be mocked to feed the client the list of allowed vendors.

SDK tests have also been added to the `ci-test` target.

## How to test it

SDK tests (CI and standalone) run successfully.

## Related Jira Ticket

-

## Additional notes for reviewers

## I already...

- [x] added some tests for any new functionality;
- [ ] updated the documentation.