### PR TITLE
Datasets: deleting a dataset with a DB entry but no S3 file should be handled correctly

### DIFF
--- a/lumigator/python/mzai/backend/backend/api/routes/datasets.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/datasets.py
@@ -1,8 +1,8 @@
 from typing import Annotated
 from uuid import UUID
 
-import loguru
 from fastapi import APIRouter, Form, HTTPException, UploadFile, status
+from loguru import logger
 from schemas.datasets import DatasetDownloadResponse, DatasetFormat, DatasetResponse
 from schemas.extras import ListingResponse
 
@@ -30,7 +30,7 @@ def delete_dataset(service: DatasetServiceDep, dataset_id: UUID) -> None:
     try:
         service.delete_dataset(dataset_id)
     except Exception as e:
-        loguru.logger.error(f"Unexpected error deleting dataset ID from DB and S3: {dataset_id}. "
+        logger.error(f"Unexpected error deleting dataset ID from DB and S3: {dataset_id}. "
                             f"{e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/lumigator/python/mzai/backend/backend/api/routes/datasets.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/datasets.py
@@ -22,7 +22,15 @@ def upload_dataset(
 
 @router.get("/{dataset_id}")
 def get_dataset(service: DatasetServiceDep, dataset_id: UUID) -> DatasetResponse:
-    return service.get_dataset(dataset_id)
+    dataset = service.get_dataset(dataset_id)
+
+    if not dataset:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Dataset not found: {dataset_id}",
+        )
+
+    return dataset
 
 
 @router.delete("/{dataset_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/lumigator/python/mzai/backend/backend/api/routes/datasets.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/datasets.py
@@ -34,7 +34,7 @@ def delete_dataset(service: DatasetServiceDep, dataset_id: UUID) -> None:
                             f"{e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Unexpected error deleting data for ID: {dataset_id}",
+            detail=f"Unexpected error deleting dataset for ID: {dataset_id}",
         ) from e
 
 

--- a/lumigator/python/mzai/backend/backend/api/routes/datasets.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/datasets.py
@@ -23,11 +23,10 @@ def upload_dataset(
 @router.get("/{dataset_id}")
 def get_dataset(service: DatasetServiceDep, dataset_id: UUID) -> DatasetResponse:
     dataset = service.get_dataset(dataset_id)
-
     if not dataset:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Dataset not found: {dataset_id}",
+            detail=f"Dataset '{dataset_id}' not found.",
         )
 
     return dataset

--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -96,8 +96,11 @@ class DatasetService:
     def _raise_unhandled_exception(self, e: Exception) -> None:
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, str(e)) from e
 
-    def _get_dataset_record(self, dataset_id: UUID) -> DatasetRecord:
+    def _get_dataset_record(self, dataset_id: UUID) -> DatasetRecord | None:
         return self.dataset_repo.get(dataset_id)
+
+    def _get_s3_path(self, dataset_key: str) -> str:
+        return f"s3://{ Path(settings.S3_BUCKET) / dataset_key }"
 
     def _get_s3_key(self, dataset_id: UUID, filename: str) -> str:
         """Generate the S3 key for the dataset contents.
@@ -115,7 +118,7 @@ class DatasetService:
 
             # Upload to S3
             dataset_key = self._get_s3_key(record.id, record.filename)
-            dataset_path = f"s3://{ Path(settings.S3_BUCKET) / dataset_key }"
+            dataset_path = self._get_s3_path(dataset_key)
             dataset_hf.save_to_disk(dataset_path, fs=self.s3_filesystem)
         except Exception as e:
             # if a record was already created, delete it from the DB
@@ -160,10 +163,13 @@ class DatasetService:
 
         return DatasetResponse.model_validate(record)
 
-    def get_dataset_s3_path(self, dataset_id: UUID) -> str:
+    def get_dataset_s3_path(self, dataset_id: UUID) -> str | None:
         record = self._get_dataset_record(dataset_id)
+        if record is None:
+            return None
+
         dataset_key = self._get_s3_key(record.id, record.filename)
-        dataset_path = f"s3://{ Path(settings.S3_BUCKET) / dataset_key }"
+        dataset_path = self._get_s3_path(dataset_key)
         return dataset_path
 
     def delete_dataset(self, dataset_id: UUID) -> None:
@@ -184,7 +190,7 @@ class DatasetService:
             # S3 delete is called first, if this fails for any other reason that the file not being
             # found, then the DB delete won't take place, and an exception raised.
             dataset_key = self._get_s3_key(record.id, record.filename)
-            dataset_path = f"s3://{ Path(settings.S3_BUCKET) / dataset_key }"
+            dataset_path = self._get_s3_path(dataset_key)
             self.s3_filesystem.rm(dataset_path, recursive=True)
         except FileNotFoundError as e:
             # File not found errors are allowed, but we perform clean-up in this situation.

--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -188,7 +188,7 @@ class DatasetService:
             self.s3_filesystem.rm(dataset_path, recursive=True)
         except FileNotFoundError as e:
             # File not found errors are allowed, but we perform clean-up in this situation.
-            logger.error(f"Dataset ID: {dataset_id} was present in the DB but not found on S3... "
+            logger.warning(f"Dataset ID: {dataset_id} was present in the DB but not found on S3... "
                          f"Cleaning up DB by removing ID. {e}")
 
         # Getting this far means we are OK to remove the record from the DB.

--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -180,12 +180,13 @@ class DatasetService:
             dataset_key = self._get_s3_key(record.id, record.filename)
             dataset_path = f"s3://{ Path(settings.S3_BUCKET) / dataset_key }"
             self.s3_filesystem.rm(dataset_path, recursive=True)
-            self.dataset_repo.delete(record.id)
         except FileNotFoundError as e:
             # File not found errors are allowed, but we perform clean-up in this situation.
             logger.error(f"Dataset ID: {dataset_id} was present in the DB but not found on S3... "
                          f"Cleaning up DB by removing ID. {e}")
-            self.dataset_repo.delete(record.id)
+
+        # Getting this far means we are OK to remove the record from the DB.
+        self.dataset_repo.delete(record.id)
 
 
     def get_dataset_download(self, dataset_id: UUID) -> DatasetDownloadResponse:

--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -167,10 +167,13 @@ class DatasetService:
         return dataset_path
 
     def delete_dataset(self, dataset_id: UUID) -> None:
-        """When the dataset exists, attempts to delete it from an S3 bucket and the repository (DB).
+        """When the dataset exists, attempts to delete it from both an S3 bucket and the DB.
 
-        Raises exceptions it encounters dealing with S3, except when the file is not found in S3.
-        In this case it deletes the orphaned record from the DB.
+        Raises exceptions it encounters dealing with S3, except when the file is not found in S3
+        (in this case it deletes the orphaned record from the DB).
+
+        This operation is idempotent, calling it with a record that never existed, or that has
+        already been deleted, will not raise an error.
         """
         record = self._get_dataset_record(dataset_id)
         # Early return if the record does not exist (for idempotency).

--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -156,7 +156,7 @@ class DatasetService:
     def get_dataset(self, dataset_id: UUID) -> DatasetResponse | None:
         record = self._get_dataset_record(dataset_id)
         if record is None:
-            return
+            return None
 
         return DatasetResponse.model_validate(record)
 

--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -153,8 +153,11 @@ class DatasetService:
 
         return DatasetResponse.model_validate(record)
 
-    def get_dataset(self, dataset_id: UUID) -> DatasetResponse:
+    def get_dataset(self, dataset_id: UUID) -> DatasetResponse | None:
         record = self._get_dataset_record(dataset_id)
+        if record is None:
+            return
+
         return DatasetResponse.model_validate(record)
 
     def get_dataset_s3_path(self, dataset_id: UUID) -> str:

--- a/lumigator/python/mzai/backend/backend/tests/api/routes/test_datasets.py
+++ b/lumigator/python/mzai/backend/backend/tests/api/routes/test_datasets.py
@@ -1,7 +1,7 @@
 import csv
 import io
 import uuid
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 from urllib.parse import urlparse
 
 import pytest

--- a/lumigator/python/mzai/backend/backend/tests/conftest.py
+++ b/lumigator/python/mzai/backend/backend/tests/conftest.py
@@ -90,14 +90,14 @@ def s3_client(localstack_container: LocalStackContainer) -> S3Client:
 def app():
     """Create the FastAPI app bound to DB managed via Alembic.
 
-     Expects an environment variable of 'SQLALCHEMY_DATABASE_URL' to be configured.
-     Ideally this should be an absolute path:
+    Expects an environment variable of 'SQLALCHEMY_DATABASE_URL' to be configured.
+    Ideally this should be an absolute path:
 
-     e.g. sqlite:////Users/{me}/tmp/local_test.db
+    e.g. sqlite:////Users/{me}/tmp/local_test.db
 
-     If the environment variable is not specified, then a 'local.db' will be created in the
-     folder where the tests are executed.
-     """
+    If the environment variable is not specified, then a 'local.db' will be created in the
+    folder where the tests are executed.
+    """
     app = create_app()
     return app
 

--- a/lumigator/python/mzai/backend/backend/tests/services/test_dataset_service.py
+++ b/lumigator/python/mzai/backend/backend/tests/services/test_dataset_service.py
@@ -14,7 +14,7 @@ def test_delete_dataset_file_not_found(db_session, s3_client):
     assert dataset_record is not None
     assert dataset_record.filename == filename
     assert dataset_record.format == format
-    dataset_service = DatasetService(dataset_repo, s3_client, S3FileSystem()) # S3FileSystem)
+    dataset_service = DatasetService(dataset_repo, s3_client, S3FileSystem())
     dataset_service.delete_dataset(dataset_record.id)
     dataset_record = dataset_service._get_dataset_record(dataset_record.id)
     assert dataset_record is None

--- a/lumigator/python/mzai/backend/backend/tests/services/test_dataset_service.py
+++ b/lumigator/python/mzai/backend/backend/tests/services/test_dataset_service.py
@@ -1,0 +1,20 @@
+from s3fs import S3FileSystem
+
+from backend.repositories.datasets import DatasetRepository
+from backend.services.datasets import DatasetService
+
+
+def test_delete_dataset_file_not_found(db_session, s3_client):
+    filename = "juan"
+    format = "job"
+    dataset_repo = DatasetRepository(db_session)
+    dataset_record = dataset_repo.create(
+        filename=filename, format=format, size=123, ground_truth=True
+    )
+    assert dataset_record is not None
+    assert dataset_record.filename == filename
+    assert dataset_record.format == format
+    dataset_service = DatasetService(dataset_repo, s3_client, S3FileSystem()) # S3FileSystem)
+    dataset_service.delete_dataset(dataset_record.id)
+    dataset_record = dataset_service._get_dataset_record(dataset_record.id)
+    assert dataset_record is None

--- a/lumigator/python/mzai/backend/backend/tests/services/test_dataset_service.py
+++ b/lumigator/python/mzai/backend/backend/tests/services/test_dataset_service.py
@@ -5,7 +5,7 @@ from backend.services.datasets import DatasetService
 
 
 def test_delete_dataset_file_not_found(db_session, s3_client):
-    filename = "juan"
+    filename = "dataset.csv"
     format = "job"
     dataset_repo = DatasetRepository(db_session)
     dataset_record = dataset_repo.create(


### PR DESCRIPTION
## What's changing

When attempting to delete a dataset which encounters issues, we now do the following:

* If the dataset existed in the DB but the file wasn't found in S3, we remove it from the DB
* Any other errors in the service will raise an exception (non-HTTP)
* The route/controller handles any exceptions, logging them and returning a 500 to the caller (with a generic message)

## How to test it

## Additional notes for reviewers

## I already...

- [x] added some tests for any new functionality
- [x] updated the documentation
- [x] checked if a (backend) DB migration step was required and included it if required
