### PR TITLE
[ LUMI-184] Build lumigator before tests

### DIFF
--- a/.github/workflows/sdk_integration_tests.yaml
+++ b/.github/workflows/sdk_integration_tests.yaml
@@ -9,7 +9,6 @@ on:
       - "**"
   workflow_dispatch:
 
-
 jobs:
   integration:
     name: SDK integration tests
@@ -26,7 +25,7 @@ jobs:
         working-directory: lumigator/python/mzai/sdk
 
       - name: Setup containers
-        run: make start-lumigator
+        run: make start-lumigator-build
 
       - name: Run tests
         run: uv run pytest -o "python_files=int_test_*.py" tests

--- a/.github/workflows/tests_uv.yaml
+++ b/.github/workflows/tests_uv.yaml
@@ -23,7 +23,7 @@ jobs:
         continue-on-error: false
 
       - name: Start backend
-        run: make start-lumigator
+        run: make start-lumigator-build
 
       - name: Run tests
         run: SQLALCHEMY_DATABASE_URL=sqlite:///local.db uv run pytest


### PR DESCRIPTION
## What's changing
This runs both integration test suites against the _current_ code. Not the `latest` tag (which currently represents the `latest` code built, and as such could literally be any branch)

## How to test it
Run pytest in backend and sdk projects
