### PR TITLE
410 notebook and documentation instructions to install schemas and sdk assume pypi

### DIFF
--- a/.github/workflows/test_notebook_integration.yaml
+++ b/.github/workflows/test_notebook_integration.yaml
@@ -28,10 +28,6 @@ jobs:
         run: uv pip install -r requirements.txt
         working-directory: notebooks
 
-      - name: Install sdk
-        run: uv pip install -e ../lumigator/python/mzai/sdk
-        working-directory: notebooks
-
       - name: Install kernel
         run: source .venv/bin/activate && python -m ipykernel install --user --name=lumigator
         working-directory: notebooks

--- a/lumigator/python/mzai/sdk/README.md
+++ b/lumigator/python/mzai/sdk/README.md
@@ -3,16 +3,16 @@
 The SDK provides the communication and validation primitives needed to contact the Lumigator itself,
 either locally or remotely.
 
-You can install the lumigator SDK  via `pip` directly or via `uv`:
+You can install the lumigator SDK  via `pip` directly or via `uv` from the cloned repository:
 
 ```bash
-pip install lumigator-sdk
+pip install -e lumigator/python/mzai/sdk
 ```
 
-or 
+or
 
 ```bash
-uv pip install lumigator-sdk
+uv pip install -e lumigator/python/mzai/sdk
 ```
 
 Now that you have the SDK installed, you can use it to communicate with Lumigator. You can run the

--- a/notebooks/requirements.txt
+++ b/notebooks/requirements.txt
@@ -1,3 +1,4 @@
+-e ../lumigator/python/mzai/sdk
 datasets==2.20.0
 ipywidgets==8.1.3
 jupyterlab==4.2.5


### PR DESCRIPTION
## What's changing
The documentation and notebooks assume we are already automatically pushing to PyPI. This is not the case, which caused this bug for a user.

This PR updates notebook requirements.txt and updates the documentation while we are changing the automatic versioning and publishing.

## How to test it
* Follow the instructions to run the notebook here.
* Run the imports cell.
* Before this PR, it would fail, as the schemas and SDK were not installed. It should now return no errors.

## Additional notes for reviewers
This is a temporary fix, since the underlying problem is not being able to do pip install lumigator-sdk, but at least we won't block folks trying Lumigator.

## I already...

- [N/A] added some tests for any new functionality 
- [x] updated the documentation
- [x] checked if a (backend) DB migration step was required and included it if required
