### PR TITLE
LUMI-53   [Security] Remove secrets from RAY_WORKER_ENV_VARS

### DIFF
--- a/.devcontainer/docker-compose-local.yaml
+++ b/.devcontainer/docker-compose-local.yaml
@@ -55,6 +55,18 @@ services:
       - REDISPASSWORD=yourpassword
       - NUM_WORKERS=4
       - NUM_CPU_WORKER=1
+      # LOCAL_FSSPEC_S3 env vars required by s3fs running inside evaluator ray jobs
+      - LOCAL_FSSPEC_S3_ENDPOINT_URL=http://localhost:4566 # Should match AWS_ENDPOINT_URL
+      - LOCAL_FSSPEC_S3_KEY=test # Should match AWS_SECRET_ACCESS_KEY
+      - LOCAL_FSSPEC_S3_SECRET=test # Should match AWS_SECRET_ACCESS_KEY
+      - MISTRAL_API_KEY=${MISTRAL_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - HF_TOKEN=${HF_TOKEN}
+      - AWS_ACCESS_KEY_ID=test
+      - AWS_SECRET_ACCESS_KEY=test
+      - AWS_DEFAULT_REGION=us-east-2
+      - AWS_ENDPOINT_URL=http://localhost:4566
+
     volumes:
       - ../lumigator/python/mzai/summarizer/summarizer.py:/home/ray/summarizer.py
     # NOTE: to keep AWS_ENDPOINT_URL as http://localhost:4566 both on the host system
@@ -95,9 +107,6 @@ services:
       - EVALUATOR_WORK_DIR=/mzai/lumigator/python/mzai
       - RAY_DASHBOARD_PORT=8265
       - RAY_HEAD_NODE_HOST=ray
-      - LOCAL_FSSPEC_S3_ENDPOINT_URL=${LOCAL_FSSPEC_S3_ENDPOINT_URL}
-      - LOCAL_FSSPEC_S3_KEY=${LOCAL_FSSPEC_S3_KEY}
-      - LOCAL_FSSPEC_S3_SECRET=${LOCAL_FSSPEC_S3_SECRET}
       - MISTRAL_API_KEY=${MISTRAL_API_KEY}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - RAY_WORKER_GPUS=0

--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ If the S3 storage service is used, the endpoint, key and secret are needed. The 
 
 | Environment variable name | Default value | Description |
 | --- | :-: | --- |
-| AWS_HOST | "" | Host where S3 is located. Currently pointing at `services.localstack`. |
 | AWS_ENDPOINT_URL | "" | Endpoint URL for the S3 data storage service. |
 | AWS_ACCESS_KEY_ID | "" | Key for the S3 data storage service. |
 | AWS_SECRET_ACCESS_KEY | "" | Secret for the S3 data storage service. |

--- a/lumigator/python/mzai/backend/backend/settings.py
+++ b/lumigator/python/mzai/backend/backend/settings.py
@@ -32,18 +32,8 @@ class BackendSettings(BaseSettings):
     RAY_DASHBOARD_PORT: int = 8265
     RAY_SERVE_INFERENCE_PORT: int = 8000
     # the following vars will be copied, if present, from Ray head to workers
-    RAY_WORKER_ENV_VARS: list[str] = [
-        "AWS_ACCESS_KEY_ID",
-        "AWS_SECRET_ACCESS_KEY",
-        "AWS_ENDPOINT_URL",
-        "AWS_HOST",
-        "LOCAL_FSSPEC_S3_KEY",
-        "LOCAL_FSSPEC_S3_SECRET",
-        "LOCAL_FSSPEC_S3_ENDPOINT_URL",
-        "HF_TOKEN",
-        "OPENAI_API_KEY",
-        "MISTRAL_API_KEY",
-    ]
+    # Secrets should be added directly to ray by setting env vars on the ray head/worker nodes
+    RAY_WORKER_ENV_VARS: list[str] = []
     RAY_WORKER_GPUS_ENV_VAR: str = "RAY_WORKER_GPUS"
     RAY_WORKER_GPUS_FRACTION_ENV_VAR: str = "RAY_WORKER_GPUS_FRACTION"
 

--- a/lumigator/python/mzai/sdk/tests/data/job.json
+++ b/lumigator/python/mzai/sdk/tests/data/job.json
@@ -41,15 +41,7 @@
         "pip_check": false
       },
       "env_vars": {
-        "MZAI_JOB_ID": "6f6487ac-7170-4a11-af7a-0f6db1ec9a74",
-        "AWS_ACCESS_KEY_ID": "test",
-        "AWS_SECRET_ACCESS_KEY": "test",
-        "AWS_ENDPOINT_URL": "http://localhost:4566",
-        "LOCAL_FSSPEC_S3_KEY": "",
-        "LOCAL_FSSPEC_S3_SECRET": "",
-        "LOCAL_FSSPEC_S3_ENDPOINT_URL": "",
-        "OPENAI_API_KEY": "",
-        "MISTRAL_API_KEY": ""
+        "MZAI_JOB_ID": "6f6487ac-7170-4a11-af7a-0f6db1ec9a74"
       },
       "_ray_commit": "97c37298df9e997b86ca9efed824e27024f3bd60"
     },

