### PR TITLE
Added label + title suggestion in issue template for bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
-labels: ''
+title: "[Bug]: "
+labels: ['bug']
 assignees: ''
 
 ---


### PR DESCRIPTION
## What's changing

Issue templates for bug automatically add label and a title suggestion.

## Additional notes for reviewers

I followed the docs [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms), perhaps there is some other idea we want to apply (or labels / titles we'd like to extend to features too)?
