### PR TITLE
workflows: Amend Notebook integration test

### DIFF
--- a/.github/workflows/notebook_integration_tests.yaml
+++ b/.github/workflows/notebook_integration_tests.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "fix-**"
   pull_request:
     branches:
       - "**"


### PR DESCRIPTION
## What's changing

The notebook integration test should only run if code is merged into main or if a new PR is opened. Currently, it also runs if a new branch named `fix-**` is pushed, due to legacy behavior.

Remove the rule that triggers the test when a new `fix-**` is pushed.
