### PR TITLE
Draft for job decoupling discussion

### DIFF
--- a/lumigator/python/mzai/backend/backend/api/routes/jobs.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/jobs.py
@@ -4,10 +4,12 @@ from fastapi import APIRouter, status
 from lumigator_schemas.extras import ListingResponse
 from lumigator_schemas.jobs import (
     JobEvalCreate,
+    JobCreate,
     JobInferenceCreate,
     JobResponse,
     JobResultDownloadResponse,
     JobResultResponse,
+    JobType
 )
 from starlette.requests import Request
 from starlette.responses import Response
@@ -16,6 +18,22 @@ from backend.api.deps import JobServiceDep
 from backend.api.http_headers import HttpHeaders
 
 router = APIRouter()
+
+
+@router.post("/alt/{type}/", status_code=status.HTTP_201_CREATED)
+def create_inference_job(
+    service: JobServiceDep,
+    job_create_request: JobCreate,
+    request: Request,
+    response: Response
+) -> JobResponse:
+    job_create_request.type = JobType(type)
+    job_response = service.create_job_alt(job_create_request)
+
+    url = request.url_for(get_job.__name__, job_id=job_response.id)
+    response.headers[HttpHeaders.LOCATION] = f"{url}"
+
+    return job_response
 
 
 @router.post("/inference/", status_code=status.HTTP_201_CREATED)

--- a/lumigator/python/mzai/backend/backend/services/jobs.py
+++ b/lumigator/python/mzai/backend/backend/services/jobs.py
@@ -15,6 +15,13 @@ from lumigator_schemas.jobs import (
     JobStatus,
     JobType,
 )
+from lumigator_schemas.inference_config import (
+    InferenceJobConfig,
+    COMMAND as INFERENCE_COMMAND,
+    PIP_REQS as INFERENCE_PIP_REQS,
+    WORK_DIR as INFERENCE_WORK_DIR,
+    CONFIG_MODEL as INFERENCE_CONFIG_MODEL
+)
 from pydantic import BaseModel
 from ray.job_submission import JobSubmissionClient
 
@@ -25,15 +32,35 @@ from backend.repositories.jobs import JobRepository, JobResultRepository
 from backend.services.datasets import DatasetService
 from backend.settings import settings
 
-from lumigator_schemas.jobs import InferenceJobConfig
-
+# from lumigator_schemas import inference_config
 
 class JobService:
     # set storage path
     storage_path = f"s3://{ Path(settings.S3_BUCKET) / settings.S3_JOB_RESULTS_PREFIX }/"
 
