### PR TITLE
Update local installation for non developers 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,12 +6,8 @@
 	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
 	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
 	"dockerComposeFile": [
-<<<<<<< HEAD
-		"../docker-compose.yaml"
-=======
-		"../../docker-compose/docker-compose.yaml",
+		"../docker-compose.yaml",
 		"./docker-compose-override.yaml"
->>>>>>> LUMI-99
 	],
 
 	// The 'service' property is the name of the service for the container that VS Code should

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,12 @@
 	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
 	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
 	"dockerComposeFile": [
+<<<<<<< HEAD
 		"../docker-compose.yaml"
+=======
+		"../../docker-compose/docker-compose.yaml",
+		"./docker-compose-override.yaml"
+>>>>>>> LUMI-99
 	],
 
 	// The 'service' property is the name of the service for the container that VS Code should

--- a/.devcontainer/docker-compose.override.yaml
+++ b/.devcontainer/docker-compose.override.yaml
@@ -1,0 +1,43 @@
+name: lumigator
+
+services:
+
+  backend:
+    build:
+      context: .
+      dockerfile: "Dockerfile"
+    platform: linux/amd64
+    command: ["uv", "run", "uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "80",  "--reload"]
+    depends_on:
+      - localstack
+    ports:
+      - 80:80
+    environment:
+      - DEPLOYMENT_TYPE=local
+      # The local file needs to be available through a mount,
+      # if persistence is needed
+      - SQLALCHEMY_DATABASE_URL=sqlite:///local.db
+      - S3_ENDPOINT_URL=http://localhost:4566
+      - AWS_ACCESS_KEY_ID=test
+      - AWS_SECRET_ACCESS_KEY=test
+      - AWS_DEFAULT_REGION=us-east-2
+      - AWS_ENDPOINT_URL=http://localhost:4566
+      - S3_BUCKET=lumigator-storage
+      - PYTHONPATH=/mzai/lumigator/python/mzai/backend
+      - PIP_REQS=/mzai/lumigator/python/mzai/evaluator/requirements.txt
+      - EVALUATOR_WORK_DIR=/mzai/lumigator/python/mzai/evaluator
+      - RAY_DASHBOARD_PORT=8265
+      - RAY_HEAD_NODE_HOST=ray
+      - MISTRAL_API_KEY=${MISTRAL_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - RAY_WORKER_GPUS=0
+      - RAY_WORKER_GPUS_FRACTION=0
+    volumes:
+      - ./:/mzai
+    # NOTE: to keep AWS_ENDPOINT_URL as http://localhost:4566 both on the host system
+    #       and inside containers, we map localhost to the host gateway IP.
+    #       This currently works properly, but might be the cause of networking
+    #       issues down the line. This should be used only for local, development
+    #       deployments.
+    extra_hosts:
+      - "localhost:host-gateway"

--- a/.devcontainer/docker-compose.override.yaml
+++ b/.devcontainer/docker-compose.override.yaml
@@ -7,11 +7,11 @@ services:
       context: .
       dockerfile: "Dockerfile"
     platform: linux/amd64
-    command: ["uv", "run", "uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "80",  "--reload"]
+    command: ["uv", "run", "uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000",  "--reload"]
     depends_on:
       - localstack
     ports:
-      - 80:80
+      - 80:8000
     environment:
       - DEPLOYMENT_TYPE=local
       # The local file needs to be available through a mount,

--- a/.devcontainer/localstack/init.sh
+++ b/.devcontainer/localstack/init.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-awslocal s3 mb s3://lumigator-storage

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# .env.example
+
+# PostgreSQL Configuration
+POSTGRES_USER=admin                   # The database username (default: admin)
+POSTGRES_PASSWORD=password             # The database password (default: password)
+POSTGRES_DB=lumigator                  # The name of the PostgreSQL database
+
+# AWS / S3 Configuration
+AWS_ACCESS_KEY_ID=test                 # AWS access key ID (default for local development: test)
+AWS_SECRET_ACCESS_KEY=test             # AWS secret access key (default for local development: test)
+AWS_DEFAULT_REGION=us-east-2           # Default AWS region
+S3_BUCKET=lumigator-storage            # S3 bucket name (default: lumigator-storage)
+S3_ENDPOINT_URL=http://localhost:4566  # S3 endpoint (default for localstack: http://localhost:4566)
+
+# LocalStack Configuration (for development/testing)
+LOCALSTACK_AUTH_TOKEN=                 # Optional: LocalStack authentication token if using LocalStack Pro
+LOCAL_FSSPEC_S3_ENDPOINT_URL=http://localhost:4566  # Filesystem spec S3 endpoint URL
+LOCAL_FSSPEC_S3_KEY=test               # Filesystem spec S3 key (default for local development: test)
+LOCAL_FSSPEC_S3_SECRET=test            # Filesystem spec S3 secret (default for local development: test)
+
+# Ray Configuration
+RAY_HEAD_NODE_HOST=ray                 # Ray head node host (default: ray)
+RAY_DASHBOARD_PORT=8265                # Ray dashboard port (default: 8265)
+
+# API Keys (Sensitive, replace with actual keys for production)
+MISTRAL_API_KEY=                       # API key for Mistral integration (required)
+OPENAI_API_KEY=                        # API key for OpenAI integration (required)
+
+# Other Configuration
+DEPLOYMENT_TYPE=local                  # Deployment type (default: local)
+PYTHONPATH=/mzai/lumigator/python/mzai/backend  # Python path for the backend service

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,9 @@ local-logs:
 start-lumigator:
 	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d 
 
+start-lumigator-external-ray:
+	docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) --profile external up -d
+
 stop-lumigator:
 	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) down
 ######

--- a/Makefile
+++ b/Makefile
@@ -71,13 +71,11 @@ update-3rdparty-lockfiles:
 # specifically dependent on that step.
 
 LOCAL_DOCKERCOMPOSE_FILE:= docker-compose.yaml
+DEV_DOCKER_COMPOSE_FILE:= .devcontainer/docker-compose.override.yaml
 
-# this is the pip requirements file needed for the local devcontainer
-3rdparty/python/requirements_python_linux_cpu.txt: install-pants
-	pants run 3rdparty/python:gen_requirements_python_linux_cpu
+local-up: 
+	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) -f ${DEV_DOCKER_COMPOSE_FILE} up -d --build
 