--- a/lumigator/python/mzai/sdk/tests/data/jobs.json
+++ b/lumigator/python/mzai/sdk/tests/data/jobs.json
@@ -42,15 +42,7 @@
         "pip_check": false
       },
       "env_vars": {
-        "MZAI_JOB_ID": "6f6487ac-7170-4a11-af7a-0f6db1ec9a74",
-        "AWS_ACCESS_KEY_ID": "test",
-        "AWS_SECRET_ACCESS_KEY": "test",
-        "AWS_ENDPOINT_URL": "http://localhost:4566",
-        "LOCAL_FSSPEC_S3_KEY": "",
-        "LOCAL_FSSPEC_S3_SECRET": "",
-        "LOCAL_FSSPEC_S3_ENDPOINT_URL": "",
-        "OPENAI_API_KEY": "",
-        "MISTRAL_API_KEY": ""
+        "MZAI_JOB_ID": "6f6487ac-7170-4a11-af7a-0f6db1ec9a74"
       },
       "_ray_commit": "97c37298df9e997b86ca9efed824e27024f3bd60"
     },
@@ -101,15 +93,7 @@
         "pip_check": false
       },
       "env_vars": {
-        "MZAI_JOB_ID": "6f6487ac-7170-4a11-af7a-0f6db1ec9a74",
-        "AWS_ACCESS_KEY_ID": "test",
-        "AWS_SECRET_ACCESS_KEY": "test",
-        "AWS_ENDPOINT_URL": "http://localhost:4566",
-        "LOCAL_FSSPEC_S3_KEY": "",
-        "LOCAL_FSSPEC_S3_SECRET": "",
-        "LOCAL_FSSPEC_S3_ENDPOINT_URL": "",
-        "OPENAI_API_KEY": "",
-        "MISTRAL_API_KEY": ""
+        "MZAI_JOB_ID": "6f6487ac-7170-4a11-af7a-0f6db1ec9a74"
       },
       "_ray_commit": "97c37298df9e997b86ca9efed824e27024f3bd60"
     },


### PR DESCRIPTION
## What's changing
Set secrets directly on Ray node instead of via backend (secrets passed via env var of ray jobs api are leaked in the logs, etc) 

Other minor changes:
- AWS_HOST doesn't seem to be set anywhere anymore, so remove from docs,
- Set HF_TOKEN on directly on ray workers now
- Remove setting LOCAL_FSSPEC_S3 env vars on the backend side (only needed by the evaluate ray job)
- Remove secrets from mocks

## How to test it
Run `make local-up`
- [x] Try dataset upload
- [x] Try running eval job

## Related Jira Ticket

https://mzai.atlassian.net/browse/LUMI-53

## Additional notes for reviewers

## I already...

- [x] Verified this works by manually running the above tests