### PR TITLE
Exit link checker and docs workflow early if no changes to /docs

### DIFF
--- a/.github/workflows/build_and_publish_docs.yaml
+++ b/.github/workflows/build_and_publish_docs.yaml
@@ -24,12 +24,22 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Check for modified paths
+      uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          changes:
+            - 'docs/**'
+
     - name: Set up Python 3.11
+      if: steps.filter.outputs.changes == 'true'
       uses: actions/setup-python@v5
       with:
         python-version: "3.11"
 
     - name: Set up environment
+      if: steps.filter.outputs.changes == 'true'
       id: setup
       run: |
         curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -38,6 +48,7 @@ jobs:
       continue-on-error: false
 
     - name: Install docs dependencies
+      if: steps.filter.outputs.changes == 'true'
       id: install_build_dependencies
       run: |
         . .venv/bin/activate
@@ -45,22 +56,24 @@ jobs:
       continue-on-error: false
 
     - name: Build documentation
+      if: steps.filter.outputs.changes == 'true'
       run: |
         . .venv/bin/activate
         cd docs
         sphinx-build source build/html
 
     - name: Set up pages
+      if: steps.filter.outputs.changes == 'true'
       uses: actions/configure-pages@v4
 
     - name: Upload artifact
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      if: steps.filter.outputs.changes == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: actions/upload-pages-artifact@v3
       with:
         path: docs/build/html/
 
     - name: Deploy
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      if: steps.filter.outputs.changes == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: actions/deploy-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check_links.yaml
+++ b/.github/workflows/check_links.yaml
@@ -3,7 +3,7 @@ name: Link checker
 on:
   push:
     branches:
-        - '*'
+        - main
   pull_request:
     branches:
       - "**"
@@ -16,7 +16,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check for modified paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            changes:
+              - 'docs/**'
+
       - name: Link Checker
+        if: steps.filter.outputs.changes == 'true'
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:


### PR DESCRIPTION
## What's changing

Provide a way to successfully exit early from docs workflows, when no docs files have been changed.

As the docs workflow status is a require status check, we cannot skip the workflow entirely.

## How to test it

## Additional notes for reviewers

## I already...

- [ ] added some tests for any new functionality
- [ ] updated the documentation
- [ ] checked if a (backend) DB migration step was required and included it if required
