### PR TITLE
Adding job logs support to health endpoint [LUMI-211]

### DIFF
--- a/lumigator/python/mzai/backend/backend/api/routes/health.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/health.py
@@ -1,5 +1,5 @@
 import json
-import urllib
+from urllib.parse import urljoin
 from http import HTTPStatus
 from uuid import UUID
 
@@ -21,18 +21,16 @@ def get_health() -> HealthResponse:
 
 @router.get("/jobs/{job_id}")
 def get_job_metadata(job_id: UUID) -> JobSubmissionResponse:
-    resp = requests.get(urllib.parse.urljoin(settings.RAY_JOBS_URL, f"{job_id}"))
+    resp = requests.get(urljoin(settings.RAY_JOBS_URL, f"{job_id}"))
 
     if resp.status_code == HTTPStatus.NOT_FOUND:
-        loguru.logger.error(f"Unexpected status code getting job metadata text: {resp.status_code}")
-        loguru.logger.error(f"Upstream job metadata response: {resp.text or ''}")
+        loguru.logger.error(f"Upstream job metadata not found ({resp.status_code}), error:  {resp.text or ''}")
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND,
             detail=f"Job metadata for ID: {job_id} not found",
         )
     elif resp.status_code != HTTPStatus.OK:
-        loguru.logger.error(f"Unexpected status code getting job metadata text: {resp.status_code}")
-        loguru.logger.error(f"Upstream job metadata response: {resp.text or ''}")
+        loguru.logger.error(f"Unexpected status code getting job metadata text: {resp.status_code}, error: {resp.text or ''}")
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             detail=f"Unexpected error getting job metadata for ID: {job_id}",
@@ -51,18 +49,16 @@ def get_job_metadata(job_id: UUID) -> JobSubmissionResponse:
 
 @router.get("/jobs/{job_id}/logs")
 def get_job_logs(job_id: UUID) -> JobLogsResponse:
-    resp = requests.get(urllib.parse.urljoin(settings.RAY_JOBS_URL, f"{job_id}/logs"))
+    resp = requests.get(urljoin(settings.RAY_JOBS_URL, f"{job_id}/logs"))
 
     if resp.status_code == HTTPStatus.NOT_FOUND:
-        loguru.logger.error(f"Unexpected status code getting job logs: {resp.status_code}")
-        loguru.logger.error(f"Upstream job logs response: {resp.text or ''}")
+        loguru.logger.error(f"Upstream job logs not found: {resp.status_code}, error: {resp.text or ''}")
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND,
             detail=f"Job logs for ID: {job_id} not found",
         )
     elif resp.status_code != HTTPStatus.OK:
-        loguru.logger.error(f"Unexpected status code getting job logs: {resp.status_code}")
-        loguru.logger.error(f"Upstream job logs response: {resp}")
+        loguru.logger.error(f"Unexpected status code getting job logs: {resp.status_code}, error: {resp.text or ''}")
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             detail=f"Unexpected error getting job logs for ID: {job_id} - {resp.text or ''}",
@@ -83,8 +79,7 @@ def get_job_logs(job_id: UUID) -> JobLogsResponse:
 def get_all_jobs() -> list[JobSubmissionResponse]:
     resp = requests.get(settings.RAY_JOBS_URL)
     if resp.status_code != HTTPStatus.OK:
-        loguru.logger.error(f"Unexpected status code getting all jobs: {resp.status_code}")
-        loguru.logger.error(f"Upstream get all jobs response: {resp}")
+        loguru.logger.error(f"Unexpected status code getting all jobs: {resp.status_code}, error: {resp.text or ''}")
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             detail=f"Unexpected error getting job logs - {resp.text or ''}",

--- a/lumigator/python/mzai/backend/backend/api/routes/health.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/health.py
@@ -1,9 +1,7 @@
 import json
+import urllib
 from http import HTTPStatus
 from uuid import UUID
-from typing import Annotated
-
-import loguru
 
 import loguru
 import requests
@@ -15,9 +13,6 @@ from backend.settings import settings
 
 router = APIRouter()
 
-def ray_jobs() -> str:
-    return f"{settings.RAY_DASHBOARD_URL}/api/jobs/"
-
 @router.get("/")
 def get_health() -> HealthResponse:
     return HealthResponse(deployment_type=settings.DEPLOYMENT_TYPE, status="OK")
@@ -25,19 +20,19 @@ def get_health() -> HealthResponse:
 
 @router.get("/jobs/{job_id}")
 def get_job_metadata(job_id: UUID) -> JobSubmissionResponse:
