### PR TITLE
Enable dummy experiment endpoint

### DIFF
--- a/lumigator/python/mzai/backend/backend/api/routes/experiments.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/experiments.py
@@ -1,8 +1,59 @@
-from fastapi import APIRouter
+from uuid import UUID
+
+from fastapi import APIRouter, status
+from lumigator_schemas.experiments import (
+    ExperimentCreate,
+    ExperimentResponse,
+    ExperimentResultDownloadResponse,
+    ExperimentResultResponse,
+)
+from lumigator_schemas.extras import ListingResponse
+from lumigator_schemas.jobs import (
+    JobEvalCreate,
+)
+
+from backend.api.deps import JobServiceDep
 
 router = APIRouter()
 
 
+@router.post("/", status_code=status.HTTP_201_CREATED)
+def create_experiment(
+    service: JobServiceDep,
+    request: ExperimentCreate,
+) -> ExperimentResponse:
+    return service.create_job(JobEvalCreate(request.model_dump()))
+
+
+@router.get("/{experiment_id}")
+def get_experiment(service: JobServiceDep, experiment_id: UUID) -> ExperimentResponse:
+    return ExperimentResponse(service.get_job(experiment_id).model_dump())
+
+
 @router.get("/")
-def get_experiments():
-    return {"message": "Experiments"}
+def list_experiments(
+    service: JobServiceDep,
+    skip: int = 0,
+    limit: int = 100,
+) -> ListingResponse[ExperimentResponse]:
+    return [ExperimentResponse(job.model_dump()) for job in service.list_jobs(skip, limit)]
+
+
+@router.get("/{experiment_id}/result")
+def get_experiment_result(
+    service: JobServiceDep,
+    experiment_id: UUID,
+) -> ExperimentResultResponse:
+    """Return experiment results metadata if av ailable in the DB."""
+    return ExperimentResultResponse(service.get_job_result(experiment_id).model_dump())
+
+
+@router.get("/{experiment_id}/result/download")
+def get_experiment_result_download(
+    service: JobServiceDep,
+    experiment_id: UUID,
+) -> ExperimentResultDownloadResponse:
+    """Return experiment results file URL for downloading."""
+    return ExperimentResultDownloadResponse(
+        service.get_job_result_download(experiment_id).model_dump()
+        )


### PR DESCRIPTION
## What's changing

An experiment endpoint reusing the jobs service is made available.

## How to test it

N/A for the moment

## Additional notes for reviewers

N/A for the moment

## I already...

- [ ] added some tests for any new functionality
- [ ] updated the documentation
- [ ] checked if a (backend) DB migration step was required and included it if required
