### PR TITLE
Add option to build to main docker-compose file and add make target

### DIFF
--- a/.devcontainer/docker-compose.override.yaml
+++ b/.devcontainer/docker-compose.override.yaml
@@ -3,9 +3,6 @@ name: lumigator
 services:
 
   backend:
-    build:
-      context: .
-      dockerfile: "Dockerfile"
     platform: linux/amd64
     command: ["uv", "run", "uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000",  "--reload"]
     depends_on:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,10 @@ local-logs:
 	docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) logs
 
 start-lumigator: 
-	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d 
+	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d
+
+start-lumigator-build:
+	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d --build
 
 start-lumigator-external-ray: 
 	docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) --profile external up -d

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -77,6 +77,9 @@ services:
 
   backend:
     image: mzdotai/lumigator:latest
+    build:
+      context: .
+      dockerfile: "Dockerfile"
     platform: linux/amd64
     depends_on:
       - localstack


### PR DESCRIPTION
## What's changing
This adds to ability to build the docker images for backend to the main docker compose file

## How to test it
- [x] Run `make local-up` - Should build docker container and mount in code
- [x] Run `make start-lumigator` - Should start lumigator and pull from latest tag
- [x] Run `make start-lumigator-build` - Should build lumigator 