### PR TITLE
Added Github Action Check for Broken Links

### DIFF
--- a/.github/workflows/broken_links_checker.yaml
+++ b/.github/workflows/broken_links_checker.yaml
@@ -1,0 +1,18 @@
+name: Check for Broken Links
+
+on:
+    workflow_dispatch:
+    push:
+        branches:
+            - '*'
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Thanks https://github.com/marketplace/actions/lychee-broken-link-checker!
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2

--- a/.github/workflows/broken_links_checker.yaml
+++ b/.github/workflows/broken_links_checker.yaml
@@ -17,5 +17,5 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-            # regex to exclude mailing addresses and localhost
+            # Args here https://github.com/lycheeverse/lychee?tab=readme-ov-file#commandline-parameters
             args: --base . --verbose --no-progress './**/*.md' --exclude 'mailto:|localhost'

--- a/.github/workflows/broken_links_checker.yaml
+++ b/.github/workflows/broken_links_checker.yaml
@@ -16,3 +16,6 @@ jobs:
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v2
+        with:
+            # regex to exclude mailing addresses and localhost
+            args: --exclude 'mailto:|localhost'

--- a/.github/workflows/broken_links_checker.yaml
+++ b/.github/workflows/broken_links_checker.yaml
@@ -1,4 +1,4 @@
-name: Check for Broken Links
+name: Check for Broken Links in Markdown
 
 on:
     workflow_dispatch:
@@ -18,4 +18,4 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
             # regex to exclude mailing addresses and localhost
-            args: --exclude 'mailto:|localhost'
+            args: --base . --verbose --no-progress './**/*.md' --exclude 'mailto:|localhost'

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See [example notebook](/notebooks/walkthrough.ipynb) for a platform API walkthro
   + [Lumigator API](/lumigator/README.md)
   + Offline Evaluations with [lm-buddy](https://github.com/mozilla-ai/lm-buddy)
 + **Extending Lumigator:**
-  + [Creating a new Lumigator endpoint](lumigator/python/mzai/backend/api/README.md)
+  + [Creating a new Lumigator endpoint](lumigator/python/mzai/backend/backend/api/README.md)
 
 
 # Available Machine Learning Tasks

--- a/lumigator/python/mzai/backend/backend/api/README.md
+++ b/lumigator/python/mzai/backend/backend/api/README.md
@@ -18,18 +18,18 @@ The components inside Backend, shown in the image below, are the different abstr
 
 * The **API** makes backend functionalities available to the UI (or whatever front-end you want to develop) through
   different **routes** (code
-  [here](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/api/routes)).
+  [here](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/api/routes)).
   [**Schemas**](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/schemas) are used in the API
   which allows one to exactly know which kind of data has to be passed to it (similarly, using the same schemas will be
   a requirement for our SDK).
 
 * **Services** implement the actual functionalities and are called by the different methods exposed in the API (code
-  [here](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/services)).
+  [here](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/services)).
 
 * **Repositories** implement the [repository pattern](https://www.cosmicpython.com/book/chapter_02_repository.html) as
   an abstraction over the DB (code
-  [here](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/repositories)). They make use
-  of [record classes](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/records) to refer
+  [here](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/repositories)). They make use
+  of [record classes](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/records) to refer
   to actual records on the DB.
 
 <p style="text-align: center;">
@@ -46,7 +46,7 @@ of the repo `/lumigator/python/mzai/backend/api/routes/`.
 ## Understanding Lumigator endpoints
 
 All the endpoints you can access in Lumigator's API are defined in
