### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/sdk_integration_tests.yaml
+++ b/.github/workflows/sdk_integration_tests.yaml
@@ -1,0 +1,36 @@
+name: SDK integration tests
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "**"
+  workflow_dispatch:
+
+
+jobs:
+  integration:
+    name: SDK integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install python
+        run: uv python install
+        working-directory: lumigator/python/mzai/sdk
+
+      - name: Setup containers
+        run: make start-lumigator
+
+      - name: Run tests
+        run: uv run pytest -o "python_files=int_test_*.py" tests
+        working-directory: lumigator/python/mzai/sdk
+
+      - name: Teardown containers
+        run: make stop-lumigator

--- a/lumigator/python/mzai/sdk/BUILD.pants
+++ b/lumigator/python/mzai/sdk/BUILD.pants
@@ -1,7 +1,0 @@
-python_sources(
-    name="sdk_sources",
-    sources=[
-        "**/*.py",
-        "!tests",
-    ],
-)

--- a/lumigator/python/mzai/sdk/tests/BUILD.pants
+++ b/lumigator/python/mzai/sdk/tests/BUILD.pants
@@ -1,9 +1,0 @@
-python_test_utils(name="sdk_test_utils", sources=["conftest.py", "helpers.py"])
-
-python_tests(
-    name="sdk_tests",
-    sources=["**/test_*.py"],
-    dependencies=[":data-json", "3rdparty/python:3rdparty#pydantic"],
-)
-
-resources(name="data-json", sources=["data/*.json"])

--- a/lumigator/python/mzai/sdk/tests/conftest.py
+++ b/lumigator/python/mzai/sdk/tests/conftest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from sdk.lumigator import LumigatorClient
 
-LUMI_HOST = "localhost"
+LUMI_HOST = "localhost:8000"
 
 
 @pytest.fixture(scope="function")
@@ -113,5 +113,5 @@ def json_data_dataset() -> Path:
 
 
 @pytest.fixture(scope="session")
-def hf_data() -> Path:
-    return resources_dir() / "thunderbird_gt_bart.csv"
+def dialog_data() -> Path:
+    return resources_dir() / "dialogsum_exc.csv"

--- a/lumigator/python/mzai/sdk/tests/data/dialogsum_exc.csv
+++ b/lumigator/python/mzai/sdk/tests/data/dialogsum_exc.csv
@@ -1,0 +1,55 @@
+examples,ground_truth
+"#Person1#: Hello, how are you doing today?
+#Person2#: I ' Ve been having trouble breathing lately.
+#Person1#: Have you had any type of cold lately?
+#Person2#: No, I haven ' t had a cold. I just have a heavy feeling in my chest when I try to breathe.
+#Person1#: Do you have any allergies that you know of?
+#Person2#: No, I don ' t have any allergies that I know of.
+#Person1#: Does this happen all the time or mostly when you are active?
+#Person2#: It happens a lot when I work out.
+#Person1#: I am going to send you to a pulmonary specialist who can run tests on you for asthma.
+#Person2#: Thank you for your help, doctor.",#Person2# has trouble breathing. The doctor asks #Person2# about it and will send #Person2# to a pulmonary specialist.
+"#Person1#: Hey Jimmy. Let's go workout later today.
+#Person2#: Sure. What time do you want to go?
+#Person1#: How about at 3:30?
+#Person2#: That sounds good. Today we work on Legs and forearm.
+#Person1#: Hey. I just played basketball earlier, so my legs are a little sore. Let's work out on arms and stomach today.
+#Person2#: I'm on a weekly schedule. You're messing everything up.
+#Person1#: C'mon. We're only switching two days. You can do legs on Friday.
+#Person2#: Aright. I'll meet you at the gym at 3:30 then.",#Person1# invites Jimmy to go workout and persuades him into working out on arms and stomach.
+"#Person1#: I need to stop eating such unhealthy foods.
+#Person2#: I know what you mean. I've started eating better myself.
+#Person1#: What foods do you eat now?
+#Person2#: I tend to stick to fruits, vegetables, and chicken.
+#Person1#: Those are the only things you eat?
+#Person2#: That's basically what I eat.
+#Person1#: Why aren't you eating anything else?
+#Person2#: Well, fruits and vegetables are very healthy.
+#Person1#: And the chicken?
+#Person2#: It's really healthy to eat when you bake it.
+#Person1#: I guess that does sound a lot healthier.","#Person1# plans to stop eating unhealthy foods, and #Person2# shares #Person2#'s healthy recipe with #Person1#."
+"#Person1#: Do you believe in UFOs?
+#Person2#: Of course, they are out there.
+#Person1#: But I never saw them.
+#Person2#: Are you stupid? They are called UFOs, so not everybody can see them.
+#Person1#: You mean that you can them.
+#Person2#: That's right. I can see them in my dreams.
+#Person1#: They come to the earth?
+#Person2#: No. Their task is to send the aliens here from the outer space.
+#Person1#: Aliens from the outer space? Do you talk to them? What do they look like?
+#Person2#: OK, OK, one by one, please! They look like robots, but they can speak. Their mission is to make friends with human beings.
+#Person1#: That means that you talk to them? In which language?
+#Person2#: Of course in English, they learn English on Mars too.
+#Person1#: Wow. Sounds fantastic!",#Person2# believes in UFOs and can see them in dreams. #Person1# asks #Person2# about UFOs and aliens in #Person2#'s dreams and finds #Person2#'s dreams fantastic.
+"#Person1#: Did you go to school today?
+#Person2#: Of course. Did you?
+#Person1#: I didn't want to, so I didn't.
+#Person2#: That's sad, but have you gone to the movies recently?
+#Person1#: That's a switch.
+#Person2#: I'm serious, have you?
+#Person1#: No, I haven't. Why?
+#Person2#: I really want to go to the movies this weekend.
+#Person1#: So go then.
+#Person2#: I really don't want to go by myself.
+#Person1#: Well anyway, do you plan on going to school tomorrow?
+#Person2#: No, I think I'm going to go to the movies.",#Person1# didn't go to school today. #Person2# wants to skip class tomorrow to go to the movies.