-    resp = requests.get(ray_jobs() + f"{job_id}")
+    resp = requests.get(urllib.parse.urljoin(settings.ray_jobs, f"{job_id}"))
 
     if resp.status_code == HTTPStatus.NOT_FOUND:
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND,
-            detail=f"Job metadata for ID: {job_id} not found",
+            detail=f"Job metadata for ID: {job_id} not found - {resp.text or ''}",
         )
     elif resp.status_code != HTTPStatus.OK:
         loguru.logger.error(f"Unexpected status code getting job metadata text: {resp.status_code}")
         loguru.logger.error(f"Upstream job metadata response: {resp}")
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            detail=f"Unexpected error getting job metadata for ID: {job_id}",
+            detail=f"Unexpected error getting job metadata for ID: {job_id} - {resp.text or ''}",
         )
 
     try:
@@ -53,32 +48,58 @@ def get_job_metadata(job_id: UUID) -> JobSubmissionResponse:
 
 @router.get("/jobs/{job_id}/logs")
 def get_job_logs(job_id: UUID) -> JobLogsResponse:
-    resp = requests.get(ray_jobs() + f"{job_id}/logs")
-    if resp.status_code == 200:
-        try:
-            metadata = json.loads(resp.text)
-            return JobLogsResponse(**metadata)
-        except json.JSONDecodeError as e:
-            print(f"JSON decode error: {e}")
-            print(f"Response text: {resp.text}")
-            return {"error": "Invalid JSON response"}
-    else:
-        return {"error": f"HTTP error {resp.status_code}"}
+    resp = requests.get(urllib.parse.urljoin(settings.ray_jobs, f"{job_id}/logs"))
+
+    if resp.status_code == HTTPStatus.NOT_FOUND:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail=f"Job logs for ID: {job_id} not found - {resp.text or ''}",
+        )
+    elif resp.status_code == HTTPStatus.BAD_REQUEST:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=f"Job ID: {job_id} not submitted via the Ray API - {resp.text or ''}",
+        )
+    elif resp.status_code != HTTPStatus.OK:
+        loguru.logger.error(f"Unexpected status code getting job logs text: {resp.status_code}")
+        loguru.logger.error(f"Upstream job metadata response: {resp}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail=f"Unexpected error getting job logs for ID: {job_id} - {resp.text or ''}",
+        )
+
+    try:
+        metadata = json.loads(resp.text)
+        return JobLogsResponse(**metadata)
+    except json.JSONDecodeError as e:
+        loguru.logger.error(f"JSON decode error: {e}")
+        loguru.logger.error(f"Response text: {resp.text}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Invalid JSON response"
+        ) from e
 
 
 @router.get("/jobs/")
 def get_all_jobs() -> list[JobSubmissionResponse]:
-    resp = requests.get(ray_jobs())
-    if resp.status_code == 200:
-        try:
-            metadata = json.loads(resp.text)
-            submissions: list[JobSubmissionResponse] = [
-                JobSubmissionResponse(**item) for item in metadata
-            ]
-            return submissions
-        except json.JSONDecodeError as e:
-            print(f"JSON decode error: {e}")
-            print(f"Response text: {resp.text}")
-            return {"error": "Invalid JSON response"}
-    else:
-        return {"error": f"HTTP error {resp.status_code}"}
+    resp = requests.get(settings.ray_jobs)
+    if resp.status_code != HTTPStatus.OK:
+        loguru.logger.error(f"Unexpected status code getting job logs text: {resp.status_code}")
+        loguru.logger.error(f"Upstream job metadata response: {resp}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail=f"Unexpected error getting job logs - {resp.text or ''}",
+        )
+    try:
+        metadata = json.loads(resp.text)
+        submissions: list[JobSubmissionResponse] = [
+            JobSubmissionResponse(**item) for item in metadata
+        ]
+        return submissions
+    except json.JSONDecodeError as e:
+        loguru.logger.error(f"JSON decode error: {e}")
+        loguru.logger.error(f"Response text: {resp.text}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Invalid JSON response"
+        ) from e

--- a/lumigator/python/mzai/backend/backend/api/routes/health.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/health.py
@@ -7,7 +7,7 @@ import loguru
 import requests
 from fastapi import APIRouter, HTTPException
 from lumigator_schemas.extras import HealthResponse
-from lumigator_schemas.jobs import JobSubmissionResponse
+from lumigator_schemas.jobs import JobSubmissionResponse, JobLogsResponse
 
 from backend.settings import settings
 
@@ -42,9 +42,9 @@ def get_job_metadata(job_id: UUID) -> JobSubmissionResponse:
         loguru.logger.error(f"JSON decode error: {e}")
         loguru.logger.error(f"Response text: {resp.text}")
         raise HTTPException(
-            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            detail="Invalid JSON response"
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Invalid JSON response"
         ) from e
+
 
 @router.get("/jobs/{job_id}/logs")
 def get_job_logs(job_id: UUID) -> JobLogsResponse:

--- a/lumigator/python/mzai/backend/backend/api/routes/health.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/health.py
@@ -7,11 +7,12 @@ import loguru
 import requests
 from fastapi import APIRouter, HTTPException
 from lumigator_schemas.extras import HealthResponse
