### PR TITLE
Added GT field recording whether a dataset contains GT

### DIFF
--- a/lumigator/python/mzai/backend/backend/records/datasets.py
+++ b/lumigator/python/mzai/backend/backend/records/datasets.py
@@ -1,8 +1,8 @@
+from schemas.datasets import DatasetFormat
 from sqlalchemy.orm import Mapped
 
 from backend.records.base import BaseRecord
 from backend.records.mixins import CreatedAtMixin
-from schemas.datasets import DatasetFormat
 
 
 class DatasetRecord(BaseRecord, CreatedAtMixin):
@@ -11,3 +11,4 @@ class DatasetRecord(BaseRecord, CreatedAtMixin):
     filename: Mapped[str]
     format: Mapped[DatasetFormat]
     size: Mapped[int]
+    gt: Mapped[bool]

--- a/lumigator/python/mzai/backend/backend/records/datasets.py
+++ b/lumigator/python/mzai/backend/backend/records/datasets.py
@@ -11,4 +11,4 @@ class DatasetRecord(BaseRecord, CreatedAtMixin):
     filename: Mapped[str]
     format: Mapped[DatasetFormat]
     size: Mapped[int]
-    gt: Mapped[bool]
+    ground_truth: Mapped[bool]

--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -156,7 +156,7 @@ class DatasetService:
 
             # Create DB record
             record = self.dataset_repo.create(
-                filename=dataset.filename, format=format, size=actual_size, gt=has_gt
+                filename=dataset.filename, format=format, size=actual_size, ground_truth=has_gt
             )
 
             # convert the dataset to HF format and save it to S3

--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -10,15 +10,16 @@ from loguru import logger
 from mypy_boto3_s3.client import S3Client
 from pydantic import ByteSize
 from s3fs import S3FileSystem
+from schemas.datasets import DatasetDownloadResponse, DatasetFormat, DatasetResponse
+from schemas.extras import ListingResponse
 
 from backend.records.datasets import DatasetRecord
 from backend.repositories.datasets import DatasetRepository
 from backend.settings import settings
-from schemas.datasets import DatasetDownloadResponse, DatasetFormat, DatasetResponse
-from schemas.extras import ListingResponse
 
-ALLOWED_EXPERIMENT_FIELDS: set[str] = {"examples", "ground_truth"}
+GT_FIELD: str = "ground_truth"
 REQUIRED_EXPERIMENT_FIELDS: set[str] = {"examples"}
+ALLOWED_EXPERIMENT_FIELDS: set[str] = {"examples", GT_FIELD}
 
 
 def validate_file_size(input: BinaryIO, output: BinaryIO, max_size: ByteSize) -> int:
@@ -83,6 +84,15 @@ def validate_experiment_dataset(filename: str):
             )
 
 