--- a/lumigator/python/mzai/sdk/tests/int_test_datasets.py
+++ b/lumigator/python/mzai/sdk/tests/int_test_datasets.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+from time import sleep
+
+from schemas.datasets import DatasetFormat
+from loguru import logger
+
+from tests.helpers import load_json, check_method
+
+
+def test_sdk_healthcheck_ok(lumi_client):
+    healthy = False
+    for i in range(10):
+        try:
+            lumi_client.health.healthcheck()
+            healthy = True
+            break
+        except Exception as e:
+            print(f'failed health check, retry {i} - due to {e}')
+            sleep(1)
+    assert healthy
+
+
+def test_get_datasets_remote_ok(lumi_client):
+    datasets = lumi_client.datasets.get_datasets()
+    assert datasets is not None
+
+
+def test_dataset_lifecycle_remote_ok(lumi_client, dialog_data):
+    with Path.open(dialog_data) as file:
+        datasets = lumi_client.datasets.get_datasets()
+        assert datasets.total is 0
+        dataset = lumi_client.datasets.create_dataset(dataset=file, format=DatasetFormat.EXPERIMENT)
+        datasets = lumi_client.datasets.get_datasets()
+        assert datasets.total is 1
+        dataset = lumi_client.datasets.get_dataset(datasets.items[0].id)
+        assert dataset is not None
+        lumi_client.datasets.delete_dataset(datasets.items[0].id)
+        datasets = lumi_client.datasets.get_datasets()
+        assert datasets.total is 0

--- a/lumigator/python/mzai/sdk/tests/test_datasets.py
+++ b/lumigator/python/mzai/sdk/tests/test_datasets.py
@@ -12,7 +12,6 @@ from tests.helpers import check_method, load_json
 def test_get_datasets_ok(mock_requests_response, mock_requests, lumi_client, json_data_datasets):
     mock_requests_response.status_code = 200
     data = load_json(json_data_datasets)
-    print(f"test data is: {data}")
     mock_requests_response.json = lambda: data
 
     datasets = lumi_client.datasets.get_datasets()


### PR DESCRIPTION
## What's changing

Integration tests will check against a running Lumigator instead of mocking responses.

## How to test it

A separate test with address `lumigator/python/mzai/sdk/tests/int_test_datasets.py:sdk_tests` has been provided.

## Related Jira Ticket

LUMI-136

## Additional notes for reviewers

## I already...

- [x] added some tests for any new functionality;
- [ ] updated the documentation.