-from lumigator_schemas.jobs import JobSubmissionResponse, JobLogsResponse
+from lumigator_schemas.jobs import JobLogsResponse, JobSubmissionResponse
 
 from backend.settings import settings
 
 router = APIRouter()
+
 
 @router.get("/")
 def get_health() -> HealthResponse:
@@ -75,8 +76,7 @@ def get_job_logs(job_id: UUID) -> JobLogsResponse:
         loguru.logger.error(f"JSON decode error: {e}")
         loguru.logger.error(f"Response text: {resp.text}")
         raise HTTPException(
-            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            detail="Invalid JSON response"
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Invalid JSON response"
         ) from e
 
 
@@ -100,6 +100,5 @@ def get_all_jobs() -> list[JobSubmissionResponse]:
         loguru.logger.error(f"JSON decode error: {e}")
         loguru.logger.error(f"Response text: {resp.text}")
         raise HTTPException(
-            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            detail="Invalid JSON response"
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Invalid JSON response"
         ) from e

--- a/lumigator/python/mzai/backend/backend/api/routes/health.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/health.py
@@ -1,6 +1,9 @@
 import json
 from http import HTTPStatus
 from uuid import UUID
+from typing import Annotated
+
+import loguru
 
 import loguru
 import requests
@@ -12,6 +15,8 @@ from backend.settings import settings
 
 router = APIRouter()
 
+def ray_jobs() -> str:
+    return f"{settings.RAY_DASHBOARD_URL}/api/jobs/"
 
 @router.get("/")
 def get_health() -> HealthResponse:
@@ -20,7 +25,7 @@ def get_health() -> HealthResponse:
 
 @router.get("/jobs/{job_id}")
 def get_job_metadata(job_id: UUID) -> JobSubmissionResponse:
-    resp = requests.get(f"{settings.RAY_DASHBOARD_URL}/api/jobs/{job_id}")
+    resp = requests.get(ray_jobs() + f"{job_id}")
 
     if resp.status_code == HTTPStatus.NOT_FOUND:
         raise HTTPException(
@@ -48,7 +53,7 @@ def get_job_metadata(job_id: UUID) -> JobSubmissionResponse:
 
 @router.get("/jobs/{job_id}/logs")
 def get_job_logs(job_id: UUID) -> JobLogsResponse:
-    resp = requests.get(f"{settings.RAY_DASHBOARD_URL}/api/jobs/{job_id}/logs")
+    resp = requests.get(ray_jobs() + f"{job_id}/logs")
     if resp.status_code == 200:
         try:
             metadata = json.loads(resp.text)
@@ -63,7 +68,7 @@ def get_job_logs(job_id: UUID) -> JobLogsResponse:
 
 @router.get("/jobs/")
 def get_all_jobs() -> list[JobSubmissionResponse]:
-    resp = requests.get(f"{settings.RAY_DASHBOARD_URL}/api/jobs/")
+    resp = requests.get(ray_jobs())
     if resp.status_code == 200:
         try:
             metadata = json.loads(resp.text)

--- a/lumigator/python/mzai/backend/backend/api/routes/health.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/health.py
@@ -1,6 +1,6 @@
 import json
-from urllib.parse import urljoin
 from http import HTTPStatus
+from urllib.parse import urljoin
 from uuid import UUID
 
 import loguru
@@ -24,13 +24,18 @@ def get_job_metadata(job_id: UUID) -> JobSubmissionResponse:
     resp = requests.get(urljoin(settings.RAY_JOBS_URL, f"{job_id}"))
 
     if resp.status_code == HTTPStatus.NOT_FOUND:
-        loguru.logger.error(f"Upstream job metadata not found ({resp.status_code}), error:  {resp.text or ''}")
+        loguru.logger.error(
+            f"Upstream job metadata not found ({resp.status_code}), error:  {resp.text or ''}"
+        )
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND,
             detail=f"Job metadata for ID: {job_id} not found",
         )
     elif resp.status_code != HTTPStatus.OK:
-        loguru.logger.error(f"Unexpected status code getting job metadata text: {resp.status_code}, error: {resp.text or ''}")
+        loguru.logger.error(
+            f"Unexpected status code getting job metadata text: "
+             "{resp.status_code}, error: {resp.text or ''}"
+        )
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             detail=f"Unexpected error getting job metadata for ID: {job_id}",
@@ -52,16 +57,20 @@ def get_job_logs(job_id: UUID) -> JobLogsResponse:
     resp = requests.get(urljoin(settings.RAY_JOBS_URL, f"{job_id}/logs"))
 
     if resp.status_code == HTTPStatus.NOT_FOUND:
-        loguru.logger.error(f"Upstream job logs not found: {resp.status_code}, error: {resp.text or ''}")
+        loguru.logger.error(
+            f"Upstream job logs not found: {resp.status_code}, error: {resp.text or ''}"
+        )
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND,
             detail=f"Job logs for ID: {job_id} not found",
         )
     elif resp.status_code != HTTPStatus.OK:
