### PR TITLE
test: avoid bad not found messages

### DIFF
--- a/lumigator/python/mzai/backend/backend/tests/api/routes/test_api_workflows.py
+++ b/lumigator/python/mzai/backend/backend/tests/api/routes/test_api_workflows.py
@@ -43,3 +43,17 @@ def test_upload_data_launch_job(local_client: TestClient, dialog_dataset):
     create_experiment_response = local_client.post("/jobs/evaluate", headers=headers, json=payload
     )
     assert create_experiment_response.status_code == 201
+
+
+def test_experiment_non_existing(local_client: TestClient):
+    non_existing_id = "71aaf905-4bea-4d19-ad06-214202165812"
+    response = local_client.get(f"/experiments/{non_existing_id}")
+    assert response.status_code == 404
+    assert response.json()["detail"] == f"Job {non_existing_id} not found."
+
+
+def test_job_non_existing(local_client: TestClient):
+    non_existing_id = "71aaf905-4bea-4d19-ad06-214202165812"
+    response = local_client.get(f"/jobs/{non_existing_id}")
+    assert response.status_code == 404
+    assert response.json()["detail"] == f"Job {non_existing_id} not found."


### PR DESCRIPTION
## What's changing
For a while we had a broken error message for non-existing experiment ids (see LUMI-125). This has gone away, but having a regression test won't hurt.

## How to test it
The usual `make test`.

Manually, by using a get on /experiments or /jobs with a made up id.

## Additional notes for reviewers
In the process of checking whether this was still a problem, I noticed we have /experiments/inference, evaluation. It's temporary, I know, and I think these 2 mini tests will still hold when experiments changes.

## I already...

- [x] added some tests for any new functionality;
- [ ] updated the documentation.