### PR TITLE
Partial fix for local hanging integration tests 

### DIFF
--- a/lumigator/python/mzai/sdk/tests/conftest.py
+++ b/lumigator/python/mzai/sdk/tests/conftest.py
@@ -27,12 +27,7 @@ def mock_requests(mock_requests_response):
 
 @pytest.fixture(scope="session")
 def lumi_client() -> LumigatorClient:
-    with mock.patch("requests.request") as req_mock:
-        with mock.patch("requests.Response") as resp_mock:
-            resp_mock.status_code = 200
-            resp_mock.json = lambda: json.loads('["openai", "mistral"]')
-            req_mock.return_value = resp_mock
-            return LumigatorClient(LUMI_HOST)
+    yield LumigatorClient(LUMI_HOST)
 
 
 @pytest.fixture(scope="session")
@@ -149,6 +144,7 @@ def json_data_job_response(resources_dir) -> Path:
 def dialog_data(common_resources_dir):
     with Path.open(common_resources_dir / "dialogsum_exc.csv") as file:
         yield file
+
 
 @pytest.fixture(scope="session")
 def simple_eval_template():

--- a/lumigator/python/mzai/sdk/tests/int_test_datasets.py
+++ b/lumigator/python/mzai/sdk/tests/int_test_datasets.py
@@ -2,41 +2,42 @@
 be started prior to running these tests using
 `make start-lumigator-build`.
 """
+
 from pathlib import Path
 from time import sleep
 
+import pytest
 import requests
 from loguru import logger
 from lumigator_schemas.datasets import DatasetFormat
 from lumigator_schemas.jobs import JobEvalCreate, JobType
 
-'''
+"""
 Test the healthcheck endpoint.
-'''
+"""
+
+
 def test_sdk_healthcheck_ok(lumi_client):
-    healthy = False
-    for i in range(10):
-        try:
-            lumi_client.health.healthcheck()
-            healthy = True
-            break
-        except Exception as e:
-            print(f"failed health check, retry {i} - due to {e}")
-            sleep(1)
-    assert healthy
+    hc = lumi_client.health.healthcheck()
+    assert hc.status == "OK"
 
 
-'''
+"""
 Test the `get_datasets` endpoint.
-'''
+"""
+
+
 def test_get_datasets_remote_ok(lumi_client):
     datasets = lumi_client.datasets.get_datasets()
     assert datasets is not None
 
-'''
+
+"""
 Test a complete dataset lifecycle test: add a new dataset,
 list datasets, remove the dataset
-'''
+"""
+
+
 def test_dataset_lifecycle_remote_ok(lumi_client, dialog_data):
     datasets = lumi_client.datasets.get_datasets()
     n_initial_datasets = datasets.total
@@ -50,12 +51,14 @@ def test_dataset_lifecycle_remote_ok(lumi_client, dialog_data):
     assert n_current_datasets - n_initial_datasets == 1
 
 
-'''
+"""
 Test a complete job lifecycle test: add a new dataset,
 create a new job, run the job, get the results
-'''
+"""
+
+
 def test_job_lifecycle_remote_ok(lumi_client, dialog_data, simple_eval_template):
-    logger.info('Starting jobs lifecycle')
+    logger.info("Starting jobs lifecycle")
     datasets = lumi_client.datasets.get_datasets()
     if datasets.total > 0:
         for removed_dataset in datasets.items:
@@ -88,5 +91,5 @@ def test_job_lifecycle_remote_ok(lumi_client, dialog_data, simple_eval_template)
     logger.info(job_status)
 
     download_info = lumi_client.jobs.get_job_download(job_creation_result.id)
-    logger.info(f'getting result from {download_info.download_url}')
+    logger.info(f"getting result from {download_info.download_url}")
     requests.get(download_info.download_url, allow_redirects=True)


### PR DESCRIPTION
## What's changing

We currently don't instantiate a real Lumigator client when running integration tests for the SDK; i.e. we use a real client but then inject it with mocks which results in a mixed state for testing.  This test introduces a real client that is yielded per-session for the SDK and simplifies the healthcheck test, which now doesn't need to wait for the client to start, as it's injected on a per-session basis. 

This should address at least the `FAILED tests/int_test_datasets.py::test_sdk_healthcheck_ok - assert False` piece for local testing mentioned in this PR.  https://github.com/mozilla-ai/lumigator/issues/403

Also adds changes from the linter in the new precommit hook. 

## How to test it

1.  Get branch
2.  Bring down any existing containers
3. `make start-lumigator-build`
4. `cd lumigator/python/mzai/sdk; uv run pytest -o python_files="test_*.py int_test_*.py"`

## Additional notes for reviewers

A follow-up PR to this will be to add the instructions in "how to test it" to a separate integration test which should be located in `tests/integration` and run separately both manually via make and in CI.  

## I already...

- [X] added some tests for any new functionality
- [ ] updated the documentation
- [ ] checked if a (backend) DB migration step was required and included it if required