-        loguru.logger.error(f"Unexpected status code getting job logs: {resp.status_code}, error: {resp.text or ''}")
+        loguru.logger.error(
+            f"Unexpected status code getting job logs: {resp.status_code}, error: {resp.text or ''}"
+        )
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            detail=f"Unexpected error getting job logs for ID: {job_id} - {resp.text or ''}",
+            detail=f"Unexpected error getting job logs for ID: {job_id}",
         )
 
     try:
@@ -79,10 +88,12 @@ def get_job_logs(job_id: UUID) -> JobLogsResponse:
 def get_all_jobs() -> list[JobSubmissionResponse]:
     resp = requests.get(settings.RAY_JOBS_URL)
     if resp.status_code != HTTPStatus.OK:
-        loguru.logger.error(f"Unexpected status code getting all jobs: {resp.status_code}, error: {resp.text or ''}")
+        loguru.logger.error(
+            f"Unexpected status code getting all jobs: {resp.status_code}, error: {resp.text or ''}"
+        )
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            detail=f"Unexpected error getting job logs - {resp.text or ''}",
+            detail="Unexpected error getting job logs",
         )
     try:
         metadata = json.loads(resp.text)

--- a/lumigator/python/mzai/backend/backend/api/routes/health.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/health.py
@@ -46,6 +46,21 @@ def get_job_metadata(job_id: UUID) -> JobSubmissionResponse:
             detail="Invalid JSON response"
         ) from e
 
+@router.get("/jobs/{job_id}/logs")
+def get_job_logs(job_id: UUID) -> JobLogsResponse:
+    resp = requests.get(f"{settings.RAY_DASHBOARD_URL}/api/jobs/{job_id}/logs")
+    if resp.status_code == 200:
+        try:
+            metadata = json.loads(resp.text)
+            return JobLogsResponse(**metadata)
+        except json.JSONDecodeError as e:
+            print(f"JSON decode error: {e}")
+            print(f"Response text: {resp.text}")
+            return {"error": "Invalid JSON response"}
+    else:
+        return {"error": f"HTTP error {resp.status_code}"}
+
+
 @router.get("/jobs/")
 def get_all_jobs() -> list[JobSubmissionResponse]:
     resp = requests.get(f"{settings.RAY_DASHBOARD_URL}/api/jobs/")

--- a/lumigator/python/mzai/backend/backend/settings.py
+++ b/lumigator/python/mzai/backend/backend/settings.py
@@ -108,7 +108,7 @@ class BackendSettings(BaseSettings):
     # URL for Ray jobs API
     @computed_field
     @property
-    def ray_jobs(self) -> str:  # noqa: N802
+    def RAY_JOBS_URL(self) -> str:  # noqa: N802
         return f"{self.RAY_DASHBOARD_URL}/api/jobs/"
 
     # URL for the DB used by Alchemy, please refer to

--- a/lumigator/python/mzai/backend/backend/settings.py
+++ b/lumigator/python/mzai/backend/backend/settings.py
@@ -99,11 +99,20 @@ class BackendSettings(BaseSettings):
     def RAY_WORKER_GPUS_FRACTION(self) -> float:  # noqa: N802
         return float(os.environ.get(self.RAY_WORKER_GPUS_FRACTION_ENV_VAR, 1.0))
 
+    # URL for the Ray Dashboard
     @computed_field
     @property
     def RAY_DASHBOARD_URL(self) -> str:  # noqa: N802
         return f"http://{self.RAY_HEAD_NODE_HOST}:{self.RAY_DASHBOARD_PORT}"
 
+    # URL for Ray jobs API
+    @computed_field
+    @property
+    def ray_jobs(self) -> str:  # noqa: N802
+        return f"{self.RAY_DASHBOARD_URL}/api/jobs/"
+
+    # URL for the DB used by Alchemy, please refer to
+    # https://docs.sqlalchemy.org/en/20/core/engines.html#backend-specific-urls
     @computed_field
     @property
     def SQLALCHEMY_DATABASE_URL(self) -> URL:  # noqa: N802

--- a/lumigator/python/mzai/backend/backend/tests/api/routes/test_datasets.py
+++ b/lumigator/python/mzai/backend/backend/tests/api/routes/test_datasets.py
@@ -1,5 +1,3 @@
-import csv
-import io
 import uuid
 from unittest.mock import patch
 from urllib.parse import urlparse
@@ -10,50 +8,6 @@ from fastapi.testclient import TestClient
 from lumigator_schemas.datasets import DatasetDownloadResponse, DatasetFormat, DatasetResponse
 
 from backend.api.http_headers import HttpHeaders