+    # A more generic implementation could be:
+    # job_settings = {}
+    # job_imports = [inference_config]
+    # for config in job_imports:
+    #     job_settings[config.JOB_TYPE] = {
+    #         "command": config.COMMAND,
+    #         "pip": config.PIP_REQS,
+    #         "work_dir": config.WORK_DIR,
+    #         "model": config.CONFIG_MODEL,
+    #         "ray_worker_gpus_fraction": settings.RAY_WORKER_GPUS_FRACTION,
+    #         "ray_worker_gpus": settings.RAY_WORKER_GPUS,
+    #     }
+
     job_settings = {
         JobType.INFERENCE: {
+            "command": INFERENCE_COMMAND,
+            "pip": INFERENCE_PIP_REQS,
+            "work_dir": INFERENCE_WORK_DIR,
+            "model": INFERENCE_CONFIG_MODEL,
+            "ray_worker_gpus_fraction": settings.RAY_WORKER_GPUS_FRACTION,
+            "ray_worker_gpus": settings.RAY_WORKER_GPUS,
+        },
+        JobType.MULTI_INFERENCE: {
             "command": settings.INFERENCE_COMMAND,
             "pip": settings.INFERENCE_PIP_REQS,
             "work_dir": settings.INFERENCE_WORK_DIR,

--- a/lumigator/python/mzai/backend/backend/settings.py
+++ b/lumigator/python/mzai/backend/backend/settings.py
@@ -7,6 +7,12 @@ from pydantic_settings import BaseSettings
 from sqlalchemy.engine import URL, make_url
 
 
+class JobSettings:
+    work_dir: str | None = None
+    pip_reqs: str | None = None
+    command: str
+
+
 class BackendSettings(BaseSettings):
     # Backend
     DEPLOYMENT_TYPE: DeploymentType = DeploymentType.LOCAL
@@ -60,6 +66,8 @@ class BackendSettings(BaseSettings):
     INFERENCE_WORK_DIR: str | None = None
     INFERENCE_PIP_REQS: str | None = None
     INFERENCE_COMMAND: str = "python inference.py"
+
+
 
     def inherit_ray_env(self, runtime_env_vars: Mapping[str, str]):
         for env_var_name in self.RAY_WORKER_ENV_VARS:

--- a/lumigator/python/mzai/backend/backend/tests/api/routes/test_api_workflows.py
+++ b/lumigator/python/mzai/backend/backend/tests/api/routes/test_api_workflows.py
@@ -4,6 +4,7 @@ import pytest
 import requests
 from fastapi.testclient import TestClient
 from lumigator_schemas.datasets import DatasetFormat, DatasetResponse
+from lumigator_schemas.jobs import JobCreate, InferenceJobConfig, DatasetConfig
 
 from backend.main import app
 
@@ -49,6 +50,108 @@ def test_upload_data_launch_job(local_client: TestClient, dialog_dataset):
 
     create_inference_job_response = local_client.post(
         "/jobs/inference/", headers=headers, json=payload
+    )
+    assert create_inference_job_response.status_code == 201
+
+
+def test_upload_data_launch_job_alt(local_client: TestClient, dialog_dataset):
+    response = local_client.get("/health")
+    assert response.status_code == 200
+
+    create_response = local_client.post(
+        "/datasets/",
+        data={},
+        files={"dataset": dialog_dataset, "format": (None, DatasetFormat.JOB.value)},
+    )
+
+    assert create_response.status_code == 201
+
+    created_dataset = DatasetResponse.model_validate(create_response.json())
+    headers = {
+        "accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+
+
+
+            job_params = {
+                "job_id": record.id,
+                "job_name": request.name,
+                "model_path": request.model,
+                "dataset_path": dataset_s3_path,
+                "max_samples": request.max_samples,
+                "storage_path": self.storage_path,
+                "model_url": model_url,
+                "system_prompt": request.system_prompt,
+                "output_field": request.output_field,
+                "max_tokens": request.max_tokens,
+                "frequency_penalty": request.frequency_penalty,
+                "temperature": request.temperature,
+                "top_p": request.top_p,
+            }
+
+
+causal_infer_template = """{{
+    "name": "{job_name}/{job_id}",
+    "model": {{ "path": "{model_path}" }},
+    "dataset": {{ "path": "{dataset_path}" }},
+}}"""
+
+
+oai_infer_template = """{{
+    "name": "{job_name}/{job_id}",
+    "dataset": {{ "path": "{dataset_path}" }},
+    "job": {{
+    }},
+    "inference_server": {{
+        "base_url": "{model_url}",
+        "engine": "{model_path}",
+        "system_prompt": "{system_prompt}",
+        "max_retries": 3
+    }},
+    "params": {{
+        "max_tokens": {max_tokens},
+        "frequency_penalty": {frequency_penalty},
+        "temperature": {temperature},
+        "top_p": {top_p}
+    }}
+}}"""
+
+
+
+    specific_payload = InferenceJobConfig(
+        name="test_run_hugging_face" f"{job_name}/{job_id}"
+        dataset=DatasetConfig(
+            path=str(created_dataset.id) dataset_s3_path
+        ),
+        job=JobConfig(
+            max_samples=10,
+            output_field="prediction",
+            enable_tqdm=True,
+        ),
+        inference_server=InferenceServerConfig(
+            "model_url": "string",
+            "model": "hf://facebook/bart-large-cnn",
+            engine: str
+            "system_prompt": "string",
+            system_prompt: str | None
+            max_retries=3
+        ),
+        params=SamplingParameters(
+            max_tokens=1024,
+            frequency_penalty=0.0,
+            temperature=1.0,
+            top_p=1.0,
+        )
+    )
+    payload = JobCreate(
+        "name": "test_run_hugging_face",
+        "description": "Test run for Huggingface model",
+    )
+
+    create_inference_job_response = local_client.post(
+        "/jobs/inference/", headers=headers, json=payload.model_dump_json()
     )
     assert create_inference_job_response.status_code == 201
 

--- a/lumigator/python/mzai/jobs/README.md
+++ b/lumigator/python/mzai/jobs/README.md
@@ -1,0 +1,17 @@
+# How to write a new job
+
+To add a new job to Lumigator, go to the `lumigator/python/mzai/schemas/lumigator_schemas` folder and perform the following steps:
+
+* Create a new enum value in `lumigator_schemas.jobs.JobType` called for example `<JOB_NAME>`.
+* Create a new file named `<job_name>_config.py` containing:
+  * Any necessary Pydantic models for the job configuration (passed as payload to the `CreateJob` endpoint).
+  * The following properties:
+    * `COMMAND`: the shell command needed to run the job (config is added automatically as a json in the `--config` command line paramater). If the rest of Python files are just scripts, this could be just `python <entrypoint>.py`
+    * `PIP_REQS`: the name of the file including the package requirements (see below).
+    * `WORK_DIR`: the URL for the packed directory containing any necessary input files, or `None` if a fresh environment is to be used.
+    * `MODEL`: the class holding the top level job configuration model.
+
+Then create a new folder under the `lumigator/python/mzai/jobs` folder called `<job_name>`. Within that folder:
+
+* Create any new files as needed to implement the task itself. These files need not be structured in modules. These files can import the entities declared in `<job_name>_config.py` file created above with `import lumigator_schemas.<job_name>_config`.
+* Create a file containing the package requirements, usually called `requirements.txt`, which has been referenced in the `PIP_REQS` property above.

--- a/lumigator/python/mzai/jobs/inference/inference.py
+++ b/lumigator/python/mzai/jobs/inference/inference.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import s3fs
 from datasets import load_from_disk
-from inference_config import InferenceJobConfig
+from lumigator_schemas.inference_config import InferenceJobConfig
 from loguru import logger
 from model_clients import (
     BaseModelClient,

--- a/lumigator/python/mzai/jobs/inference/requirements.txt
+++ b/lumigator/python/mzai/jobs/inference/requirements.txt
@@ -4,3 +4,4 @@ datasets==2.20.0
 python-box==7.2.0
 mistralai==0.4.2
 openai==1.52.0
+lumigator-schemas==0.1.0-rc.2

--- a/lumigator/python/mzai/schemas/lumigator_schemas/inference_config.py
+++ b/lumigator/python/mzai/schemas/lumigator_schemas/inference_config.py
@@ -1,8 +1,5 @@
 from pydantic import BaseModel, ConfigDict
 
-from lumigator_schemas.jobs import JobType
-
-# Model class definitions
 
 class DatasetConfig(BaseModel):
     path: str
@@ -40,12 +37,3 @@ class InferenceJobConfig(BaseModel):
     inference_server: InferenceServerConfig
     params: SamplingParameters
     model_config = ConfigDict(extra="forbid")
-
-# Job properties
-# NOTE maybe make a @property and/or a dict/obj/pydantic model
-# typing.Protocol might be used to allow IDE support
-COMMAND = "python inference.py"
-PIP_REQS = "requirements.txt"
-WORK_DIR = None
-MODEL = InferenceJobConfig
-JOB_TYPE = JobType.INFERENCE

--- a/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
+++ b/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 
 class JobType(str, Enum):
@@ -76,6 +76,54 @@ class JobInferenceCreate(BaseModel):
     top_p: float = 1.0
     config_template: str | None = None
 
+class JobCreate(BaseModel):
+    name: str
+    description: str = ""
+    model: str
+    dataset: UUID
+    max_samples: int = -1 # set to all samples by default
+    model_url: str | None = None
+    specific_config: Any
+    type: JobType
+
+class DatasetConfig(BaseModel):
+    path: str
+    model_config = ConfigDict(extra="forbid")
+
+
+class JobConfig(BaseModel):
+    max_samples: int = -1 # set to all samples by default
+    storage_path: str
+    output_field: str = "prediction"
+    enable_tqdm: bool = True
+    model_config = ConfigDict(extra="forbid")
+
+
+class InferenceServerConfig(BaseModel):
+    base_url: str
+    engine: str
+    system_prompt: str | None
+    max_retries: int = 3
+    model_config = ConfigDict(extra="forbid")
+
+class SamplingParameters(BaseModel):
+    max_tokens: int = 1024
+    frequency_penalty: float = 0.0
+    temperature: float = 1.0
+    top_p: float = 1.0
+    model_config = ConfigDict(extra="forbid")
+
+class InferenceJobConfig(BaseModel):
+    name: str
+    dataset: DatasetConfig
+    job: JobConfig
+    inference_server: InferenceServerConfig
+    params: SamplingParameters
+    model_config = ConfigDict(extra="forbid")
+
+config_per_job = {
+    JobType.INFERENCE.value: InferenceJobConfig
+}
 
 class JobResponse(BaseModel, from_attributes=True):
     id: UUID

--- a/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
+++ b/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field, ConfigDict
 class JobType(str, Enum):
     INFERENCE = "inference"
     EVALUATION = "evaluate"
+    MULTI_INFERENCE = "multi_inference"
 
 
 class JobStatus(str, Enum):
@@ -85,45 +86,6 @@ class JobCreate(BaseModel):
     model_url: str | None = None
     specific_config: Any
     type: JobType
-
-class DatasetConfig(BaseModel):
-    path: str
-    model_config = ConfigDict(extra="forbid")
-
-
-class JobConfig(BaseModel):
-    max_samples: int = -1 # set to all samples by default
-    storage_path: str
-    output_field: str = "prediction"
-    enable_tqdm: bool = True
-    model_config = ConfigDict(extra="forbid")
-
-
-class InferenceServerConfig(BaseModel):
-    base_url: str
-    engine: str
-    system_prompt: str | None
-    max_retries: int = 3
-    model_config = ConfigDict(extra="forbid")
-
-class SamplingParameters(BaseModel):
-    max_tokens: int = 1024
-    frequency_penalty: float = 0.0
-    temperature: float = 1.0
-    top_p: float = 1.0
-    model_config = ConfigDict(extra="forbid")
-
-class InferenceJobConfig(BaseModel):
-    name: str
-    dataset: DatasetConfig
-    job: JobConfig
-    inference_server: InferenceServerConfig
-    params: SamplingParameters
-    model_config = ConfigDict(extra="forbid")
-
-config_per_job = {
-    JobType.INFERENCE.value: InferenceJobConfig
-}
 
 class JobResponse(BaseModel, from_attributes=True):
     id: UUID


### PR DESCRIPTION
## What's changing

A new generic `create_job_alt` is proposed. The key changes are:

* Job _data_ are retrieved from a dict, which allows programmatic changes in the future, and a more general config and use right now
* Job _config models_ are stored in the same dict from a statically imported file
  * Currently models are used in standalone scripts, so they need to be added to lumigator somehow
    * The image build process could include these files somehow (maybe using the mechanisms in https://hatch.pypa.io/latest/config/build/)
    * The models could be included in lumigator itself, and the scripts could import the lumigator_schemas package
  * More dynamic imports using `importlib` to load models at load-time or run-time could be done later on without changes to the current job creation
* Additional steps can be added as hooks, if needed, in the same way that the model code is added

The current code has not been checked; once the approach is validated, a full, working implementation will be provided.

## How to test it

N/A; draft for discussion at the moment.

## Additional notes for reviewers

N/A

## I already...

- [ ] added some tests for any new functionality
- [ ] updated the documentation
- [ ] checked if a (backend) DB migration step was required and included it if required