+def dataset_has_gt(filename: str) -> bool:
+    with Path(filename).open() as f:
+        reader = csv.DictReader(f)
+        fields = set(reader.fieldnames or [])
+        has_gt = GT_FIELD in fields
+
+    return has_gt
+
+
 class DatasetService:
     def __init__(
         self, dataset_repo: DatasetRepository, s3_client: S3Client, s3_filesystem: S3FileSystem
@@ -141,11 +151,12 @@ class DatasetService:
             # Validate format
             validate_dataset_format(temp.name, format)
 
+            # Verify whether the dataset contains ground truth
+            has_gt = dataset_has_gt(temp.name)
+
             # Create DB record
             record = self.dataset_repo.create(
-                filename=dataset.filename,
-                format=format,
-                size=actual_size,
+                filename=dataset.filename, format=format, size=actual_size, gt=has_gt
             )
 
             # convert the dataset to HF format and save it to S3

--- a/lumigator/python/mzai/backend/backend/tests/api/routes/test_datasets.py
+++ b/lumigator/python/mzai/backend/backend/tests/api/routes/test_datasets.py
@@ -135,7 +135,7 @@ def test_experiment_ground_truth(
     )
     assert create_response.status_code == status.HTTP_201_CREATED
     created_dataset = DatasetResponse.model_validate(create_response.json())
-    assert created_dataset.gt is True
+    assert created_dataset.ground_truth is True
 
     create_response = app_client.post(
         url="/datasets",
@@ -144,4 +144,4 @@ def test_experiment_ground_truth(
     )
     assert create_response.status_code == status.HTTP_201_CREATED
     created_dataset = DatasetResponse.model_validate(create_response.json())
-    assert created_dataset.gt is False
+    assert created_dataset.ground_truth is False

--- a/lumigator/python/mzai/backend/backend/tests/api/routes/test_datasets.py
+++ b/lumigator/python/mzai/backend/backend/tests/api/routes/test_datasets.py
@@ -108,19 +108,24 @@ def test_presigned_download(app_client: TestClient, valid_experiment_dataset: st
         assert upload_filename in parse_result.path
 
 
+@pytest.mark.parametrize(
+    "dataset, expected_status",
+    [
+        ("missing_examples_dataset", status.HTTP_403_FORBIDDEN),
+        ("extra_column_dataset", status.HTTP_403_FORBIDDEN),
+    ],
+)
 def test_experiment_format_validation(
     app_client: TestClient,
-    missing_examples_dataset: str,
-    extra_column_dataset: str,
+    dataset: str,
+    expected_status: int,
 ):
-    datasets = [missing_examples_dataset, extra_column_dataset]
-    for d in datasets:
-        response = app_client.post(
-            url="/datasets",
-            data={"format": DatasetFormat.EXPERIMENT.value},
-            files={"dataset": ("dataset.csv", d)},
-        )
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+    response = app_client.post(
+        url="/datasets",
+        data={"format": DatasetFormat.EXPERIMENT.value},
+        files={"dataset": ("dataset.csv", dataset)},
+    )
+    assert response.status_code == expected_status
 
 
 def test_experiment_ground_truth(

--- a/lumigator/python/mzai/backend/schemas/datasets.py
+++ b/lumigator/python/mzai/backend/schemas/datasets.py
@@ -19,5 +19,5 @@ class DatasetResponse(BaseModel, from_attributes=True):
     filename: str
     format: DatasetFormat
     size: int
-    gt: bool
+    ground_truth: bool
     created_at: datetime.datetime

--- a/lumigator/python/mzai/backend/schemas/datasets.py
+++ b/lumigator/python/mzai/backend/schemas/datasets.py
@@ -19,4 +19,5 @@ class DatasetResponse(BaseModel, from_attributes=True):
     filename: str
     format: DatasetFormat
     size: int
+    gt: bool
     created_at: datetime.datetime

--- a/lumigator/python/mzai/sdk/tests/data/dataset.json
+++ b/lumigator/python/mzai/sdk/tests/data/dataset.json
@@ -3,6 +3,6 @@
     "filename": "test.hf",
     "format": "experiment",
     "size": 16,
-    "gt": true,
+    "ground_truth": true,
     "created_at": "2024-09-26T11:52:05"
 }

--- a/lumigator/python/mzai/sdk/tests/data/dataset.json
+++ b/lumigator/python/mzai/sdk/tests/data/dataset.json
@@ -3,5 +3,6 @@
     "filename": "test.hf",
     "format": "experiment",
     "size": 16,
+    "gt": true,
     "created_at": "2024-09-26T11:52:05"
 }

--- a/lumigator/python/mzai/sdk/tests/data/datasets.json
+++ b/lumigator/python/mzai/sdk/tests/data/datasets.json
@@ -6,7 +6,7 @@
             "filename": "ds1.hf",
             "format": "experiment",
             "size": 16,
-            "gt": true,
+            "ground_truth": true,
             "created_at": "2024-09-26T11:52:05"
         },
         {
@@ -14,7 +14,7 @@
             "filename": "ds2.hf",
             "format": "experiment",
             "size": 16,
-            "gt": false,
+            "ground_truth": false,
             "created_at": "2024-09-26T11:52:05"
         },
         {
@@ -22,7 +22,7 @@
             "filename": "ds3.hf",
             "format": "experiment",
             "size": 16,
-            "gt": true,
+            "ground_truth": true,
             "created_at": "2024-09-26T11:52:05"
         }
     ]

--- a/lumigator/python/mzai/sdk/tests/data/datasets.json
+++ b/lumigator/python/mzai/sdk/tests/data/datasets.json
@@ -6,6 +6,7 @@
             "filename": "ds1.hf",
             "format": "experiment",
             "size": 16,
+            "gt": true,
             "created_at": "2024-09-26T11:52:05"
         },
         {
@@ -13,6 +14,7 @@
             "filename": "ds2.hf",
             "format": "experiment",
             "size": 16,
+            "gt": false,
             "created_at": "2024-09-26T11:52:05"
         },
         {
@@ -20,6 +22,7 @@
             "filename": "ds3.hf",
             "format": "experiment",
             "size": 16,
+            "gt": true,
             "created_at": "2024-09-26T11:52:05"
         }
     ]

--- a/lumigator/python/mzai/sdk/tests/test_datasets.py
+++ b/lumigator/python/mzai/sdk/tests/test_datasets.py
@@ -1,13 +1,11 @@
-from pathlib import Path
-
-import json
 import io
+import json
+from http import HTTPMethod
+from pathlib import Path
 from uuid import UUID
 
 from schemas.datasets import DatasetFormat
-from http import HTTPMethod
-
-from tests.helpers import load_json, check_method
+from tests.helpers import check_method, load_json
 
 
 def test_get_datasets_ok(mock_requests_response, mock_requests, lumi_client, json_data_datasets):


### PR DESCRIPTION
## What's changing
A new field is added to the datasets table recording whether GT is included within a dataset.
Exposing this information allows the UI to act accordingly (e.g. warning the user before running an eval) without downloading the whole dataset.

## How to test it
- unit tests: pants test lumigator/python/mzai/backend/backend/tests:backend_tests@parametrize=darwin
- integration tests w curl

## Related Jira Ticket
https://mzai.atlassian.net/browse/LUMI-88

## Additional notes for reviewers

I added @peteski22 and @javiermtorres to get specific SDK-related feedback 🙏 

## I already...

- [ x] added some tests for any new functionality: UNIT TEST
