### PR TITLE
match style used in GH docs

### DIFF
--- a/.github/workflows/build_and_publish_docs.yaml
+++ b/.github/workflows/build_and_publish_docs.yaml
@@ -4,8 +4,7 @@ on:
   # required to enable manual triggers on the GH web ui
   workflow_dispatch:
   workflow_run:
-    workflows:
-      - Documentation - Link checker
+    workflows: ["Documentation - Link checker"]
     types:
       - completed
 


### PR DESCRIPTION
## What's changing

Successful completion of `Documentation - Link checker` workflow should trigger `Documentation - Build and publish`.

This PR adjusts the way the name is shown in the YAML (to match examples from the GitHub docs).

## How to test it

## Additional notes for reviewers

## I already...

- [ ] added some tests for any new functionality
- [ ] updated the documentation
- [ ] checked if a (backend) DB migration step was required and included it if required
