### PR TITLE
API: `health/jobs` related endpoints - correctly handle 404s etc

### DIFF
--- a/lumigator/python/mzai/backend/backend/api/routes/health.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/health.py
@@ -1,8 +1,10 @@
 import json
+from http import HTTPStatus
 from uuid import UUID
 
+import loguru
 import requests
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from schemas.extras import HealthResponse
 from schemas.jobs import JobSubmissionResponse
 
@@ -19,31 +21,53 @@ def get_health() -> HealthResponse:
 @router.get("/jobs/{job_id}")
 def get_job_metadata(job_id: UUID) -> JobSubmissionResponse:
     resp = requests.get(f"{settings.RAY_DASHBOARD_URL}/api/jobs/{job_id}")
-    if resp.status_code == 200:
-        try:
-            metadata = json.loads(resp.text)
-            return JobSubmissionResponse(**metadata)
-        except json.JSONDecodeError as e:
-            print(f"JSON decode error: {e}")
-            print(f"Response text: {resp.text}")
-            return {"error": "Invalid JSON response"}
-    else:
-        return {"error": f"HTTP error {resp.status_code}"}
 
+    if resp.status_code == HTTPStatus.NOT_FOUND:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail=f"Job metadata for ID: {job_id} not found",
+        )
+    elif resp.status_code != HTTPStatus.OK:
+        loguru.logger.error(f"Unexpected status code getting job metadata text: {resp.status_code}")
+        loguru.logger.error(f"Upstream job metadata response: {resp}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail=f"Unexpected error getting job metadata for ID: {job_id}",
+        )
+
+    try:
+        metadata = json.loads(resp.text)
+        return JobSubmissionResponse(**metadata)
+    except json.JSONDecodeError as e:
+        loguru.logger.error(f"JSON decode error: {e}")
+        loguru.logger.error(f"Response text: {resp.text}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Invalid JSON response"
+        ) from e
 
 @router.get("/jobs/")
 def get_all_jobs() -> list[JobSubmissionResponse]:
     resp = requests.get(f"{settings.RAY_DASHBOARD_URL}/api/jobs/")
-    if resp.status_code == 200:
-        try:
-            metadata = json.loads(resp.text)
-            submissions: list[JobSubmissionResponse] = [
-                JobSubmissionResponse(**item) for item in metadata
-            ]
-            return submissions
-        except json.JSONDecodeError as e:
-            print(f"JSON decode error: {e}")
-            print(f"Response text: {resp.text}")
-            return {"error": "Invalid JSON response"}
-    else:
-        return {"error": f"HTTP error {resp.status_code}"}
+
+    if resp.status_code != HTTPStatus.OK:
+        loguru.logger.error(f"Unexpected status code getting jobs: {resp.status_code}")
+        loguru.logger.error(f"Upstream jobs response: {resp}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Unexpected error getting jobs",
+        )
+
+    try:
+        metadata = json.loads(resp.text)
+        submissions: list[JobSubmissionResponse] = [
+            JobSubmissionResponse(**item) for item in metadata
+        ]
+        return submissions
+    except json.JSONDecodeError as e:
+        loguru.logger.error(f"JSON decode error: {e}")
+        loguru.logger.error(f"Response text: {resp.text}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Invalid JSON response"
+        ) from e


### PR DESCRIPTION
## What's changing

`200` OK and an empty JSON object were returned when querying the current health job metadata endpoint under  `health/jobs/{job_id}`. 

This PR improves the way the response from upstream is handled, now returning a `404` NOT FOUND when it's not found.

**TODO**: Add unit tests with mocks

## How to test it

Where ID `3fa85f64-5717-4562-b3fc-2c963f66afa6` does not exist:

```
curl -v http://localhost:8000/api/v1/health/jobs/3fa85f64-5717-4562-b3fc-2c963f66afa6 \
  -H 'accept: application/json' | jq
```

Returns:

```
HTTP/1.1 404 Not Found
```

and JSON response body:

```json
{
  "detail": "Job metadata for ID: 3fa85f64-5717-4562-b3fc-2c963f66afa6 not found"
}
```

## Additional notes for reviewers

## I already...

- [ ] added some tests for any new functionality;
- [ ] updated the documentation.