### PR TITLE
Trigger push to dockerhub only when merging PRs

### DIFF
--- a/.github/workflows/build_images_uv.yaml
+++ b/.github/workflows/build_images_uv.yaml
@@ -32,15 +32,16 @@ jobs:
       - name: Get repo version
         run: |
           echo "REPOVERSION=$(git describe --tags --dirty --match \"[0-9\.]*\" --always)" >> $GITHUB_ENV
-          echo "Version of the repo for this build: $REPOVERSION"   
+          echo "Version of the repo for this build: $REPOVERSION"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -50,9 +51,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           target: "main_image"
           tags: |
             mzdotai/lumigator:backend_dev_${{ env.REPOVERSION }}
             ${{ github.ref == 'refs/heads/main' && 'mzdotai/lumigator:latest' || '' }}
-

--- a/.github/workflows/build_images_uv.yaml
+++ b/.github/workflows/build_images_uv.yaml
@@ -22,13 +22,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-
-      - name: Lint
-        run: uvx ruff check --config ruff.toml
-        continue-on-error: false
-
       - name: Get repo version
         run: |
           echo "REPOVERSION=$(git describe --tags --dirty --match \"[0-9\.]*\" --always)" >> $GITHUB_ENV


### PR DESCRIPTION
## What's changing
We currently have an [issue](https://github.com/mozilla-ai/lumigator/issues/343) when external users want to open a PR against our code. This is related to [accessing](https://michaelheap.com/access-secrets-from-forks/) secrets from forks. The proposed solution is to only login & push to dockerhub when we actually merge to main (as I don't think we need the images in dockerhub if they come from a PR)

We've also removed the linting process from the PR/push to main as it's already triggered every time we [push](https://github.com/mozilla-ai/lumigator/blob/main/.github/workflows/tests_uv.yaml)

## How to test it
Ensure CI works properly and after merge we can fork the repo and try to see if the error still happens
## Additional notes for reviewers

## I already...

- [N/A] added some tests for any new functionality
- [N/A] updated the documentation
- [N/A] checked if a (backend) DB migration step was required and included it if required
