### PR TITLE
Set max samples to unlimited by default with option to override API request cycle

### DIFF
--- a/lumigator/python/mzai/backend/backend/services/jobs.py
+++ b/lumigator/python/mzai/backend/backend/services/jobs.py
@@ -148,9 +148,6 @@ class JobService:
                 "top_p": request.top_p,
             }
 
-        # set max samples to unlimited if not specified
-        if request.max_samples is None:
-            request.max_samples = -1
 
         return job_params
 

--- a/lumigator/python/mzai/backend/backend/services/jobs.py
+++ b/lumigator/python/mzai/backend/backend/services/jobs.py
@@ -148,6 +148,10 @@ class JobService:
                 "top_p": request.top_p,
             }
 
+        # set max samples to unlimited if not specified
+        if request.max_samples is None:
+            request.max_samples = -1
+
         return job_params
 
     def create_job(self, request: JobEvalCreate | JobInferenceCreate) -> JobResponse:

--- a/lumigator/python/mzai/backend/backend/services/jobs.py
+++ b/lumigator/python/mzai/backend/backend/services/jobs.py
@@ -148,7 +148,6 @@ class JobService:
                 "top_p": request.top_p,
             }
 
-
         return job_params
 
     def create_job(self, request: JobEvalCreate | JobInferenceCreate) -> JobResponse:

--- a/lumigator/python/mzai/backend/backend/tests/conftest.py
+++ b/lumigator/python/mzai/backend/backend/tests/conftest.py
@@ -167,6 +167,7 @@ def job_repository(db_session):
 @pytest.fixture(scope="function")
 def result_repository(db_session):
     return JobResultRepository(session=db_session)
+
 @pytest.fixture(scope="function")
 def fake_ray_client():
     return FakeJobSubmissionClient()
@@ -175,9 +176,11 @@ def fake_ray_client():
 def dataset_service(db_session):
     dataset_repo = DatasetRepository(db_session)
     return DatasetService(dataset_repo=dataset_repo,s3_client=s3_client, s3_filesystem=S3FileSystem())
+
 @pytest.fixture(scope="function")
 def job_record(db_session):
     return JobRecord
+
 @pytest.fixture(scope="function")
 def job_service(db_session, job_repository, result_repository,fake_ray_client,dataset_service):
     return JobService(job_repository, result_repository,fake_ray_client, dataset_service)

--- a/lumigator/python/mzai/backend/backend/tests/fakes/fake_ray_client.py
+++ b/lumigator/python/mzai/backend/backend/tests/fakes/fake_ray_client.py
@@ -1,0 +1,8 @@
+class FakeJobSubmissionClient:
+    """
+    A mock implementation of Ray's JobSubmissionClient for testing purposes.
+    Simulates basic job submission and management functionality.
+    """
+    def __init__(self):
+        self.jobs: dict[str, dict] = {}  # Store jobs and their metadata
+        self.runtime_env = {}

--- a/lumigator/python/mzai/backend/backend/tests/services/test_job_service.py
+++ b/lumigator/python/mzai/backend/backend/tests/services/test_job_service.py
@@ -1,0 +1,22 @@
+
+from backend.services.jobs import JobService
+from lumigator_schemas.jobs import (
+    JobInferenceCreate,
+
+)
+def test_set_null_inference_job_params(job_record,job_service ):
+    request = JobInferenceCreate(name="test_run_hugging_face",
+                                 description="Test run for Huggingface model",
+                                    model="Test run for Huggingface model",
+                                 dataset="cced289c-f869-4af1-9195-1d58e32d1cc1")
+    params = job_service._get_job_params("INFERENCE", job_record,request)
+    assert params["max_samples"] == -1
+
+def test_set_explicit_inference_job_params(job_record,job_service ):
+    request = JobInferenceCreate(name="test_run_hugging_face",
+                                 description="Test run for Huggingface model",
+                                 max_samples=10,
+                                    model="Test run for Huggingface model",
+                                 dataset="cced289c-f869-4af1-9195-1d58e32d1cc1")
+    params = job_service._get_job_params("INFERENCE", job_record,request)
+    assert params["max_samples"] == 10

--- a/lumigator/python/mzai/jobs/evaluator/evaluator/configs/jobs/hf_evaluate.py
+++ b/lumigator/python/mzai/jobs/evaluator/evaluator/configs/jobs/hf_evaluate.py
@@ -18,7 +18,7 @@ class HuggingFaceEvaluationConfig(EvaluatorConfig):
     metrics: conlist(str, min_length=1)
     use_pipeline: bool = False
     enable_tqdm: bool = False
-    max_samples: int | None = None
+    max_samples: int = -1 # set to all samples by default
     storage_path: str | None = None
     return_input_data: bool = False
     return_predictions: bool = False

--- a/lumigator/python/mzai/jobs/inference/inference_config.py
+++ b/lumigator/python/mzai/jobs/inference/inference_config.py
@@ -7,7 +7,7 @@ class DatasetConfig(BaseModel):
 
 
 class JobConfig(BaseModel):
-    max_samples: int = 0
+    max_samples: int = -1 # set to all samples by default
     storage_path: str
     output_field: str = "prediction"
     enable_tqdm: bool = True

--- a/lumigator/python/mzai/schemas/lumigator_schemas/experiments.py
+++ b/lumigator/python/mzai/schemas/lumigator_schemas/experiments.py
@@ -11,7 +11,7 @@ class ExperimentCreate(BaseModel):
     description: str = ""
     model: str
     dataset: UUID
-    max_samples: int | None = None
+    max_samples: int = -1 # set to all samples by default
     model_url: str | None = None
     system_prompt: str | None = None
     config_template: str | None = None

--- a/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
+++ b/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
@@ -55,7 +55,7 @@ class JobEvalCreate(BaseModel):
     description: str = ""
     model: str
     dataset: UUID
-    max_samples: int | None = None
+    max_samples: int = -1 # set to all samples by default
     model_url: str | None = None
     system_prompt: str | None = None
     config_template: str | None = None
@@ -66,7 +66,7 @@ class JobInferenceCreate(BaseModel):
     description: str = ""
     model: str
     dataset: UUID
-    max_samples: int | None = None
+    max_samples: int = -1 # set to all samples by default
     model_url: str | None = None
     system_prompt: str | None = None
     output_field: str | None = "prediction"


### PR DESCRIPTION
## What's changing

We're currently not enforcing a `max_samples` value when they initially get passed into the application, and then again when they're sent via the API to Ray. 

This forces `max_samples` for both inference and eval jobs to be set if they're not once on input and once again on submission for evaluation.  Tests cover setting via the service. 

Original PR was here, overwritten by improvements/merges from inference API. (https://github.com/mozilla-ai/lumigator/compare/main...fix_max_samples)

## How to test it

Unit tests cover input at the API level. 

## Additional notes for reviewers

## I already...

- [X] added some tests for any new functionality
- [ ] updated the documentation
- [ ] checked if a (backend) DB migration step was required and included it if required
