### PR TITLE
Add docker compose external file with overrides for using external deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,27 +11,31 @@ ifeq ($(ARCH), arm64)
 	RAY_ARCH_SUFFIX := -aarch64
 endif
 
-
+EXTERNAL_DOCKER_COMPOSE_FILE:= docker-compose.external.yaml
 LOCAL_DOCKERCOMPOSE_FILE:= docker-compose.yaml
 DEV_DOCKER_COMPOSE_FILE:= .devcontainer/docker-compose.override.yaml
 
+# Launches Lumigator in 'development' mode (all services running locally, code mounted in)
 local-up: 
-	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) -f ${DEV_DOCKER_COMPOSE_FILE} up -d --build
+	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose --profile local -f $(LOCAL_DOCKERCOMPOSE_FILE) -f ${DEV_DOCKER_COMPOSE_FILE} up -d --build
 
 local-down:
-	docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) down
+	docker compose --profile local -f $(LOCAL_DOCKERCOMPOSE_FILE) down
 
 local-logs:
 	docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) logs
 
+# Launches lumigator in 'user-local' mode (All services running locally, using latest docker container, no code mounted in)
 start-lumigator: 
 	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d
 
+# Launches lumigator with no code mounted in, and forces build of containers (used in CI for integration tests)
 start-lumigator-build:
 	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d --build
 
+# Launches lumigator without external dependencies (ray, S3)
 start-lumigator-external-ray: 
-	docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) --profile external up -d
+	docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) -f ${EXTERNAL_DOCKER_COMPOSE_FILE} up -d
 
 stop-lumigator:
 	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) down

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: local-up local-down local-logs clean-docker-buildcache clean-docker-images clean-docker-containers start-lumigator-external-ray start-lumigator stop-lumigator
+.PHONY: local-up local-down local-logs clean-docker-buildcache clean-docker-images clean-docker-containers start-lumigator-external-services start-lumigator stop-lumigator
 
 SHELL:=/bin/bash
 UNAME:= $(shell uname -o)
@@ -33,8 +33,8 @@ start-lumigator:
 start-lumigator-build:
 	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d --build
 
-# Launches lumigator without external dependencies (ray, S3)
-start-lumigator-external-ray: 
+# Launches lumigator without local dependencies (ray, S3)
+start-lumigator-external-services: 
 	docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) -f ${EXTERNAL_DOCKER_COMPOSE_FILE} up -d
 
 stop-lumigator:

--- a/README.md
+++ b/README.md
@@ -96,18 +96,10 @@ You can build the local project `docker-compose` on Mac or Linux,  or into a dis
 2. `make start-lumigator`
 3. The REST API should be available at http://localhost:8000. (If you need to change the port, you can do it in the[`docker-compose`](docker-compose) )
 
-## Running Lumigator with an external Ray cluster
-To run Lumigator with an external Ray cluster you need to ensure the following variables are configured properly in the [`docker-compose`](docker-compose) file before you start Lumigator:
-- `AWS_ACCESS_KEY_ID`
-- `AWS_SECRET_ACCESS_KEY`
-- `AWS_DEFAULT_REGION`
-- `RAY_DASHBOARD_PORT`
-- `RAY_HEAD_NODE_HOST`
+## Running Lumigator with an external services (Ray, S3)
+To run Lumigator with an external services you, fill in the required values in the `docker-compose.external.yaml` file. Once that's done, you can start Lumigator with:
 
-
-Once that's done, you can start Lumigator with:
-
-`make start-lumigator-external-ray`
+`make start-lumigator-external-services`
 
 ## Local Development Setup (either Mac or Linux)
 1. `git clone git@github.com:mozilla-ai/lumigator.git`

--- a/docker-compose.external.yaml
+++ b/docker-compose.external.yaml
@@ -1,0 +1,14 @@
+name: lumigator
+
+services:
+
+  backend:
+    environment:
+      - S3_ENDPOINT_URL=fill-in
+      - AWS_ACCESS_KEY_ID=fill-in
+      - AWS_SECRET_ACCESS_KEY=fill-in
+      - AWS_DEFAULT_REGION=fill-in
+      - AWS_ENDPOINT_URL=fill-in
+      - S3_BUCKET=fill-in
+      - RAY_DASHBOARD_PORT=8265
+      - RAY_HEAD_NODE_HOST=fill-in

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,8 @@ services:
       - SNAPSHOT_SAVE_STRATEGY=ON_REQUEST
     volumes:
       - localstack-data:/var/lib/localstack
+    profiles:
+      - local
 
   localstack-create-bucket:
     image: localstack/localstack:3.4.0
@@ -29,6 +31,8 @@ services:
        bash -c "awslocal s3 mb s3://lumigator-storage"
     extra_hosts:
       - "localhost:host-gateway"
+    profiles:
+      - local
 
   ray:
     image: rayproject/ray:2.30.0-py311-cpu${RAY_ARCH_SUFFIX}
@@ -64,7 +68,6 @@ services:
       - AWS_DEFAULT_REGION=us-east-2
       - AWS_ENDPOINT_URL=http://localhost:4566
 
-
     # NOTE: to keep AWS_ENDPOINT_URL as http://localhost:4566 both on the host system
     #       and inside containers, we map localhost to the host gateway IP.
     #       This currently works properly, but might be the cause of networking
@@ -73,7 +76,7 @@ services:
     extra_hosts:
       - "localhost:host-gateway"
     profiles: 
-      - !external
+      - local
 
   backend:
     image: mzdotai/lumigator:latest
@@ -82,7 +85,12 @@ services:
       dockerfile: "Dockerfile"
     platform: linux/amd64
     depends_on:
-      - localstack
+      localstack:
+        condition: "service_started"
+        required: false
+      ray:
+        condition: "service_started"
+        required: false
     ports:
       - 8000:8000
     environment:


### PR DESCRIPTION
## What's changing
This adds a new `docker-compose.external.yaml` file which a user would fill in with values to connect with their external `s3` and `ray` services.

**Note:** When using an external Ray cluster, a user _must_ use an external object store as well (So both the lumigator backend and Ray can see datasets, etc)

## How to test it
Fill in values needed in `docker-compose.external.yaml` then run 

## Additional notes for reviewers

## I already...

- [ ] added some tests for any new functionality;
- [ ] updated the documentation.