-
-
-def format_dataset(data: list[list[str]]) -> str:
-    """Format a list of tabular data as a CSV string."""
-    buffer = io.StringIO()
-    csv.writer(buffer).writerows(data)
-    buffer.seek(0)
-    return buffer.read()
-
-
-@pytest.fixture
-def valid_experiment_dataset() -> str:
-    data = [
-        ["examples", "ground_truth"],
-        ["Hello World", "Hello"],
-    ]
-    return format_dataset(data)
-
-
-@pytest.fixture
-def valid_experiment_dataset_without_gt() -> str:
-    data = [
-        ["examples"],
-        ["Hello World"],
-    ]
-    return format_dataset(data)
-
-
-@pytest.fixture
-def missing_examples_dataset() -> str:
-    data = [
-        ["ground_truth"],
-        ["Hello"],
-    ]
-    return format_dataset(data)
-
-
-@pytest.fixture
-def extra_column_dataset() -> str:
-    data = [
-        ["examples", "ground_truth", "extra"],
-        ["Hello World", "Hello", "Nope"],
-    ]
-    return format_dataset(data)
 
 
 def test_upload_delete(app_client: TestClient, valid_experiment_dataset: str):

--- a/lumigator/python/mzai/backend/backend/tests/api/routes/test_datasets.py
+++ b/lumigator/python/mzai/backend/backend/tests/api/routes/test_datasets.py
@@ -44,8 +44,9 @@ def test_upload_delete(app_client: TestClient, valid_experiment_dataset: str):
 def test_dataset_delete_error(app_client: TestClient):
     dataset_id = uuid.uuid4()
     with patch(
-            "backend.services.datasets.DatasetService.delete_dataset",
-            side_effect=Exception("argh I am exceptional")):
+        "backend.services.datasets.DatasetService.delete_dataset",
+        side_effect=Exception("argh I am exceptional"),
+    ):
         resp = app_client.delete(f"/datasets/{dataset_id}")
         assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         data = resp.json()

--- a/lumigator/python/mzai/backend/backend/tests/api/routes/test_health.py
+++ b/lumigator/python/mzai/backend/backend/tests/api/routes/test_health.py
@@ -27,7 +27,7 @@ def test_get_job_metadata_not_found(
 ):
     job_id = "42e146e3-10eb-4a55-8018-218829c4752d"
     request_mock.get(
-        url=urllib.parse.urljoin(f"{settings.ray_jobs}", f"{job_id}"),
+        url=urllib.parse.urljoin(f"{settings.RAY_JOBS_URL}", f"{job_id}"),
         status_code=status.HTTP_404_NOT_FOUND,
         text="Not Found",
     )
