### PR TITLE
Change dataset input fields to required only 

### DIFF
--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -19,7 +19,6 @@ from backend.settings import settings
 
 GT_FIELD: str = "ground_truth"
 REQUIRED_EXPERIMENT_FIELDS: set[str] = {"examples"}
-ALLOWED_EXPERIMENT_FIELDS: set[str] = {"examples", GT_FIELD}
 
 
 def validate_file_size(input: BinaryIO, output: BinaryIO, max_size: ByteSize) -> int:
@@ -47,7 +46,7 @@ def validate_file_size(input: BinaryIO, output: BinaryIO, max_size: ByteSize) ->
 def validate_dataset_format(filename: str, format: DatasetFormat):
     try:
         match format:
-            case DatasetFormat.EXPERIMENT:
+            case DatasetFormat.JOB:
                 validate_experiment_dataset(filename)
             case _:
                 # Should not be reachable
@@ -71,16 +70,6 @@ def validate_experiment_dataset(filename: str):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Experiment dataset is missing the required fields: {missing_fields}.",
-            )
-
-        extra_fields = fields.difference(ALLOWED_EXPERIMENT_FIELDS)
-        if extra_fields:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=(
-                    f"Experiment dataset contains the invalid fields: {extra_fields}. "
-                    f"Only {ALLOWED_EXPERIMENT_FIELDS} are allowed."
-                ),
             )
 
 

--- a/lumigator/python/mzai/backend/backend/tests/api/routes/test_api_workflows.py
+++ b/lumigator/python/mzai/backend/backend/tests/api/routes/test_api_workflows.py
@@ -18,7 +18,7 @@ def test_upload_data_launch_job(local_client: TestClient, dialog_dataset):
 
     create_response = local_client.post("/datasets",
             data={},
-            files={"dataset": dialog_dataset, "format": (None, DatasetFormat.EXPERIMENT.value)},
+            files={"dataset": dialog_dataset, "format": (None, DatasetFormat.JOB.value)},
         )
 
     assert create_response.status_code == 201

--- a/lumigator/python/mzai/backend/backend/tests/api/routes/test_datasets.py
+++ b/lumigator/python/mzai/backend/backend/tests/api/routes/test_datasets.py
@@ -58,7 +58,7 @@ def test_upload_delete(app_client: TestClient, valid_experiment_dataset: str):
     # Create
     create_response = app_client.post(
         url="/datasets",
-        data={"format": DatasetFormat.EXPERIMENT.value},
+        data={"format": DatasetFormat.JOB.value},
         files={"dataset": (upload_filename, valid_experiment_dataset)},
     )
     assert create_response.status_code == status.HTTP_201_CREATED