-[`backend/api/routes/`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/api/routes)
+[`backend/api/routes/`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/api/routes)
 and explicitly listed in
 [`backend/api/router.py`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/api/router.py),
 together with a metadata tag (defined
@@ -178,12 +178,12 @@ standard code structure:
 
 |                        |                                                                                                                                                                                                                                           |
 |------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [`backend/api/routes`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/api/routes)   | The actual API endpoints one can hit (remember they need to be explicitly added to the [router.py](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/api/router.py) file before you can actually see them!) |
-| [`backend/services`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/services)     | The code that implements core functionalities for each route                                                                                                                                                                              |
-| [`backend/api/deps.py`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/api/deps.py)  | Used to inject dependencies for services                                                                                                                                                                                                  |
+| [`backend/api/routes`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/api/routes)   | The actual API endpoints one can hit (remember they need to be explicitly added to the [router.py](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/api/router.py) file before you can actually see them!) |
+| [`backend/services`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/services)     | The code that implements core functionalities for each route                                                                                                                                                                              |
+| [`backend/api/deps.py`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/api/deps.py)  | Used to inject dependencies for services                                                                                                                                                                                                  |
 | [`schemas`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/schemas)              | The schemas used by each route / service                                                                                                                                                                                                  |
-| [`backend/repositories`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/repositories) | Repositories used by each service                                                                                                                                                                                                         |
-| [`backend/records`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/records)      | Records used by each service                                                                                                                                                                                                              |
+| [`backend/repositories`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/repositories) | Repositories used by each service                                                                                                                                                                                                         |
+| [`backend/records`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/records)      | Records used by each service                                                                                                                                                                                                              |
 
 The general rule is that for most endpoints you'll end up with an identical filename for each of the above directories
 (see e.g. `datasets`, `experiments`, etc).
@@ -233,7 +233,7 @@ Being this the code for a new route, you will save it in `backend/api/routes/tas
 
 #### 1.2. Add the route to `router.py`with the appropriate tags
 
-The following step is adding the new route to [`backend/api/router.py`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/api/router.py). The code below shows the updated file with
+The following step is adding the new route to [`backend/api/router.py`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/api/router.py). The code below shows the updated file with
 comments next to the two lines marked below as **NEW**:
 
 ```
@@ -258,7 +258,7 @@ api_router.include_router(completions.router, prefix="/completions", tags=[Tags.
 api_router.include_router(tasks.router, prefix="/tasks", tags=[Tags.TASKS]) ### NEW
 ```
 
-Also note that we are specifying some `Tags.TASKS` which have not been defined yet! Open [`backend/api/tags.py`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/api/tags.py) and add
+Also note that we are specifying some `Tags.TASKS` which have not been defined yet! Open [`backend/api/tags.py`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/api/tags.py) and add
 the sections marked below as **NEW**:
 
 ```

--- a/lumigator/python/mzai/backend/backend/api/README.md
+++ b/lumigator/python/mzai/backend/backend/api/README.md
@@ -48,9 +48,9 @@ of the repo `/lumigator/python/mzai/backend/api/routes/`.
 All the endpoints you can access in Lumigator's API are defined in
 [`backend/api/routes/`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/api/routes)
 and explicitly listed in
-[`backend/api/router.py`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/api/router.py),
+[`backend/api/router.py`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/backend/api/router.py),
 together with a metadata tag (defined
-[here](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/api/tags.py)) which is used to
+[here](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/backend/api/tags.py)) which is used to
 provide a short description of the route:
 
 <p style="text-align: center;">
@@ -70,7 +70,7 @@ Description appearing in the API docs
 
 ### The simplest endpoint: /health
 
-The [`/health`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/api/routes/health.py) route provides
+The [`/health`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/backend/api/routes/health.py) route provides
 perhaps the simplest example as it allows you to get the current backend status which is a constant:
 
 ```
@@ -88,7 +88,7 @@ with the same name of the route, service, etc.
 
 Being this simple, all the code for `get_health()` directly appears in the route file. A `HealthResponse`, composed of a
 deployment type which is loaded from 
-[`backend/settings.py`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/settings.py) and the status (currently always ok), is returned. Nothing is ran, nothing is saved on DB or on storage.
+[`backend/settings.py`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/backend/settings.py) and the status (currently always ok), is returned. Nothing is ran, nothing is saved on DB or on storage.
 
 ### One step further: /datasets
 
@@ -102,7 +102,7 @@ def get_dataset(service: DatasetServiceDep, dataset_id: UUID) -> DatasetResponse
 ```
 
 * the core functionalities are provided by a *service* (in this case a `DatasetService`) defined in
-  [`backend/services/datasets.py`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/services/datasets.py)
+  [`backend/services/datasets.py`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/backend/services/datasets.py)
 
 * instead of directly passing a `DatasetService` to the `get_dataset` method, DatasetServiceDep is defined to perform a
   *dependency injection* (see [FastAPI's dependencies](https://fastapi.tiangolo.com/tutorial/dependencies/))
@@ -115,7 +115,7 @@ So, let us suppose you have already uploaded a dataset on Lumigator. What happen
 `/datasets` endpoint by passing a dataset id?
 
 First thing, `DatasetServiceDep` will make sure that all the dependencies to run your `DatasetService` are met. If you
-look at [`backend/api/deps.py`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/api/deps.py) you will see that
+look at [`backend/api/deps.py`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/backend/api/deps.py) you will see that
 a `DatasetServiceDep` is nothing more than a `DatasetService` that depends on a `DBSessionDep` and and `S3ClientDep`:
 
 ```
@@ -130,7 +130,7 @@ def get_dataset_service(session: DBSessionDep, s3_client: S3ClientDep) -> Datase
 an S3 client.  
 I'll leave you to transitively following deps. For now, it is interesting to note that while the S3 dep is a "simple"
 one (i.e. it just instantiates a boto3 client in place), the DB one is a bit more advanced (i.e. it relies on a
-[`DatabaseSessionManager`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/db.py) to return a session).
+[`DatabaseSessionManager`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/backend/db.py) to return a session).
 
 Secondly, `DatasetService` provides a `get_dataset` method which gets the actual data from the DB and returns a
 `DatasetResponse` after validating it:
@@ -150,10 +150,10 @@ def _get_dataset_record(self, dataset_id: UUID) -> DatasetRecord:
 
 The way data is selected from the DB is through a *repository* , in this case from the `DatasetRepository` class. All
 repositories are defined in `backend/repositories` and inherit from 
-[`BaseRepository`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/repositories/base.py) which is
+[`BaseRepository`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/backend/repositories/base.py) which is
 a general class providing the low-level code to count, create, update, get, delete, and list items. In particular, the
 `DatasetRepository` is a `BaseRepository` working with items of type
-[`DatasetRecord`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/records/datasets.py).
+[`DatasetRecord`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/backend/records/datasets.py).
 
 Fields in records are defined as a mix of explicit type definitions and declarative mappings (see the picture below to
 see how the fields in the datasets table are defined).
@@ -178,7 +178,7 @@ standard code structure:
 
 |                        |                                                                                                                                                                                                                                           |
 |------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [`backend/api/routes`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/api/routes)   | The actual API endpoints one can hit (remember they need to be explicitly added to the [router.py](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/api/router.py) file before you can actually see them!) |
+| [`backend/api/routes`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/api/routes)   | The actual API endpoints one can hit (remember they need to be explicitly added to the [router.py](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/backend/api/router.py) file before you can actually see them!) |
 | [`backend/services`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/services)     | The code that implements core functionalities for each route                                                                                                                                                                              |
 | [`backend/api/deps.py`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/backend/backend/api/deps.py)  | Used to inject dependencies for services                                                                                                                                                                                                  |
 | [`schemas`](https://github.com/mozilla-ai/lumigator/tree/main/lumigator/python/mzai/schemas)              | The schemas used by each route / service                                                                                                                                                                                                  |
@@ -372,7 +372,7 @@ class TaskRepository(BaseRepository[TaskRecord]):
 ```
 
 This does not usually change much as long as you are fine with the base methods provided by the
-[`BaseRepository`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/repositories/base.py) class.
+[`BaseRepository`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/backend/repositories/base.py) class.
 
 The `TaskRepository` is a repository that allows to run the set of methods defined in the `BaseRepository` on the table
 defined by `TaskRecord`. You can define a `TaskRecord` in `backend/records/tasks.py` as follows:
@@ -390,7 +390,7 @@ class TaskRecord(BaseRecord, NameDescriptionMixin, CreatedAtMixin):
 ```
 
 Similarly to what you saw before for `DatasetRecord`, `TaskRecord` inherits from
-[`BaseRecord`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/records/base.py) the property
+[`BaseRecord`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/backend/records/base.py) the property
 of having an `id` primary key. In addition to that, it inherits `name` and `description` from `NameDescriptionMixin` and
 `created_at` from `CreatedAtMixin`. The only field that we need to specify manually is `models`, a non-null column
 holding a list of strings.
@@ -485,7 +485,7 @@ but we'll discuss that in another tutorial.
 
 As `TaskService` depends on the existence of a database, we should inject a dependency on a DB session. To do this, add
 the following code to 
-[`backend/api/deps.py`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/api/deps.py):
+[`backend/api/deps.py`](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/backend/api/deps.py):
 
 ```
 def get_task_service(session: DBSessionDep) -> TaskService:

--- a/lumigator/python/mzai/jobs/evaluator/README.md
+++ b/lumigator/python/mzai/jobs/evaluator/README.md
@@ -27,6 +27,6 @@ def command(self) -> str:
         )
 
 ```
-and are populated from [these config templates.](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/config_templates.py)
-Via [submission run here](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/jobs/submission.py). 
+and are populated from [these config templates.](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/backend/config_templates.py)
+Via [submission run here](https://github.com/mozilla-ai/lumigator/blob/main/lumigator/python/mzai/backend/backend/ray_submit/submission.py). 
 


### PR DESCRIPTION
## What's changing

Please totally feel free to throw this away if you find it to be unnecessary overhead for the project. 😄  When I was browsing the repo I clicked a few broken links so I thought this might help prevent links from accidentally being broken when changes are made.
 
Added a Github Action to check and flag broken links in markdown: The summary page of the Github action will show a summary and print out which links are broken.  This is the action: https://github.com/marketplace/actions/lychee-broken-link-checker

As the project gets reorganized this may be helpful to ensure that all links remain intact.

<img width="272" alt="Screenshot 2024-11-01 at 4 03 37 PM" src="https://github.com/user-attachments/assets/9f58c52f-daba-441d-b400-e066a7cf2d1a">

## How to test it
In the Github Actions page, click on the workflow name and then "run workflow" and you'll see it flag a variety of broken links. 

## Additional notes for reviewers

I only included .md files but this could be expanded to include other file types if you wanted. I excluded all localhost addresses and also any 'mailto' that might show up, but we could also exclude addresses outside the repository, if you only wanted to check links that refer to something else in the repo.

## I already...

Ran it on my fork to verify that it checks and finds the broken links. I didn't yet fix the broken links that it found

- [ x] added some tests for any new functionality
- [ ] updated the documentation
- [ x] checked if a (backend) DB migration step was required and included it if required