@@ -35,7 +35,7 @@ def test_get_job_metadata_not_found(
     assert response is not None
     assert response.status_code == status.HTTP_404_NOT_FOUND
     data = response.json()
-    assert data["detail"] == f"Job metadata for ID: {job_id} not found - Not Found"
+    assert data["detail"] == f"Job metadata for ID: {job_id} not found"
 
 
 def test_get_job_metadata_not_ok(
@@ -44,14 +44,14 @@ def test_get_job_metadata_not_ok(
 ):
     job_id = "22e146e3-10eb-4a55-8018-218829c4752a"
     request_mock.get(
-        url=urllib.parse.urljoin(f"{settings.ray_jobs}", f"{job_id}"),
+        url=urllib.parse.urljoin(f"{settings.RAY_JOBS_URL}", f"{job_id}"),
         status_code=status.HTTP_409_CONFLICT,
     )
     response = app_client.get(f"/health/jobs/{job_id}")
     assert response is not None
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     data = response.json()
-    assert data["detail"] == f"Unexpected error getting job metadata for ID: {job_id} - "
+    assert data["detail"] == f"Unexpected error getting job metadata for ID: {job_id}"
 
 
 def test_get_job_metadata_ok(
@@ -62,7 +62,7 @@ def test_get_job_metadata_ok(
 ):
     job_id = "e899341d-bada-4f3c-ae32-b87bf730f897"
     request_mock.get(
-        url=urllib.parse.urljoin(f"{settings.ray_jobs}", f"{job_id}"),
+        url=urllib.parse.urljoin(f"{settings.RAY_JOBS_URL}", f"{job_id}"),
         status_code=status.HTTP_200_OK,
         text=json.dumps(load_json(json_data_health_job_metadata_ray)),
     )
@@ -84,7 +84,7 @@ def test_job_logs(
     logs_content = f'{{"logs": "{log}"}}'
 
     request_mock.get(
-        url=urllib.parse.urljoin(f"{settings.ray_jobs}", f"{job_id}/logs"),
+        url=urllib.parse.urljoin(f"{settings.RAY_JOBS_URL}", f"{job_id}/logs"),
         status_code=status.HTTP_200_OK,
         text=logs_content,
     )

--- a/lumigator/python/mzai/backend/backend/tests/api/routes/test_health.py
+++ b/lumigator/python/mzai/backend/backend/tests/api/routes/test_health.py
@@ -1,9 +1,7 @@
-import csv
-import io
 import json
 from pathlib import Path
+import urllib
 
-import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 from lumigator_schemas.extras import HealthResponse
@@ -15,16 +13,21 @@ def load_json(path: Path) -> str:
     with Path.open(path) as file:
         return json.load(file)
 
+
 def test_health_check(app_client: TestClient):
     response = app_client.get("/health")
     assert response.status_code == status.HTTP_200_OK
     health = HealthResponse.model_validate(response.json())
     assert health.status == "OK"
 
-def test_get_job_metadata_not_found(app_client: TestClient, request_mock,):
+
+def test_get_job_metadata_not_found(
+    app_client: TestClient,
+    request_mock,
+):
     job_id = "42e146e3-10eb-4a55-8018-218829c4752d"
     request_mock.get(
-        url=f"{settings.RAY_DASHBOARD_URL}/api/jobs/{job_id}",
+        url=urllib.parse.urljoin(f"{settings.ray_jobs}", f"{job_id}"),
         status_code=status.HTTP_404_NOT_FOUND,
         text="Not Found",
     )
@@ -34,10 +37,14 @@ def test_get_job_metadata_not_found(app_client: TestClient, request_mock,):
     data = response.json()
     assert data["detail"] == f"Job metadata for ID: {job_id} not found - Not Found"
 
-def test_get_job_metadata_not_ok(app_client: TestClient, request_mock,):
+
+def test_get_job_metadata_not_ok(
+    app_client: TestClient,
+    request_mock,
+):
     job_id = "22e146e3-10eb-4a55-8018-218829c4752a"
     request_mock.get(
-        url=f"{settings.ray_jobs}{job_id}",
+        url=urllib.parse.urljoin(f"{settings.ray_jobs}", f"{job_id}"),
         status_code=status.HTTP_409_CONFLICT,
     )
     response = app_client.get(f"/health/jobs/{job_id}")
@@ -46,15 +53,18 @@ def test_get_job_metadata_not_ok(app_client: TestClient, request_mock,):
     data = response.json()
     assert data["detail"] == f"Unexpected error getting job metadata for ID: {job_id} - "
 
-def test_get_job_metadata_ok(app_client: TestClient,
-                             request_mock,
-                             json_data_health_job_metadata_ray,
-                             json_data_health_job_metadata_ok):
+
+def test_get_job_metadata_ok(
+    app_client: TestClient,
+    request_mock,
+    json_data_health_job_metadata_ray: Path,
+    json_data_health_job_metadata_ok: Path,
+):
     job_id = "e899341d-bada-4f3c-ae32-b87bf730f897"
     request_mock.get(
-        url=f"{settings.ray_jobs}{job_id}",
+        url=urllib.parse.urljoin(f"{settings.ray_jobs}", f"{job_id}"),
         status_code=status.HTTP_200_OK,
-        text = json.dumps(load_json(json_data_health_job_metadata_ray))
+        text=json.dumps(load_json(json_data_health_job_metadata_ray)),
     )
     response = app_client.get(f"/health/jobs/{job_id}")
     assert response is not None
@@ -64,57 +74,21 @@ def test_get_job_metadata_ok(app_client: TestClient,
     expected = load_json(json_data_health_job_metadata_ok)
     assert expected == actual
 
-def test_get_job_logs_ok(app_client: TestClient,
-                         request_mock,
-                         valid_experiment_dataset):
-    job_id = "e899341d-bada-4f3c-ae32-b87bf730f897"
+
+def test_job_logs(
+    app_client: TestClient,
+    request_mock,
+):
+    job_id = "d34dd34d-d34d-d34d-d34d-d34dd34dd34d"
+    log = "2024-11-13 02:00:08,889\\tINFO job_manager.py:530 -- Runtime env is setting up.\\n"
+    logs_content = f'{{"logs": "{log}"}}'
+
     request_mock.get(
-        url=f"{settings.ray_jobs}{job_id}/logs",
+        url=urllib.parse.urljoin(f"{settings.ray_jobs}", f"{job_id}/logs"),
         status_code=status.HTTP_200_OK,
-        text = '{"logs": ""}'
+        text=logs_content,
     )
-    logs_resp = app_client.get(f'/health/jobs/{job_id}/logs')
-    assert logs_resp is not None
-    assert logs_resp.status_code == status.HTTP_200_OK
-    assert (json.loads(logs_resp.text))["logs"] == ""
-
-def test_integration_job_logs(app_client: TestClient, valid_experiment_dataset: str):
-    upload_filename = "dataset.csv"
-    dataset_resp = app_client.post(
-        url="/datasets",
-        data={"format": (None, DatasetFormat.JOB.value)},
-        files={"dataset": (upload_filename, valid_experiment_dataset)},
-    )
-    assert dataset_resp.status_code == status.HTTP_201_CREATED
-    dataset = DatasetResponse.model_validate(dataset_resp.json())
-
-    eval_template = """{{
-        "name": "{job_name}/{job_id}",
-        "model": {{ "path": "{model_path}" }},
-        "dataset": {{ "path": "{dataset_path}" }},
-        "evaluation": {{
-            "metrics": ["meteor", "rouge"],
-            "use_pipeline": false,
-            "max_samples": {max_samples},
-            "return_input_data": true,
-            "return_predictions": true,
-            "storage_path": "{storage_path}"
-        }}
-    }}"""
-
-    job = JobCreate(
-        name="test-job-int-001",
-        model="hf://trl-internal-testing/tiny-random-LlamaForCausalLM",
-        dataset=dataset.id,
-        config_template=eval_template,
-        description="This is a test job",
-        max_samples=2,
-    )
-
-    job_response_resp = app_client.post("/jobs/evaluate/", data=job.model_dump_json())
-    assert job_response_resp.status_code == status.HTTP_201_CREATED
-    job_response = JobResponse.model_validate(job_response_resp.json())
-
-    logs_resp = app_client.get(f'/health/jobs/{job_response.id}/logs')
-    assert logs_resp.status_code == status.HTTP_200_OK
-    job_response = JobLogsResponse.model_validate(job_response_resp.json())
+    response = app_client.get(f"/health/jobs/{job_id}/logs")
+    assert response is not None
+    assert response.status_code == status.HTTP_200_OK
+    assert json.loads(logs_content)["logs"] == json.loads(f'"{log}"')

--- a/lumigator/python/mzai/backend/backend/tests/api/routes/test_health.py
+++ b/lumigator/python/mzai/backend/backend/tests/api/routes/test_health.py
@@ -1,6 +1,6 @@
 import json
-from pathlib import Path
 import urllib
+from pathlib import Path
 
 from fastapi import status
 from fastapi.testclient import TestClient

--- a/lumigator/python/mzai/backend/backend/tests/conftest.py
+++ b/lumigator/python/mzai/backend/backend/tests/conftest.py
@@ -2,8 +2,6 @@ import csv
 import io
 import os
 from pathlib import Path
-from s3fs import S3FileSystem
-
 
 import pytest
 import requests_mock
@@ -11,20 +9,20 @@ from botocore.exceptions import ClientError
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from mypy_boto3_s3 import S3Client
+from s3fs import S3FileSystem
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.orm import Session
 from testcontainers.localstack import LocalStackContainer
-from backend.repositories.jobs import JobRepository, JobResultRepository,BaseRepository
-from backend.repositories.datasets import DatasetRepository
-from backend.records.jobs import JobRecord, JobResultRecord
-from backend.services.jobs import JobService
 
 from backend.api.deps import get_db_session, get_s3_client
 from backend.api.router import API_V1_PREFIX
 from backend.main import create_app
+from backend.records.jobs import JobRecord, JobResultRecord
+from backend.repositories.datasets import DatasetRepository
+from backend.repositories.jobs import BaseRepository, JobRepository, JobResultRepository
 from backend.services.datasets import DatasetService
+from backend.services.jobs import JobService
 from backend.settings import settings
-
 from backend.tests.fakes.fake_ray_client import FakeJobSubmissionClient
 
 # TODO: Break tests into "unit" and "integration" folders based on fixture dependencies
@@ -40,6 +38,13 @@ def format_dataset(data: list[list[str]]) -> str:
     buffer.seek(0)
     return buffer.read()
 
+@pytest.fixture
+def valid_experiment_dataset() -> str:
+    data = [
+        ["examples", "ground_truth"],
+        ["Hello World", "Hello"],
+    ]
+    return format_dataset(data)
 
 @pytest.fixture(scope="session")
 def valid_experiment_dataset_without_gt() -> str:
@@ -197,7 +202,6 @@ def request_mock() -> requests_mock.Mocker:
     with requests_mock.Mocker() as cm:
         yield cm
 
-<<<<<<< HEAD
 @pytest.fixture(scope="function")
 def job_repository(db_session):
     return JobRepository(session=db_session)

--- a/lumigator/python/mzai/backend/backend/tests/conftest.py
+++ b/lumigator/python/mzai/backend/backend/tests/conftest.py
@@ -1,4 +1,5 @@
-import json
+import csv
+import io
 import os
 from pathlib import Path
 from s3fs import S3FileSystem
@@ -30,6 +31,42 @@ from backend.tests.fakes.fake_ray_client import FakeJobSubmissionClient
 
 def common_resources_dir() -> Path:
     return Path(__file__).parent.parent.parent.parent
+
+
+def format_dataset(data: list[list[str]]) -> str:
+    """Format a list of tabular data as a CSV string."""
+    buffer = io.StringIO()
+    csv.writer(buffer).writerows(data)
+    buffer.seek(0)
+    return buffer.read()
+
+
+@pytest.fixture(scope="session")
+def valid_experiment_dataset_without_gt() -> str:
+    data = [
+        ["examples"],
+        ["Hello World"],
+    ]
+    return format_dataset(data)
+
+
+@pytest.fixture(scope="session")
+def missing_examples_dataset() -> str:
+    data = [
+        ["ground_truth"],
+        ["Hello"],
+    ]
+    return format_dataset(data)
+
+
+@pytest.fixture(scope="session")
+def extra_column_dataset() -> str:
+    data = [
+        ["examples", "ground_truth", "extra"],
+        ["Hello World", "Hello", "Nope"],
+    ]
+    return format_dataset(data)
+
 
 @pytest.fixture(scope="function")
 def dialog_dataset():
@@ -160,6 +197,7 @@ def request_mock() -> requests_mock.Mocker:
     with requests_mock.Mocker() as cm:
         yield cm
 
+<<<<<<< HEAD
 @pytest.fixture(scope="function")
 def job_repository(db_session):
     return JobRepository(session=db_session)

--- a/lumigator/python/mzai/backend/backend/tests/fakes/fake_ray_client.py
+++ b/lumigator/python/mzai/backend/backend/tests/fakes/fake_ray_client.py
@@ -1,6 +1,5 @@
 class FakeJobSubmissionClient:
-    """
-    A mock implementation of Ray's JobSubmissionClient for testing purposes.
+    """A mock implementation of Ray's JobSubmissionClient for testing purposes.
     Simulates basic job submission and management functionality.
     """
     def __init__(self):

--- a/lumigator/python/mzai/backend/backend/tests/services/test_job_service.py
+++ b/lumigator/python/mzai/backend/backend/tests/services/test_job_service.py
@@ -1,9 +1,11 @@
 
-from backend.services.jobs import JobService
 from lumigator_schemas.jobs import (
     JobInferenceCreate,
-
 )
+
+from backend.services.jobs import JobService
+
+
 def test_set_null_inference_job_params(job_record,job_service ):
     request = JobInferenceCreate(name="test_run_hugging_face",
                                  description="Test run for Huggingface model",

--- a/lumigator/python/mzai/jobs/evaluator/evaluator/paths.py
+++ b/lumigator/python/mzai/jobs/evaluator/evaluator/paths.py
@@ -91,6 +91,7 @@ def validate_asset_path(path: str) -> "AssetPath":
 
 AssetPath = Annotated[str, AfterValidator(lambda x: validate_asset_path(x))]
 
+
 def format_file_path(path: str | Path) -> AssetPath:
     path = Path(path).absolute()
     return f"{PathPrefix.FILE.value}{path}"
@@ -109,11 +110,15 @@ def format_artifact_path(artifact: wandb.Artifact) -> AssetPath:
             "Make sure to log the artifact before calling this method."
         )
         raise ValueError(msg) from e
+
+
 def format_s3_path(bucket: str, key: str) -> AssetPath:
     return f"{PathPrefix.S3.value}{bucket}/{key}"
 
+
 def format_openai_model_path(model_name: str) -> AssetPath:
     return f"{PathPrefix.OPENAI.value}{model_name}"
+
 
 def format_mistral_model_path(model_name: str) -> AssetPath:
     return f"{PathPrefix.MISTRAL.value}{model_name}"

--- a/lumigator/python/mzai/jobs/evaluator/evaluator/paths.py
+++ b/lumigator/python/mzai/jobs/evaluator/evaluator/paths.py
@@ -61,7 +61,7 @@ def is_valid_llamafile_model_name(model_name: str) -> bool:
 
 def validate_asset_path(path: str) -> "AssetPath":
     raw_path = strip_path_prefix(path)
-    
+
     if path.startswith(PathPrefix.FILE):
         if not Path(raw_path).is_absolute():
             raise ValueError(f"'{raw_path}' is not an absolute file path.")

--- a/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
+++ b/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
@@ -32,6 +32,10 @@ class JobEvent(BaseModel):
     detail: str | None = None
 
 
+class JobLogsResponse(BaseModel):
+    logs: str | None = None
+
+
 class JobSubmissionResponse(BaseModel):
     type: str | None = None
     job_id: str | None = None


### PR DESCRIPTION
## What's changing

Added a new endpoint (`/health/jobs/{job_id}/logs`) which connects to the local [ray server API](https://docs.ray.io/en/latest/cluster/running-applications/job-submission/rest.html) (on `/api/jobs/{job_id}/logs`) to get logs given a job id.
This could be used to surface logs to a UI / SDK / generic client both at the end of the job and when it is running (by polling our API).

## How to test it

- start a job
- send a request to the `/health/jobs/{job_id}/logs` API endpoint (e.g. from the http://localhost:8000/docs# interface)

## Additional notes for reviewers

N/A

## I already...

- [x] added some tests for any new functionality
- [x] updated the documentation (some internal docstrings)
- [x] checked if a (backend) DB migration step was required and included it if required