### PR TITLE
GitHub actions: allow docker image build to be a required check

### DIFF
--- a/.github/workflows/build_images_uv.yaml
+++ b/.github/workflows/build_images_uv.yaml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-image:
+  build:
     name: Build Docker image
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build_images_uv.yaml
+++ b/.github/workflows/build_images_uv.yaml
@@ -2,45 +2,58 @@ name: Docker image CI
 
 on:
   pull_request:
-    paths:
-      - "lumigator/**"
-      - ".github/**"
+    branches:
+      - "**"
     # synchronized is when you push new commits
     types: ["opened", "synchronize"]
   push:
     branches:
-      - main
+      - "main"
   # required to enable manual triggers on the GH web ui
   workflow_dispatch:
 
 jobs:
-  build:
+  build-image:
     name: Build Docker image
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+
+      - name: Check for modified paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rebuild:
+              - '.github/**'
+              - 'lumigator/**'
 
       - name: Get repo version
+        if: steps.filter.outputs.rebuild == 'true'
         run: |
           echo "REPOVERSION=$(git describe --tags --dirty --match \"[0-9\.]*\" --always)" >> $GITHUB_ENV
           echo "Version of the repo for this build: $REPOVERSION"
 
       - name: Set up QEMU
+        if: steps.filter.outputs.rebuild == 'true'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker buildx
+        if: steps.filter.outputs.rebuild == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: ${{ steps.filter.outputs.rebuild == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
+        if: steps.filter.outputs.backrebuildend == 'true'
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build_images_uv.yaml
+++ b/.github/workflows/build_images_uv.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+          fetch-depth: 0
 
       - name: Check for modified paths
         uses: dorny/paths-filter@v3

--- a/.github/workflows/build_images_uv.yaml
+++ b/.github/workflows/build_images_uv.yaml
@@ -19,10 +19,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          # For PRs set the depth to be one more than the number of commits in the PR,
-          # otherwise set it to one (e.g. for merge to main).
-          fetch-depth: $(( ${{ github.event_name == 'pull_request' && github.event.pull_request.commits || 0 }} + 1 ))
 
       - name: Check for modified paths
         uses: dorny/paths-filter@v3

--- a/.github/workflows/build_images_uv.yaml
+++ b/.github/workflows/build_images_uv.yaml
@@ -53,7 +53,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        if: steps.filter.outputs.backrebuildend == 'true'
+        if: steps.filter.outputs.rebuild == 'true'
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build_images_uv.yaml
+++ b/.github/workflows/build_images_uv.yaml
@@ -20,7 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          # For PRs set the depth to be one more than the number of commits in the PR,
+          # otherwise set it to one (e.g. for merge to main).
+          fetch-depth: $(( ${{ github.event_name == 'pull_request' && github.event.pull_request.commits || 0 }} + 1 ))
 
       - name: Check for modified paths
         uses: dorny/paths-filter@v3

--- a/.github/workflows/build_images_uv.yaml
+++ b/.github/workflows/build_images_uv.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        if: ${{ steps.filter.outputs.rebuild == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: steps.filter.outputs.rebuild == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build_images_uv.yaml
+++ b/.github/workflows/build_images_uv.yaml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: Build Docker image
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build_images_uv.yaml
+++ b/.github/workflows/build_images_uv.yaml
@@ -8,7 +8,7 @@ on:
     types: ["opened", "synchronize"]
   push:
     branches:
-      - "main"
+      - main
   # required to enable manual triggers on the GH web ui
   workflow_dispatch:
 


### PR DESCRIPTION
## What's changing

The `Docker image CI` workflow can be run on merges to `main` and PR branches. It is required as a status check before allowing a merge to occur, but there are times when we don't need to rebuild the image, for example if only the `/docs` folder changes in a PR it's a waste of time and resources to build the docker image. 

With this PR change we will always trigger the workflow, but it can successfully 'exit early' if a rebuild is not required.

The current folders that are examined for changes are:

* `.github/**`
* `lumigator/**`

## How to test it


## Additional notes for reviewers

We use [dorny/paths-filter](https://github.com/dorny/paths-filter) to do the heavy lifting/checking for us, previous iterations of this PR tried to do a lot of juggling with `git diff `and `git diff-tree` etc.

The [GH runner output](https://github.com/mozilla-ai/lumigator/actions/runs/11894989446/job/33143495270?pr=378#step:3:16) can be used to see what changes were found and whether we decided a rebuild was required or not.

## I already...

- [ ] added some tests for any new functionality
- [ ] updated the documentation
- [x] checked if a (backend) DB migration step was required and included it if required
