### PR TITLE
GitHub actions: update link checker and docs build workflows

### DIFF
--- a/.github/workflows/build_and_publish_docs.yaml
+++ b/.github/workflows/build_and_publish_docs.yaml
@@ -1,11 +1,11 @@
-name: Build and publish docs
+name: Documentation - Build and publish
 
 on:
   # required to enable manual triggers on the GH web ui
   workflow_dispatch:
   workflow_run:
     workflows:
-      - Link checker
+      - Documentation - Link checker
     types:
       - completed
 
@@ -29,17 +29,17 @@ jobs:
       id: filter
       with:
         filters: |
-          changes:
+          docs_changes:
             - 'docs/**'
 
     - name: Set up Python 3.11
-      if: steps.filter.outputs.changes == 'true'
+      if: steps.filter.outputs.docs_changes == 'true'
       uses: actions/setup-python@v5
       with:
         python-version: "3.11"
 
     - name: Set up environment
-      if: steps.filter.outputs.changes == 'true'
+      if: steps.filter.outputs.docs_changes == 'true'
       id: setup
       run: |
         curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -48,7 +48,7 @@ jobs:
       continue-on-error: false
 
     - name: Install docs dependencies
-      if: steps.filter.outputs.changes == 'true'
+      if: steps.filter.outputs.docs_changes == 'true'
       id: install_build_dependencies
       run: |
         . .venv/bin/activate
@@ -56,24 +56,24 @@ jobs:
       continue-on-error: false
 
     - name: Build documentation
-      if: steps.filter.outputs.changes == 'true'
+      if: steps.filter.outputs.docs_changes == 'true'
       run: |
         . .venv/bin/activate
         cd docs
         sphinx-build source build/html
 
     - name: Set up pages
-      if: steps.filter.outputs.changes == 'true'
+      if: steps.filter.outputs.docs_changes == 'true'
       uses: actions/configure-pages@v4
 
     - name: Upload artifact
-      if: steps.filter.outputs.changes == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: steps.filter.outputs.docs_changes == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: actions/upload-pages-artifact@v3
       with:
         path: docs/build/html/
 
     - name: Deploy
-      if: steps.filter.outputs.changes == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: steps.filter.outputs.docs_changes == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: actions/deploy-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_and_publish_docs.yaml
+++ b/.github/workflows/build_and_publish_docs.yaml
@@ -4,8 +4,7 @@ on:
   # required to enable manual triggers on the GH web ui
   workflow_dispatch:
   workflow_run:
-    workflows:
-      - Documentation - Link checker
+    workflows: ["Documentation - Link checker"]
     types:
       - completed
 

--- a/.github/workflows/build_and_publish_docs.yaml
+++ b/.github/workflows/build_and_publish_docs.yaml
@@ -4,7 +4,8 @@ on:
   # required to enable manual triggers on the GH web ui
   workflow_dispatch:
   workflow_run:
-    workflows: ["Documentation - Link checker"]
+    workflows:
+      - Documentation - Link checker
     types:
       - completed
 

--- a/.github/workflows/check_links.yaml
+++ b/.github/workflows/check_links.yaml
@@ -1,4 +1,4 @@
-name: Link checker
+name: Documentation - Link checker
 
 on:
   push:
@@ -16,15 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check for modified paths
-        uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            changes:
-              - 'docs/**'
-
-      - name: Link Checker
+      - name: Check links
         if: steps.filter.outputs.changes == 'true'
         id: lychee
         uses: lycheeverse/lychee-action@v2

--- a/.github/workflows/check_links.yaml
+++ b/.github/workflows/check_links.yaml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check links
-        if: steps.filter.outputs.changes == 'true'
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:


### PR DESCRIPTION
## What's changing

Link checking needs to happen regardless as it scans the whole repo for file changes (such as on `.md`s) not just `/docs`.

When link checking completes it should trigger the docs building workflow (as it did previously). 

NOTE: the workflow that is the trigger needs to exist in `main` (the default branch) in order for this to work.

## How to test it

## Additional notes for reviewers

See: https://github.com/mozilla-ai/lumigator/pull/394

## I already...

- [ ] added some tests for any new functionality
- [ ] updated the documentation
- [ ] checked if a (backend) DB migration step was required and included it if required
