### PR TITLE
GHA: Update names of workflow jobs

### DIFF
--- a/.github/workflows/build_images_uv.yaml
+++ b/.github/workflows/build_images_uv.yaml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Docker image CI
 
 on:
   pull_request:
@@ -30,7 +30,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
+      - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,4 +1,4 @@
-name: Build and Publish Docs
+name: Build and publish docs
 
 on:
   # required to enable manual triggers on the GH web ui
@@ -18,11 +18,11 @@ permissions:
 
 jobs:
   build-docs:
-    name: Build and Publish Docs
+    name: Build and publish docs
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout Code
+    - name: Checkout code
       uses: actions/checkout@v4
 
     - name: Set up Python 3.11
@@ -30,7 +30,7 @@ jobs:
       with:
         python-version: "3.11"
 
-    - name: Set up Environment
+    - name: Set up environment
       id: setup
       run: |
         curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -38,23 +38,23 @@ jobs:
         echo "VIRTUAL_ENV=$HOME/.venv" >> $GITHUB_ENV
       continue-on-error: false
 
-    - name: Install Docs Dependencies
+    - name: Install docs dependencies
       id: install_build_dependencies
       run: |
         . .venv/bin/activate
         uv pip install -r pyproject.toml --extra docs
       continue-on-error: false
 
-    - name: Build Documentation
+    - name: Build documentation
       run: |
         . .venv/bin/activate
         cd docs
         sphinx-build source build/html
 
-    - name: Set up Pages
+    - name: Set up pages
       uses: actions/configure-pages@v4
 
-    - name: Upload Artifact
+    - name: Upload artifact
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       uses: actions/upload-pages-artifact@v3
       with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build-docs:
-    name: Build Docs
+    name: Build and Publish Docs
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/links_checker.yaml
+++ b/.github/workflows/links_checker.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   link-checker:
-    name: Link Checker
+    name: Docs - Link Checker
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/links_checker.yaml
+++ b/.github/workflows/links_checker.yaml
@@ -1,4 +1,4 @@
-name: Build and Publish Docs
+name: Build and publish docs
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
 
 jobs:
   link-checker:
-    name: Docs - Link Checker
+    name: Docs - Link checker
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sdk_integration_tests.yaml
+++ b/.github/workflows/sdk_integration_tests.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   integration:
-    name: SDK integration tests
+    name: SDK integration tests - Python
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/sdk_integration_tests.yaml
+++ b/.github/workflows/sdk_integration_tests.yaml
@@ -1,4 +1,4 @@
-name: SDK integration tests
+name: SDK tests
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  integration:
+  sdk-integration-tests:
     name: SDK integration tests - Python
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests_uv.yaml
+++ b/.github/workflows/tests_uv.yaml
@@ -1,4 +1,4 @@
-name: Lumigator integration tests
+name: Lumigator backend tests
 
 on:
   push:

--- a/.github/workflows/tests_uv.yaml
+++ b/.github/workflows/tests_uv.yaml
@@ -1,11 +1,11 @@
-name: Tests
+name: Lumigator integration tests
 
 on:
   push:
 
 jobs:
   uv-example:
-    name: python
+    name: Integration tests - Python
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests_uv.yaml
+++ b/.github/workflows/tests_uv.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
 
-      - name: Install python
+      - name: Install Python
         run: uv python install
         working-directory: lumigator/python/mzai/backend
 

--- a/.github/workflows/tests_uv.yaml
+++ b/.github/workflows/tests_uv.yaml
@@ -4,7 +4,7 @@ on:
   push:
 
 jobs:
-  uv-example:
+  backend-integration-tests:
     name: Backend integration tests - Python
     runs-on: ubuntu-latest
 

--- a/.github/workflows/tests_uv.yaml
+++ b/.github/workflows/tests_uv.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   uv-example:
-    name: Integration tests - Python
+    name: Backend integration tests - Python
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests_uv_sdk.yaml
+++ b/.github/workflows/tests_uv_sdk.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   uv-example:
-    name: python
+    name: SDK tests - Python
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests_uv_sdk.yaml
+++ b/.github/workflows/tests_uv_sdk.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   uv-example:
-    name: SDK tests - Python
+    name: SDK unit tests - Python
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests_uv_sdk.yaml
+++ b/.github/workflows/tests_uv_sdk.yaml
@@ -1,4 +1,4 @@
-name: SDK Tests
+name: SDK tests
 
 on:
   push:

--- a/.github/workflows/tests_uv_sdk.yaml
+++ b/.github/workflows/tests_uv_sdk.yaml
@@ -4,7 +4,7 @@ on:
   push:
 
 jobs:
-  uv-example:
+  sdk-unit-tests:
     name: SDK unit tests - Python
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## What's changing

GitHub's UI can make it difficult to know for sure which task you're trying  to associate with a required status check as it resolves only the job name and shows no information about the scope (i.e. the workflow name it is associate with).

This PR makes the job names more specific as to which workflow they are part of.

Once the PR merges it will be easier to find and [configure the required status checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging) for PRs merging to `main`.
## How to test it

## Additional notes for reviewers

Current branch protection rules for main only have a few checks configured, but we'd want more to be successful before allowing a merge. 

![image](https://github.com/user-attachments/assets/e103df24-0a7b-459b-b8cb-9f080c025283)

This way we can ensure that we don't accidentally merge with changes that wouldn't pass our linting for example.

## I already...

- [ ] added some tests for any new functionality
- [ ] updated the documentation
- [ ] checked if a (backend) DB migration step was required and included it if required
