### PR TITLE
run tests (SDK/Backend) on PR changes and when PRs merge to main

### DIFF
--- a/.github/workflows/tests_uv.yaml
+++ b/.github/workflows/tests_uv.yaml
@@ -2,6 +2,11 @@ name: Lumigator backend tests
 
 on:
   push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "**"
 
 jobs:
   backend-integration-tests:

--- a/.github/workflows/tests_uv_sdk.yaml
+++ b/.github/workflows/tests_uv_sdk.yaml
@@ -2,6 +2,12 @@ name: SDK tests
 
 on:
   push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "**"
+  workflow_dispatch:
 
 jobs:
   sdk-unit-tests:


### PR DESCRIPTION
## What's changing

Some required checks may hang when the branch of a PR is updated via GitHub's UI (merges `main`) as this doesn't retrigger the workflow job. 

This PR modifies the `on` for SDK and backend tests.

## How to test it

## Additional notes for reviewers

## I already...

- [ ] added some tests for any new functionality
- [ ] updated the documentation
- [ ] checked if a (backend) DB migration step was required and included it if required