-local-up:
-	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d --build
 
 local-down:
 	docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) down
@@ -86,7 +84,11 @@ local-logs:
 	docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) logs
 
 
+start-lumigator:
+	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d 
 
+stop-lumigator:
+	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) down
 ######
 # convenience function that mostly shows the various targets in this repo. not necessary at all
 ######

--- a/README.md
+++ b/README.md
@@ -81,10 +81,30 @@ It consists of:
 + A Postgres database to track platform-level tasks and dataset metadata
 
 # Get Started
+You can run the project locally using `docker-compose` on Mac or Linux, or into a distributed environment using Kubernetes [`Helm charts`](lumigator/infra/mzai/helm/lumigator/README.md)
 
-You can build the local project using `pants` and `docker-compose` on Mac or Linux,  or into a distributed environment using Kubernetes [`Helm charts`](lumigator/infra/mzai/helm/lumigator/README.md)
+## Prerequisites:
+`docker` and `docker-compose` must be installed on your system.
 
-## Local Requirements
+## Environment Variables
+
+The project uses a `.env` file to configure settings such as database credentials, API keys, etc. By default, Docker Compose will look for `.env` in the root of the project directory.
+
+If the `.env` file does not exist, it will be automatically created from [`.env.example.`](.env.example)
+
+# Running Lumigator locally
+
+1. `git clone git@github.com:mozilla-ai/lumigator.git`
+2. `make start-lumigator`
+3. The application should be available at http://localhost:8000. 
+
+# Running Lumigator with an external Ray cluster
+To run Lumigator with an external Ray cluster, ensure the ray host and port are configured in [`.env.example.`](.env.example) and then use the following command:
+
+`make start-lumigator-external-ray`
+
+## Local Development Requirements
+If you want to contribute to the project or run it in a development environment these are the requirements.
 
 + [Docker](https://docs.docker.com/engine/install/)
     + On Linux, please also follow the [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,17 +1,5 @@
 name: lumigator
 services:
-  postgres:
-    image: postgres:16-alpine
-    platform: linux/amd64
-    volumes:
-      - postgres-data:/var/lib/postgresql/data/
-    ports:
-      - 5432:5432
-    environment:
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=${POSTGRES_DB}
-
   localstack:
     image: localstack/localstack:3.4.0
     platform: linux/amd64
@@ -64,14 +52,12 @@ services:
       - "localhost:host-gateway"
     profiles: 
       - !external
-      - !arm64
-    
+   
  
   backend:
     image: mzdotai/lumigator:first_uv
     platform: linux/amd64
     depends_on:
-      - postgres
       - localstack
     ports:
       - 80:8000
@@ -104,5 +90,4 @@ services:
       - "localhost:host-gateway"
 
 volumes:
-  postgres-data:
   localstack-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,8 +24,18 @@ services:
       - PERSISTENCE=1
       - SNAPSHOT_SAVE_STRATEGY=ON_REQUEST
     volumes:
-      - .devcontainer/localstack:/etc/localstack/init/ready.d
       - localstack-data:/var/lib/localstack
+  
+  localstack-create-bucket:
+    image: localstack/localstack:3.4.0
+    platform: linux/amd64
+    depends_on:
+      localstack:
+        condition: service_healthy
+    entrypoint: >
+       bash -c "awslocal s3 mb s3://lumigator-storage"
+    extra_hosts:
+      - "localhost:host-gateway"
 
   ray:
     image: rayproject/ray:2.30.0-py311-cpu${RAY_ARCH_SUFFIX}
@@ -64,7 +74,7 @@ services:
       - postgres
       - localstack
     ports:
-      - 8000:8000
+      - 80:8000
     environment:
       - DEPLOYMENT_TYPE=${DEPLOYMENT_TYPE:-local}
       - POSTGRES_HOST=postgres

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,25 +1,30 @@
 name: lumigator
-
 services:
+  postgres:
+    image: postgres:16-alpine
+    platform: linux/amd64
+    volumes:
+      - postgres-data:/var/lib/postgresql/data/
+    ports:
+      - 5432:5432
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
 
   localstack:
-    # if you want to enable local S3-style data persistence, use the following
-    # image and set LOCALSTACK_AUTH_TOKEN in your env
-    # image: localstack/localstack-pro:3.4.0
     image: localstack/localstack:3.4.0
     platform: linux/amd64
     ports:
       - 4566:4566
     environment:
       - SERVICES=s3:4566
-      - CREATE_BUCKETS=lumigator-storage
+      - CREATE_BUCKETS=${S3_BUCKET}
       - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN}
       - PERSISTENCE=1
       - SNAPSHOT_SAVE_STRATEGY=ON_REQUEST
     volumes:
-      # Sync localstack startup scripts
-      # https://docs.localstack.cloud/references/init-hooks/
-      - ./.devcontainer/localstack:/etc/localstack/init/ready.d
+      - .devcontainer/localstack:/etc/localstack/init/ready.d
       - localstack-data:/var/lib/localstack
 
   ray:
@@ -28,7 +33,7 @@ services:
       - "6379:6379"
       - "8265:8265"
       - "10001:10001"
-    command: bash -c "ray start --head --dashboard-port=8265 --port=6379 --dashboard-host=0.0.0.0 --redis-password=yourpassword --block" # pragma: allowlist secret
+    command: bash -c "ray start --head --dashboard-port=8265 --port=6379 --dashboard-host=0.0.0.0 --redis-password=${REDISPASSWORD} --block"
     shm_size: 2g
     deploy:
       resources:
@@ -37,75 +42,57 @@ services:
           memory: '5g'
     environment:
       - HOST=localhost
-      - RAY_IMAGE=raytest
       - REDISPORT=6379
       - DASHBOARDPORT=8265
       - HEADNODEPORT=10001
-      - REDISPASSWORD=yourpassword
+      - REDISPASSWORD=${REDISPASSWORD}
       - NUM_WORKERS=4
       - NUM_CPU_WORKER=1
-      # LOCAL_FSSPEC_S3 env vars required by s3fs running inside evaluator ray jobs
-      - LOCAL_FSSPEC_S3_ENDPOINT_URL=http://localhost:4566 # Should match AWS_ENDPOINT_URL
-      - LOCAL_FSSPEC_S3_KEY=test # Should match AWS_SECRET_ACCESS_KEY
-      - LOCAL_FSSPEC_S3_SECRET=test # Should match AWS_SECRET_ACCESS_KEY
-      - MISTRAL_API_KEY=${MISTRAL_API_KEY}
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - HF_TOKEN=${HF_TOKEN}
-      - AWS_ACCESS_KEY_ID=test
-      - AWS_SECRET_ACCESS_KEY=test
-      - AWS_DEFAULT_REGION=us-east-2
-      - AWS_ENDPOINT_URL=http://localhost:4566
-
     volumes:
-      - ./lumigator/python/mzai/summarizer/summarizer.py:/home/ray/summarizer.py
-    # NOTE: to keep AWS_ENDPOINT_URL as http://localhost:4566 both on the host system
-    #       and inside containers, we map localhost to the host gateway IP.
-    #       This currently works properly, but might be the cause of networking
-    #       issues down the line. This should be used only for local, development
-    #       deployments.
+      - ../lumigator/python/mzai/summarizer/summarizer.py:/home/ray/summarizer.py
     extra_hosts:
       - "localhost:host-gateway"
-
+    profiles: 
+      - !external
+      - !arm64
+    
+ 
   backend:
-    build:
-      context: .
-      dockerfile: "Dockerfile"
+    image: mzdotai/lumigator:first_uv
     platform: linux/amd64
-    command: ["uv", "run", "uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "80",  "--reload"]
     depends_on:
+      - postgres
       - localstack
     ports:
-      - 80:80
+      - 8000:8000
     environment:
-      - DEPLOYMENT_TYPE=local
-      # The local file needs to be available through a mount,
-      # if persistence is needed
+      - DEPLOYMENT_TYPE=${DEPLOYMENT_TYPE:-local}
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PORT=${POSTGRES_PORT:-5432}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - SQLALCHEMY_DATABASE_URL=sqlite:///local.db
-      - S3_ENDPOINT_URL=http://localhost:4566
-      - AWS_ACCESS_KEY_ID=test
-      - AWS_SECRET_ACCESS_KEY=test
-      - AWS_DEFAULT_REGION=us-east-2
-      - AWS_ENDPOINT_URL=http://localhost:4566
-      - S3_BUCKET=lumigator-storage
+      - POSTGRES_DB=${POSTGRES_DB}
+      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-2}
+      - AWS_ENDPOINT_URL=${S3_ENDPOINT_URL}
+      - S3_BUCKET=${S3_BUCKET}
       - PYTHONPATH=/mzai/lumigator/python/mzai/backend
-      - PIP_REQS=/mzai/lumigator/python/mzai/evaluator/requirements.txt
-      - EVALUATOR_WORK_DIR=/mzai/lumigator/python/mzai/evaluator
-      - RAY_DASHBOARD_PORT=8265
-      - RAY_HEAD_NODE_HOST=ray
+      - EVALUATOR_WORK_DIR=/mzai/lumigator/python/mzai
+      - RAY_DASHBOARD_PORT=${RAY_DASHBOARD_PORT}
+      - RAY_HEAD_NODE_HOST=${RAY_HEAD_NODE_HOST}
+      - LOCAL_FSSPEC_S3_ENDPOINT_URL=${LOCAL_FSSPEC_S3_ENDPOINT_URL}
+      - LOCAL_FSSPEC_S3_KEY=${LOCAL_FSSPEC_S3_KEY}
+      - LOCAL_FSSPEC_S3_SECRET=${LOCAL_FSSPEC_S3_SECRET}
       - MISTRAL_API_KEY=${MISTRAL_API_KEY}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - RAY_WORKER_GPUS=0
-      - RAY_WORKER_GPUS_FRACTION=0
-    volumes:
-      - ./:/mzai
-    # NOTE: to keep AWS_ENDPOINT_URL as http://localhost:4566 both on the host system
-    #       and inside containers, we map localhost to the host gateway IP.
-    #       This currently works properly, but might be the cause of networking
-    #       issues down the line. This should be used only for local, development
-    #       deployments.
+      - RAY_WORKER_GPUS=${RAY_WORKER_GPUS:-0}
+      - RAY_WORKER_GPUS_FRACTION=${RAY_WORKER_GPUS_FRACTION:-0}
     extra_hosts:
       - "localhost:host-gateway"
 
 volumes:
-
-    localstack-data:
+  postgres-data:
+  localstack-data:


### PR DESCRIPTION
## What's changing

- Simplified the Lumigator setup by using a pre-built external container, removing the need for users to set up a local Python environment.
- Added new Makefile entry points to streamline running and managing the app.
- Maintained support for the original local setup for backward compatibility.

## How to test it
Run both versions of lumigator, the old one with make-local-up and the new one with start-lumigator and test the app
## Related Jira Ticket

## Additional notes for reviewers

## I already...

- [N/A ] added some tests for any new functionality;
- [x] updated the documentation.