### PR TITLE
GHA: SDK - run unit tests only when there are changes to SDK

### DIFF
--- a/.github/workflows/test_sdk_uv.yaml
+++ b/.github/workflows/test_sdk_uv.yaml
@@ -17,13 +17,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check for modified paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            run_sdk_unit_tests:
+              - 'lumigator/python/mzai/sdk/**'
+
       - name: Install uv
+        if: steps.filter.outputs.run_sdk_unit_tests == 'true'
         uses: astral-sh/setup-uv@v3
 
       - name: Install python
+        if: steps.filter.outputs.run_sdk_unit_tests == 'true'
         run: uv python install
         working-directory: lumigator/python/mzai/sdk
 
       - name: Run tests
+        if: steps.filter.outputs.run_sdk_unit_tests == 'true'
         run: uv run pytest
         working-directory: lumigator/python/mzai/sdk


### PR DESCRIPTION
## What's changing

The `SDK unit tests - Python` job will still be triggered but will be able to exit early, and successfully if there are no changes to the sdk folder.

NOTE: Integration tests cannot be skipped using this rule as changes elsewhere in the code base need to be assured in the SDK too.

## How to test it

https://github.com/mozilla-ai/lumigator/actions/runs/11935459789/job/33266824892?pr=402#step:3:17

![image](https://github.com/user-attachments/assets/eb4347b8-0df6-4c49-840f-20ac1d456147)

## Additional notes for reviewers

## I already...

- [ ] added some tests for any new functionality
- [ ] updated the documentation
- [ ] checked if a (backend) DB migration step was required and included it if required