@@ -89,7 +89,7 @@ def test_presigned_download(app_client: TestClient, valid_experiment_dataset: st
     # Create
     create_response = app_client.post(
         url="/datasets",
-        data={"format": DatasetFormat.EXPERIMENT.value},
+        data={"format": DatasetFormat.JOB.value},
         files={"dataset": (upload_filename, valid_experiment_dataset)},
     )
     created_dataset = DatasetResponse.model_validate(create_response.json())
@@ -122,7 +122,7 @@ def test_experiment_format_validation(
 ):
     response = app_client.post(
         url="/datasets",
-        data={"format": DatasetFormat.EXPERIMENT.value},
+        data={"format": DatasetFormat.JOB.value},
         files={"dataset": ("dataset.csv", dataset)},
     )
     assert response.status_code == expected_status
@@ -135,7 +135,7 @@ def test_experiment_ground_truth(
 ):
     create_response = app_client.post(
         url="/datasets",
-        data={"format": DatasetFormat.EXPERIMENT.value},
+        data={"format": DatasetFormat.JOB.value},
         files={"dataset": ("dataset.csv", valid_experiment_dataset)},
     )
     assert create_response.status_code == status.HTTP_201_CREATED
@@ -144,7 +144,7 @@ def test_experiment_ground_truth(
 
     create_response = app_client.post(
         url="/datasets",
-        data={"format": DatasetFormat.EXPERIMENT.value},
+        data={"format": DatasetFormat.JOB.value},
         files={"dataset": ("dataset.csv", valid_experiment_dataset_without_gt)},
     )
     assert create_response.status_code == status.HTTP_201_CREATED

--- a/lumigator/python/mzai/schemas/schemas/datasets.py
+++ b/lumigator/python/mzai/schemas/schemas/datasets.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 
 class DatasetFormat(str, Enum):
-    EXPERIMENT = "experiment"
+    JOB = "job"
 
 
 class DatasetDownloadResponse(BaseModel):

--- a/lumigator/python/mzai/sdk/sdk/lm_datasets.py
+++ b/lumigator/python/mzai/sdk/sdk/lm_datasets.py
@@ -52,7 +52,7 @@ class Datasets:
 
         Args:
             dataset(IOBase): a bytes-like object containing the dataset itself.
-            format(DatasetFormat): currently, always `DatasetFormat.EXPERIMENT`.
+            format(DatasetFormat): currently, always `DatasetFormat.JOB`.
 
         Returns:
             DatasetResponse: the information for the newly created dataset.

--- a/lumigator/python/mzai/sdk/tests/data/dataset.json
+++ b/lumigator/python/mzai/sdk/tests/data/dataset.json
@@ -1,7 +1,7 @@
 {
     "id": "daab39ac-be9f-4de9-87c0-c4c94b297a97",
     "filename": "test.hf",
-    "format": "experiment",
+    "format": "job",
     "size": 16,
     "ground_truth": true,
     "created_at": "2024-09-26T11:52:05"

--- a/lumigator/python/mzai/sdk/tests/data/datasets.json
+++ b/lumigator/python/mzai/sdk/tests/data/datasets.json
@@ -4,7 +4,7 @@
         {
             "id": "daab39ac-be9f-4de9-87c0-c4c94b297a97",
             "filename": "ds1.hf",
-            "format": "experiment",
+            "format": "job",
             "size": 16,
             "ground_truth": true,
             "created_at": "2024-09-26T11:52:05"
@@ -12,7 +12,7 @@
         {
             "id": "e3be6e4b-dd1e-43b7-a97b-0d47dcc49a4f",
             "filename": "ds2.hf",
-            "format": "experiment",
+            "format": "job",
             "size": 16,
             "ground_truth": false,
             "created_at": "2024-09-26T11:52:05"
@@ -20,7 +20,7 @@
         {
             "id": "1e23ed9f-b193-444e-8427-e2119a08b0d8",
             "filename": "ds3.hf",
-            "format": "experiment",
+            "format": "job",
             "size": 16,
             "ground_truth": true,
             "created_at": "2024-09-26T11:52:05"

--- a/lumigator/python/mzai/sdk/tests/int_test_datasets.py
+++ b/lumigator/python/mzai/sdk/tests/int_test_datasets.py
@@ -29,7 +29,7 @@ def test_dataset_lifecycle_remote_ok(lumi_client, dialog_data):
     with Path.open(dialog_data) as file:
         datasets = lumi_client.datasets.get_datasets()
         assert datasets.total == 0
-        dataset = lumi_client.datasets.create_dataset(dataset=file, format=DatasetFormat.EXPERIMENT)
+        dataset = lumi_client.datasets.create_dataset(dataset=file, format=DatasetFormat.JOB)
         datasets = lumi_client.datasets.get_datasets()
         assert datasets.total == 1
         dataset = lumi_client.datasets.get_dataset(datasets.items[0].id)

--- a/lumigator/python/mzai/sdk/tests/test_datasets.py
+++ b/lumigator/python/mzai/sdk/tests/test_datasets.py
@@ -65,6 +65,6 @@ def test_create_dataset_ok(mock_requests_response, mock_requests, lumi_client, j
 
     content = io.BytesIO(bytearray(b"0" * 20))
     dataset = lumi_client.datasets.create_dataset(
-        dataset=(data["filename"], content), format=DatasetFormat.EXPERIMENT
+        dataset=(data["filename"], content), format=DatasetFormat.JOB
     )
     assert dataset is not None


### PR DESCRIPTION
## What's changing

Addressing https://github.com/mozilla-ai/lumigator/issues/144 - We'd like to only require `examples` as a field and allow for optional fields, including `ground_truth` so we don't create errors when users upload data with more fields or files from other experiments.  Also changing `EXPERIMENT` to `JOB` for dataset format validation.  

## How to test it

Unit tests and upload file with various headers 

## Additional notes for reviewers

## I already...

- [ ] added some tests for any new functionality;
- [ ] updated the documentation.