### PR TITLE
chore: tear down containers launched after make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LOCAL_DOCKERCOMPOSE_FILE:= docker-compose.yaml
 DEV_DOCKER_COMPOSE_FILE:= .devcontainer/docker-compose.override.yaml
 
 # Launches Lumigator in 'development' mode (all services running locally, code mounted in)
-local-up: 
+local-up:
 	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose --profile local -f $(LOCAL_DOCKERCOMPOSE_FILE) -f ${DEV_DOCKER_COMPOSE_FILE} up -d --build
 	uv run pre-commit install
 
@@ -27,7 +27,7 @@ local-logs:
 	docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) logs
 
 # Launches lumigator in 'user-local' mode (All services running locally, using latest docker container, no code mounted in)
-start-lumigator: 
+start-lumigator:
 	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose --profile local -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d
 
 # Launches lumigator with no code mounted in, and forces build of containers (used in CI for integration tests)
@@ -35,7 +35,7 @@ start-lumigator-build:
 	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose --profile local -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d --build
 
 # Launches lumigator without local dependencies (ray, S3)
-start-lumigator-external-services: 
+start-lumigator-external-services:
 	docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) -f ${EXTERNAL_DOCKER_COMPOSE_FILE} up -d
 
 stop-lumigator:
@@ -58,3 +58,4 @@ test:
 	make start-lumigator-build
 	cd lumigator/python/mzai/backend; SQLALCHEMY_DATABASE_URL=sqlite:///local.db uv run pytest
 	cd lumigator/python/mzai/sdk; uv run pytest
+	make stop-lumigator

--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ uv add package
 Make sure to commit the updated uv.lock file
 
 **Run Test Suite Across all projects**
-
 ```
 make test
 ```


### PR DESCRIPTION
## What's changing
stop-lumigator is now called inside make test, to clean up.

## How to test it
Clean folder, clone, docker ps shows no (lumigator-related) running containers, make test, docker ps shows no running containers (lumigator-related) and no unrelated containers were stopped.

## Additional notes for reviewers
We could discuss tearing down only those started by make test, but hopefully this is already better than not tearing down lumigator containers after the test.

Pre-commit hooks also fixed some whitespaces in the Makefile.
 
## I already...

- [x] added some tests for any new functionality
- [ ] updated the documentation --> N/A
- [ ] checked if a (backend) DB migration step was required and included it if required --> N/A
