### PR TITLE
[backend] Expose suggested models

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,8 +12,8 @@ from pathlib import Path
 # patch the Sphinx run so that it can operate directly on the sources
 # see: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#ensuring-the-code-can-be-imported
 module_paths = [
-    Path('..', '..', 'lumigator', 'python', 'mzai', 'sdk').resolve(),
-    Path('..', '..', 'lumigator', 'python', 'mzai', 'schemas').resolve()
+    Path("..", "..", "lumigator", "python", "mzai", "sdk").resolve(),
+    Path("..", "..", "lumigator", "python", "mzai", "schemas").resolve(),
 ]
 
 for path in module_paths:
@@ -22,12 +22,12 @@ for path in module_paths:
 
 # import the modules that we want to document here to aboid the autodoc error
 # see: https://github.com/pydantic/pydantic/discussions/7763#discussioncomment-8417097
-from lumigator_sdk import jobs, lm_datasets  # noqa: F401, E402
+from lumigator_sdk import jobs, lm_datasets, models  # noqa: F401, E402
 
-project = 'Lumigator 🐊'
-copyright = '2024, Mozilla AI'
-author = 'Mozilla AI Engineering'
-release = '0.0.1'
+project = "Lumigator 🐊"
+copyright = "2024, Mozilla AI"
+author = "Mozilla AI Engineering"
+release = "0.0.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -38,7 +38,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "myst_parser",
     "sphinx_design",
-    "sphinx_copybutton"
+    "sphinx_copybutton",
 ]
 
 # napoleon settings
@@ -49,9 +49,9 @@ myst_enable_extensions = [
     "colon_fence",
 ]
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 source_suffix = [".rst", ".md"]
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 copybutton_exclude = ".linenos, .gp, .go"
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/get-started/suggested-models.md
+++ b/docs/source/get-started/suggested-models.md
@@ -1,0 +1,187 @@
+# Suggested Models
+
+Lumigator supports any model uploaded to the [Hugging Face Hub](https://huggingface.co/models?pipeline_tag=summarization&sort=trending)
+and trained for *summarization*, provided the model is compatible with the required library versions
+(e.g., Transformers) and runtime dependencies (e.g., vLLM). Practical factors such as compute
+availability and system configurations may also impact the successful use of a model. To get
+started, [we have extensively tested a few models](https://blog.mozilla.ai/on-model-selection-for-text-summarization/)
+and created an endpoint to easily retrieve them.
+
+In this guide, we assume that you have already [installed Lumigator locally](quickstart), and have a
+running instance. To get a list of suggested models, you can use the following command:
+
+::::{tab-set}
+
+:::{tab-item} cURL
+:sync: tab1
+
+```console
+user@host:~/lumigator$ curl -s http://localhost:8000/api/v1/models/summarization | jq
+{
+  "total": 9,
+  "items": [
+    {
+      "name": "facebook/bart-large-cnn",
+      "uri": "hf://facebook/bart-large-cnn",
+      "description": "BART is a large-sized model fine-tuned on the CNN Daily Mail dataset.",
+      "info": {
+        "parameter_count": "406M",
+        "tensor_type": "F32",
+        "model_size": "1.63GB"
+      },
+      "tasks": [
+        {
+          "summarization": {
+...
+```
+
+:::
+
+:::{tab-item} Python SDK
+:sync: tab2
+```python
+from lumigator_sdk.lumigator import LumigatorClient
+
+# The default port for Lumigator is 8000
+lm_client = LumigatorClient("localhost:8000")
+lm_client.models.get_suggested_models("summarization")
+```
+:::
+
+::::
+
+```{note}
+Note that the default port for Lumigator is `8000`. If you are running Lumigator on a different
+port, you should replace `8000` with the correct port number.
+```
+
+The output will show a list of suggested models we have tested. The `uri` field is the one you
+should use when creating a new evaluation job. The response also includes other useful information,
+such the model size and the default parameters used for evaluation. These fields are not applicable
+to every model, but they are included for the ones we have tested.
+
+## Model Types and Parameters
+
+The following table shows the models we have tested and their respective types.
+The `HuggingFace` column shows if the model is on the Hugging Face Hub, `API` indicates availability
+via an external API, and `llamafile` shows if it is distributed as a
+[llamafile](https://github.com/Mozilla-Ocho/llamafile).
+
+```{note}
+Please note we do not, at present, launch a llamafile for you, Lumigator assumes you have already
+launched it.
+```
+
+| Model Type | Model                                    | HuggingFace | API | llamafile |
+|------------|------------------------------------------|-------------|-----|-----------|
+| seq2seq    | facebook/bart-large-cnn                  |      X      |     |           |
+| seq2seq    | longformer-qmsum-meeting-summarization   |      X      |     |           |
+| seq2seq    | mrm8488/t5-base-finetuned-summarize-news |      X      |     |           |
+| seq2seq    | Falconsai/text_summarization             |      X      |     |           |
+| causal     | gpt-4o-mini, gpt-4o                      |             |  X  |           |
+| causal     | open-mistral-7b                          |             |  X  |           |
+| causal     | Mistral-7B-Instruct                      |             |     |     X     |
+
+## Bart Large CNN
+
+The [`facebook/bart-large-cnn`](https://huggingface.co/facebook/bart-large-cnn) model is pre-trained
+on English language, and fine-tuned on [CNN Daily Mail](https://huggingface.co/datasets/cnn_dailymail).
+It was introduced in the paper
+[BART: Denoising Sequence-to-Sequence Pre-training for Natural Language Generation, Translation, and Comprehension](https://arxiv.org/abs/1910.13461)
+by Lewis et al. and first released [here](https://github.com/pytorch/fairseq/tree/master/examples/bart).
+
+The model has 406M parameters (FP32), and the model size is 1.63GB. The default parameters used for
+evaluation are:
+
+| Parameter Name         | Description                                            | Value |
+|------------------------|--------------------------------------------------------|-------|
+| `max_length`           | Maximum length of the summary                          | 142   |
+| `min_length`           | Minimum length of the summary                          | 56    |
+| `length_penalty`       | Length penalty to apply during beam search             | 2.0   |
+| `early_stopping`       | Controls the stopping condition for beam-based methods | true  |
+| `no_repeat_ngram_size` | All n-grams of that size can only occur once           | 3     |
+| `num_beams`            | Number of beams for beam search                        | 4     |
+
+## Longformer QMSum Meeting Summarization
+
+The [`longformer-qmsum-meeting-summarization`](https://huggingface.co/mikeadimech/longformer-qmsum-meeting-summarization)
+model is a fine-tuned version of [alenai/led-base-16384](https://huggingface.co/allenai/led-base-16384)
+for summarization.
+
+As described in [Longformer: The Long-Document Transformer](https://arxiv.org/pdf/2004.05150.pdf) by
+Iz Beltagy, Matthew E. Peters, Arman Cohan, `led-base-16384` was initialized from `bart-base` since
+both models share the exact same architecture, but modified for long-range summarization and
+question answering.
+
+The model has 162M parameters (FP32), and the model size is 648MB. There are no
+summarization-specific parameters for this model.
+
+## T5 Base Finetuned Summarize News
+
+The [`mrm8488/t5-base-finetuned-summarize-news`](https://huggingface.co/mrm8488/t5-base-finetuned-summarize-news)
+model is a [Google's T5](https://ai.googleblog.com/2020/02/exploring-transfer-learning-with-t5.html)
+base fine-tuned on [News Summary](https://www.kaggle.com/sunnysai12345/news-summary) dataset for
+summarization downstream task.
+
+The model has 223M parameters (FP32), and the model size is 892MB. The default parameters used for
+evaluation are:
+
+| Parameter Name         | Description                                            | Value |
+|------------------------|--------------------------------------------------------|-------|
+| `max_length`           | Maximum length of the summary                          | 200   |
+| `min_length`           | Minimum length of the summary                          | 30    |
+| `length_penalty`       | Length penalty to apply during beam search             | 2.0   |
+| `early_stopping`       | Controls the stopping condition for beam-based methods | true  |
+| `no_repeat_ngram_size` | All n-grams of that size can only occur once           | 3     |
+| `num_beams`            | Number of beams for beam search                        | 4     |
+
+## Falconsai Text Summarization
+
+The [`Falconsai/text_summarization`](https://huggingface.co/Falconsai/text_summarization) model is
+a variant of the T5 transformer model, designed for the task of text summarization. It is adapted
+and fine-tuned to generate concise and coherent summaries of input text.
+
+The model has 60.5M parameters (FP32), and the model size is 242MB. The default parameters used for
+evaluation are:
+
+| Parameter Name         | Description                                            | Value |
+|------------------------|--------------------------------------------------------|-------|
+| `max_length`           | Maximum length of the summary                          | 200   |
+| `min_length`           | Minimum length of the summary                          | 30    |
+| `length_penalty`       | Length penalty to apply during beam search             | 2.0   |
+| `early_stopping`       | Controls the stopping condition for beam-based methods | true  |
+| `no_repeat_ngram_size` | All n-grams of that size can only occur once           | 3     |
+| `num_beams`            | Number of beams for beam search                        | 4     |
+
+## Mistral 7B Instruct
+
+The [mistralai/Mistral-7B-Instruct-v0.3]https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3)
+Large Language Model (LLM) is an instruct fine-tuned version of the
+[Mistral-7B-v0.3](https://huggingface.co/mistralai/Mistral-7B-v0.3).
+
+The model has 7.25B parameters (BF16), and the model size is 14.5GB. There are no
+summarization-specific parameters for this model.
+
+## GPT-4o Mini and GPT-4o
+
+The GPT-4o Mini and GPT-4o models are causal language models developed by OpenAI.
+
+There are no summarization-specific parameters for these models.
+
+## Open Mistral 7B
+
+The [Open Mistral 7B](https://mistral.ai/news/announcing-mistral-7b/) model is a causal language
+model developed by [Mistral AI](https://mistral.ai/). It is the smaller version of the
+Mistal AI family of models.
+
+There are no summarization-specific parameters for this model.
+
+## Mistral 7B Instruct Llamafile
+
+The [mistralai/Mistral-7B-Instruct-v0.2](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2)
+model is a causal language model developed by [Mistral AI](https://mistral.ai/), packaged as a
+llamafile. A llamafile is an executable LLM that you can run on your own computer. It contains the
+weights for a given open LLM, as well as everything needed to actually run that model on your
+computer. There's nothing to install or configure.
+
+There are no summarization-specific parameters for this model.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,6 +36,7 @@ Hugging Face and local stores or accessed through APIs. It consists of:
 
    get-started/installation
    get-started/quickstart
+   get-started/suggested-models
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/reference/schemas.rst
+++ b/docs/source/reference/schemas.rst
@@ -1,14 +1,14 @@
 Schemas
 =======
 
-.. automodule:: schemas.completions
+.. automodule:: lumigator_schemas.completions
    :members:
 
-.. automodule:: schemas.datasets
+.. automodule:: lumigator_schemas.datasets
    :members:
 
-.. automodule:: schemas.jobs
+.. automodule:: lumigator_schemas.jobs
    :members:
 
-.. automodule:: schemas.extras
+.. automodule:: lumigator_schemas.extras
    :members:

--- a/docs/source/reference/sdk.rst
+++ b/docs/source/reference/sdk.rst
@@ -11,7 +11,7 @@ Lumigator Client
 The main entry point to the SDK is the `LumigatorClient` class. You can create an instance of this
 class by providing the Lumigator API host and your Ray cluster address.
 
-.. automodule:: sdk.lumigator
+.. automodule:: lumigator_sdk.lumigator
    :members:
    :undoc-members:
 
@@ -21,7 +21,7 @@ Health
 The `Health` class provides a simple interface to check the health of the Lumigator API and the
 status of the Ray jobs running on the cluster.
 
-.. automodule:: sdk.health
+.. automodule:: lumigator_sdk.health
    :members:
    :undoc-members:
 
@@ -30,7 +30,7 @@ Datasets
 
 The `Datasets` class provides a simple interface to create, update, delete, and list datasets.
 
-.. automodule:: sdk.lm_datasets
+.. automodule:: lumigator_sdk.lm_datasets
    :members:
    :undoc-members:
 
@@ -40,7 +40,7 @@ Jobs
 The `Jobs` class provides a simple interface to submit and monitor jobs. Currently, we support two
 types of jobs: Inference and Evaluation.
 
-.. automodule:: sdk.jobs
+.. automodule:: lumigator_sdk.jobs
    :members:
    :undoc-members:
 
@@ -50,7 +50,7 @@ Completions
  The `Completions` class provides a simple interface to request completions from external APIs.
  Currently, we support two APIs: OpenAI's and Mistral's.
 
-.. automodule:: sdk.completions
+.. automodule:: lumigator_sdk.completions
    :members:
    :undoc-members:
 
@@ -60,6 +60,6 @@ Base Client
 The `BaseClient` class provides a base class for the LumigatorClient. You can use this class to
 create your own client with custom methods.
 
-.. automodule:: sdk.client
+.. automodule:: lumigator_sdk.client
    :members:
    :undoc-members:

--- a/lumigator/python/mzai/backend/backend/api/router.py
+++ b/lumigator/python/mzai/backend/backend/api/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from backend.api.routes import completions, datasets, experiments, health, jobs
+from backend.api.routes import completions, datasets, experiments, health, jobs, models
 from backend.api.tags import Tags
 
 API_V1_PREFIX = "/api/v1"
@@ -11,3 +11,4 @@ api_router.include_router(datasets.router, prefix="/datasets", tags=[Tags.DATASE
 api_router.include_router(jobs.router, prefix="/jobs", tags=[Tags.JOBS])
 api_router.include_router(experiments.router, prefix="/experiments", tags=[Tags.EXPERIMENTS])
 api_router.include_router(completions.router, prefix="/completions", tags=[Tags.COMPLETIONS])
+api_router.include_router(models.router, prefix="/models", tags=[Tags.MODELS])

--- a/lumigator/python/mzai/backend/backend/api/routes/models.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/models.py
@@ -1,64 +1,11 @@
+from pathlib import Path
+
+import yaml
 from fastapi import APIRouter, HTTPException
 from lumigator_schemas.extras import ListingResponse
 
 SUPPORTED_TASKS = ["summarization"]
-
-SUGGESTED_MODELS = [
-    {
-        "name:": "facebook/bart-large-cnn",
-        "uri": "hf://facebook/bart-large-cnn",
-        "description": "BART is a large-sized model fine-tuned on the CNN Daily Mail dataset.",
-    },
-    {
-        "name": "mikeadimech/longformer-qmsum-meeting-summarization",
-        "uri": "hf://mikeadimech/longformer-qmsum-meeting-summarization",
-        "description": (
-            "Longformer is a transformer model that is capable of processing long sequences."
-        ),
-    },
-    {
-        "name": "mrm8488/t5-base-finetuned-summarize-news",
-        "uri": "hf://mrm8488/t5-base-finetuned-summarize-news",
-        "description": (
-            "Google's T5 base fine-tuned on News Summary dataset for summarization downstream task."
-        ),
-    },
-    {
-        "name": "Falconsai/text_summarization",
-        "uri": "hf://Falconsai/text_summarization",
-        "description": (
-            "A fine-tuned variant of the T5 transformer model, designed for the task "
-            "of text summarization."
-        ),
-    },
-    {
-        "name": "mistralai/Mistral-7B-Instruct-v0.3",
-        "uri": "hf://mistralai/Mistral-7B-Instruct-v0.3",
-        "description": (
-            "Mistral-7B-Instruct-v0.3 is an instruct fine-tuned version of the Mistral-7B-v0.3."
-        ),
-    },
-    {
-        "name": "gpt-4o-mini",
-        "uri": "oai://gpt-4o-mini",
-        "description": "OpenAI's GPT-4o-mini model.",
-    },
-    {
-        "name": "gpt-4-turbo",
-        "uri": "oai://gpt-4-turbo",
-        "description": "OpenAI's GPT-4 Turbo model.",
-    },
-    {
-        "name": "open-mistral-7b",
-        "uri": "mistral://open-mistral-7b",
-        "description": "Mistral's 7B model.",
-    },
-    {
-        "name": "mistralai/Mistral-7B-Instruct-v0.2",
-        "uri": "llamafile://mistralai/Mistral-7B-Instruct-v0.2",
-        "description": "A llamafile package of Mistral's 7B Instruct model.",
-    },
-]
+MODELS_PATH = Path(__file__).resolve().parents[2] / "models.yaml"
 
 router = APIRouter()
 
@@ -80,8 +27,11 @@ def get_suggested_models(task_name: str) -> ListingResponse[dict]:
             detail=f"Unsupported task. Choose from: {SUPPORTED_TASKS}",
         )
 
+    with Path(MODELS_PATH).open() as file:
+        data = yaml.safe_load(file)
+
     return_data = {
-        "total": len(SUGGESTED_MODELS),
-        "items": SUGGESTED_MODELS,
+        "total": len(data),
+        "items": data,
     }
     return ListingResponse[dict].model_validate(return_data)

--- a/lumigator/python/mzai/backend/backend/api/routes/models.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/models.py
@@ -4,10 +4,18 @@ import yaml
 from fastapi import APIRouter, HTTPException
 from lumigator_schemas.extras import ListingResponse
 
-SUPPORTED_TASKS = ["summarization"]
 MODELS_PATH = Path(__file__).resolve().parents[2] / "models.yaml"
 
 router = APIRouter()
+
+
+def _get_supported_tasks(data: dict) -> list[str]:
+    tasks = set()
+    for model in data:
+        for task in model.get("tasks", []):
+            tasks.update(task.keys())
+
+    return list(tasks)
 
 
 @router.get("/{task_name}")
@@ -20,15 +28,17 @@ def get_suggested_models(task_name: str) -> ListingResponse[dict]:
     Returns:
         ListingResponse[str]: A list of suggested models.
     """
+    with Path(MODELS_PATH).open() as file:
+        data = yaml.safe_load(file)
+
+    supported_tasks = _get_supported_tasks(data)
+
     # Currently, only summarization task is supported.
     if task_name != "summarization":
         raise HTTPException(
             status_code=400,
-            detail=f"Unsupported task. Choose from: {SUPPORTED_TASKS}",
+            detail=f"Unsupported task. Choose from: {supported_tasks}",
         )
-
-    with Path(MODELS_PATH).open() as file:
-        data = yaml.safe_load(file)
 
     return_data = {
         "total": len(data),

--- a/lumigator/python/mzai/backend/backend/api/routes/models.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/models.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import yaml
 from fastapi import APIRouter, HTTPException
 from lumigator_schemas.extras import ListingResponse
+from lumigator_schemas.models import ModelsResponse
 
 MODELS_PATH = Path(__file__).resolve().parents[2] / "models.yaml"
 
@@ -19,7 +20,7 @@ def _get_supported_tasks(data: dict) -> list[str]:
 
 
 @router.get("/{task_name}")
-def get_suggested_models(task_name: str) -> ListingResponse[dict]:
+def get_suggested_models(task_name: str) -> ListingResponse[ModelsResponse]:
     """Get a list of suggested models for the given task.
 
     Args:
@@ -44,4 +45,4 @@ def get_suggested_models(task_name: str) -> ListingResponse[dict]:
         "total": len(data),
         "items": data,
     }
-    return ListingResponse[dict].model_validate(return_data)
+    return ListingResponse[ModelsResponse].model_validate(return_data)

--- a/lumigator/python/mzai/backend/backend/api/routes/models.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/models.py
@@ -1,0 +1,87 @@
+from fastapi import APIRouter, HTTPException
+from lumigator_schemas.extras import ListingResponse
+
+SUPPORTED_TASKS = ["summarization"]
+
+SUGGESTED_MODELS = [
+    {
+        "name:": "facebook/bart-large-cnn",
+        "uri": "hf://facebook/bart-large-cnn",
+        "description": "BART is a large-sized model fine-tuned on the CNN Daily Mail dataset.",
+    },
+    {
+        "name": "mikeadimech/longformer-qmsum-meeting-summarization",
+        "uri": "hf://mikeadimech/longformer-qmsum-meeting-summarization",
+        "description": (
+            "Longformer is a transformer model that is capable of processing long sequences."
+        ),
+    },
+    {
+        "name": "mrm8488/t5-base-finetuned-summarize-news",
+        "uri": "hf://mrm8488/t5-base-finetuned-summarize-news",
+        "description": (
+            "Google's T5 base fine-tuned on News Summary dataset for summarization downstream task."
+        ),
+    },
+    {
+        "name": "Falconsai/text_summarization",
+        "uri": "hf://Falconsai/text_summarization",
+        "description": (
+            "A fine-tuned variant of the T5 transformer model, designed for the task "
+            "of text summarization."
+        ),
+    },
+    {
+        "name": "mistralai/Mistral-7B-Instruct-v0.3",
+        "uri": "hf://mistralai/Mistral-7B-Instruct-v0.3",
+        "description": (
+            "Mistral-7B-Instruct-v0.3 is an instruct fine-tuned version of the Mistral-7B-v0.3."
+        ),
+    },
+    {
+        "name": "gpt-4o-mini",
+        "uri": "oai://gpt-4o-mini",
+        "description": "OpenAI's GPT-4o-mini model.",
+    },
+    {
+        "name": "gpt-4-turbo",
+        "uri": "oai://gpt-4-turbo",
+        "description": "OpenAI's GPT-4 Turbo model.",
+    },
+    {
+        "name": "open-mistral-7b",
+        "uri": "mistral://open-mistral-7b",
+        "description": "Mistral's 7B model.",
+    },
+    {
+        "name": "mistralai/Mistral-7B-Instruct-v0.2",
+        "uri": "llamafile://mistralai/Mistral-7B-Instruct-v0.2",
+        "description": "A llamafile package of Mistral's 7B Instruct model.",
+    },
+]
+
+router = APIRouter()
+
+
+@router.get("/{task_name}")
+def get_suggested_models(task_name: str) -> ListingResponse[dict]:
+    """Get a list of suggested models for the given task.
+
+    Args:
+        task_name (str): The task name.
+
+    Returns:
+        ListingResponse[str]: A list of suggested models.
+    """
+    # Currently, only summarization task is supported.
+    if task_name != "summarization":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported task. Choose from: {SUPPORTED_TASKS}",
+        )
+
+    return_data = {
+        "total": len(SUGGESTED_MODELS),
+        "items": SUGGESTED_MODELS,
+    }
+    return ListingResponse[dict].model_validate(return_data)

--- a/lumigator/python/mzai/backend/backend/api/tags.py
+++ b/lumigator/python/mzai/backend/backend/api/tags.py
@@ -7,6 +7,7 @@ class Tags(str, Enum):
     JOBS = "jobs"
     COMPLETIONS = "completions"
     EXPERIMENTS = "experiments"
+    MODELS = "models"
 
 
 TAGS_METADATA = [
@@ -29,6 +30,10 @@ TAGS_METADATA = [
     {
         "name": Tags.COMPLETIONS,
         "description": "Access models via external vendor endpoints",
+    },
+    {
+        "name": Tags.MODELS,
+        "description": "Return a list of suggested models for a given task.",
     },
 ]
 """Metadata to associate with route tags in the OpenAPI documentation.

--- a/lumigator/python/mzai/backend/backend/models.yaml
+++ b/lumigator/python/mzai/backend/backend/models.yaml
@@ -1,0 +1,35 @@
+- name: facebook/bart-large-cnn
+  uri: hf://facebook/bart-large-cnn
+  description: BART is a large-sized model fine-tuned on the CNN Daily Mail dataset.
+
+- name: mikeadimech/longformer-qmsum-meeting-summarization
+  uri: hf://mikeadimech/longformer-qmsum-meeting-summarization
+  description: Longformer is a transformer model that is capable of processing long sequences.
+
+- name: mrm8488/t5-base-finetuned-summarize-news
+  uri: hf://mrm8488/t5-base-finetuned-summarize-news
+  description: Google's T5 base fine-tuned on News Summary dataset for summarization downstream task.
+
+- name: Falconsai/text_summarization
+  uri: hf://Falconsai/text_summarization
+  description: A fine-tuned variant of the T5 transformer model, designed for the task of text summarization.
+
+- name: mistralai/Mistral-7B-Instruct-v0.3
+  uri: hf://mistralai/Mistral-7B-Instruct-v0.3
+  description: Mistral-7B-Instruct-v0.3 is an instruct fine-tuned version of the Mistral-7B-v0.3.
+
+- name: gpt-4o-mini
+  uri: oai://gpt-4o-mini
+  description: OpenAI's GPT-4o-mini model.
+
+- name: gpt-4-turbo
+  uri: oai://gpt-4-turbo
+  description: OpenAI's GPT-4 Turbo model.
+
+- name: open-mistral-7b
+  uri: mistral://open-mistral-7b
+  description: Mistral's 7B model.
+
+- name: mistralai/Mistral-7B-Instruct-v0.2
+  uri: llamafile://mistralai/Mistral-7B-Instruct-v0.2
+  description: A llamafile package of Mistral's 7B Instruct model.

--- a/lumigator/python/mzai/backend/backend/models.yaml
+++ b/lumigator/python/mzai/backend/backend/models.yaml
@@ -22,9 +22,9 @@
   uri: oai://gpt-4o-mini
   description: OpenAI's GPT-4o-mini model.
 
-- name: gpt-4-turbo
-  uri: oai://gpt-4-turbo
-  description: OpenAI's GPT-4 Turbo model.
+- name: gpt-4o
+  uri: oai://gpt-4o
+  description: OpenAI's GPT-4o model.
 
 - name: open-mistral-7b
   uri: mistral://open-mistral-7b

--- a/lumigator/python/mzai/backend/backend/models.yaml
+++ b/lumigator/python/mzai/backend/backend/models.yaml
@@ -1,35 +1,95 @@
 - name: facebook/bart-large-cnn
   uri: hf://facebook/bart-large-cnn
   description: BART is a large-sized model fine-tuned on the CNN Daily Mail dataset.
+  info:
+    parameter_count: 406M
+    tensor_type: F32
+    model_size: 1.63GB
+  tasks:
+    - summarization:
+        max_length: 142
+        min_length: 56
+        length_penalty: 2.0
+        early_stopping: true
+        no_repeat_ngram_size: 3
+        num_beams: 4
 
 - name: mikeadimech/longformer-qmsum-meeting-summarization
   uri: hf://mikeadimech/longformer-qmsum-meeting-summarization
   description: Longformer is a transformer model that is capable of processing long sequences.
+  info:
+    parameter_count: 162M
+    tensor_type: F32
+    model_size: 648MB
+  tasks:
+    - summarization:
 
 - name: mrm8488/t5-base-finetuned-summarize-news
   uri: hf://mrm8488/t5-base-finetuned-summarize-news
   description: Google's T5 base fine-tuned on News Summary dataset for summarization downstream task.
+  info:
+    parameter_count: 223M
+    tensor_type: F32
+    model_size: 892MB
+  tasks:
+    - summarization:
+        max_length: 200
+        min_length: 30
+        length_penalty: 2.0
+        early_stopping: true
+        no_repeat_ngram_size: 3
+        num_beams: 4
 
 - name: Falconsai/text_summarization
   uri: hf://Falconsai/text_summarization
   description: A fine-tuned variant of the T5 transformer model, designed for the task of text summarization.
+  info:
+    parameter_count: 60.5M
+    tensor_type: F32
+    model_size: 242MB
+  tasks:
+    - summarization:
+        max_length: 200
+        min_length: 30
+        length_penalty: 2.0
+        early_stopping: true
+        no_repeat_ngram_size: 3
+        num_beams: 4
 
 - name: mistralai/Mistral-7B-Instruct-v0.3
   uri: hf://mistralai/Mistral-7B-Instruct-v0.3
   description: Mistral-7B-Instruct-v0.3 is an instruct fine-tuned version of the Mistral-7B-v0.3.
+  info:
+    parameter_count: 7.25B
+    tensor_type: BF16
+    model_size: 14.5GB
+  tasks:
+    - summarization:
 
 - name: gpt-4o-mini
   uri: oai://gpt-4o-mini
   description: OpenAI's GPT-4o-mini model.
+  tasks:
+    - summarization:
 
 - name: gpt-4o
   uri: oai://gpt-4o
   description: OpenAI's GPT-4o model.
+  tasks:
+    - summarization:
 
 - name: open-mistral-7b
   uri: mistral://open-mistral-7b
   description: Mistral's 7B model.
+  tasks:
+    - summarization:
 
 - name: mistralai/Mistral-7B-Instruct-v0.2
   uri: llamafile://mistralai/Mistral-7B-Instruct-v0.2
   description: A llamafile package of Mistral's 7B Instruct model.
+  info:
+    parameter_count: 7.24B
+    tensor_type: BF16
+    model_size: 14.5GB
+  tasks:
+    - summarization:

--- a/lumigator/python/mzai/backend/backend/tests/api/routes/test_models.py
+++ b/lumigator/python/mzai/backend/backend/tests/api/routes/test_models.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from lumigator_schemas.extras import ListingResponse
+from lumigator_schemas.models import ModelsResponse
+
+from backend.api.routes.models import _get_supported_tasks
+
+
+def test_get_suggested_models_summarization_ok(app_client: TestClient, json_data_models: Path):
+    response = app_client.get("/models/summarization")
+    assert response.status_code == 200
+    models = ListingResponse[ModelsResponse].model_validate(response.json())
+
+    with Path(json_data_models).open() as file:
+        data = json.load(file)
+
+    assert models.total == data["total"]
+
+
+def test_get_suggested_models_invalid_task(app_client: TestClient, json_data_models: Path):
+    response = app_client.get("/models/invalid_task")
+    assert response.status_code == 400
+
+    with Path(json_data_models).open() as file:
+        data = json.load(file)
+
+    supported_tasks = _get_supported_tasks(data.get("items", []))
+
+    assert response.json() == {"detail": f"Unsupported task. Choose from: {supported_tasks}"}

--- a/lumigator/python/mzai/backend/backend/tests/conftest.py
+++ b/lumigator/python/mzai/backend/backend/tests/conftest.py
@@ -27,6 +27,7 @@ from backend.tests.fakes.fake_ray_client import FakeJobSubmissionClient
 
 # TODO: Break tests into "unit" and "integration" folders based on fixture dependencies
 
+
 def common_resources_dir() -> Path:
     return Path(__file__).parent.parent.parent.parent
 
@@ -38,6 +39,7 @@ def format_dataset(data: list[list[str]]) -> str:
     buffer.seek(0)
     return buffer.read()
 
+
 @pytest.fixture
 def valid_experiment_dataset() -> str:
     data = [
@@ -45,6 +47,7 @@ def valid_experiment_dataset() -> str:
         ["Hello World", "Hello"],
     ]
     return format_dataset(data)
+
 
 @pytest.fixture(scope="session")
 def valid_experiment_dataset_without_gt() -> str:
@@ -78,6 +81,7 @@ def dialog_dataset():
     filename = common_resources_dir() / "sample_data" / "dialogsum_exc.csv"
     with Path(filename).open("rb") as f:
         yield f
+
 
 @pytest.fixture(scope="session", autouse=True)
 def db_engine():
@@ -127,10 +131,10 @@ def setup_aws(localstack_container: LocalStackContainer):
             raise e
     # add ENV vars for FSSPEC access to S3 (s3fs + HuggingFace datasets)
     os.environ["FSSPEC_S3_KEY"] = "testcontainers-localstack"
-    os.environ["FSSPEC_S3_SECRET"] = "testcontainers-localstack" # pragma: allowlist secret
+    os.environ["FSSPEC_S3_SECRET"] = "testcontainers-localstack"  # pragma: allowlist secret
     os.environ["FSSPEC_S3_ENDPOINT_URL"] = localstack_container.get_url()
     os.environ["AWS_ACCESS_KEY_ID"] = "testcontainers-localstack"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testcontainers-localstack" # pragma: allowlist secret
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testcontainers-localstack"  # pragma: allowlist secret
     os.environ["AWS_ENDPOINT_URL"] = localstack_container.get_url()
 
 
@@ -154,12 +158,14 @@ def app():
     app = create_app()
     return app
 
+
 @pytest.fixture(scope="function")
 def app_client(app: FastAPI):
     """Create a test client for calling the FastAPI app."""
     base_url = f"http://dev{API_V1_PREFIX}"  # Fake base URL for the app
     with TestClient(app, base_url=base_url) as c:
         yield c
+
 
 @pytest.fixture(scope="function")
 def local_client(app: FastAPI):
@@ -185,44 +191,61 @@ def dependency_overrides(app: FastAPI, db_session: Session, s3_client: S3Client)
     app.dependency_overrides[get_db_session] = get_db_session_override
     app.dependency_overrides[get_s3_client] = get_s3_client_override
 
+
 @pytest.fixture(scope="session")
 def resources_dir() -> Path:
     return Path(__file__).parent / "data"
+
+
+@pytest.fixture(scope="session")
+def json_data_models(resources_dir) -> Path:
+    return resources_dir / "models.json"
+
 
 @pytest.fixture(scope="session")
 def json_data_health_job_metadata_ok(resources_dir) -> Path:
     return resources_dir / "health_job_metadata.json"
 
+
 @pytest.fixture(scope="session")
 def json_data_health_job_metadata_ray(resources_dir) -> Path:
     return resources_dir / "health_job_metadata_ray.json"
+
 
 @pytest.fixture(scope="function")
 def request_mock() -> requests_mock.Mocker:
     with requests_mock.Mocker() as cm:
         yield cm
 
+
 @pytest.fixture(scope="function")
 def job_repository(db_session):
     return JobRepository(session=db_session)
+
 
 @pytest.fixture(scope="function")
 def result_repository(db_session):
     return JobResultRepository(session=db_session)
 
+
 @pytest.fixture(scope="function")
 def fake_ray_client():
     return FakeJobSubmissionClient()
 
+
 @pytest.fixture(scope="function")
 def dataset_service(db_session):
     dataset_repo = DatasetRepository(db_session)
-    return DatasetService(dataset_repo=dataset_repo,s3_client=s3_client, s3_filesystem=S3FileSystem())
+    return DatasetService(
+        dataset_repo=dataset_repo, s3_client=s3_client, s3_filesystem=S3FileSystem()
+    )
+
 
 @pytest.fixture(scope="function")
 def job_record(db_session):
     return JobRecord
 
+
 @pytest.fixture(scope="function")
-def job_service(db_session, job_repository, result_repository,fake_ray_client,dataset_service):
-    return JobService(job_repository, result_repository,fake_ray_client, dataset_service)
+def job_service(db_session, job_repository, result_repository, fake_ray_client, dataset_service):
+    return JobService(job_repository, result_repository, fake_ray_client, dataset_service)

--- a/lumigator/python/mzai/backend/backend/tests/data/models.json
+++ b/lumigator/python/mzai/backend/backend/tests/data/models.json
@@ -1,0 +1,149 @@
+{
+    "total": 9,
+    "items": [
+      {
+        "name": "facebook/bart-large-cnn",
+        "uri": "hf://facebook/bart-large-cnn",
+        "description": "BART is a large-sized model fine-tuned on the CNN Daily Mail dataset.",
+        "info": {
+          "parameter_count": "406M",
+          "tensor_type": "F32",
+          "model_size": "1.63GB"
+        },
+        "tasks": [
+          {
+            "summarization": {
+              "max_length": 142,
+              "min_length": 56,
+              "length_penalty": 2,
+              "early_stopping": true,
+              "no_repeat_ngram_size": 3,
+              "num_beams": 4
+            }
+          }
+        ]
+      },
+      {
+        "name": "mikeadimech/longformer-qmsum-meeting-summarization",
+        "uri": "hf://mikeadimech/longformer-qmsum-meeting-summarization",
+        "description": "Longformer is a transformer model that is capable of processing long sequences.",
+        "info": {
+          "parameter_count": "162M",
+          "tensor_type": "F32",
+          "model_size": "648MB"
+        },
+        "tasks": [
+          {
+            "summarization": null
+          }
+        ]
+      },
+      {
+        "name": "mrm8488/t5-base-finetuned-summarize-news",
+        "uri": "hf://mrm8488/t5-base-finetuned-summarize-news",
+        "description": "Google's T5 base fine-tuned on News Summary dataset for summarization downstream task.",
+        "info": {
+          "parameter_count": "223M",
+          "tensor_type": "F32",
+          "model_size": "892MB"
+        },
+        "tasks": [
+          {
+            "summarization": {
+              "max_length": 200,
+              "min_length": 30,
+              "length_penalty": 2,
+              "early_stopping": true,
+              "no_repeat_ngram_size": 3,
+              "num_beams": 4
+            }
+          }
+        ]
+      },
+      {
+        "name": "Falconsai/text_summarization",
+        "uri": "hf://Falconsai/text_summarization",
+        "description": "A fine-tuned variant of the T5 transformer model, designed for the task of text summarization.",
+        "info": {
+          "parameter_count": "60.5M",
+          "tensor_type": "F32",
+          "model_size": "242MB"
+        },
+        "tasks": [
+          {
+            "summarization": {
+              "max_length": 200,
+              "min_length": 30,
+              "length_penalty": 2,
+              "early_stopping": true,
+              "no_repeat_ngram_size": 3,
+              "num_beams": 4
+            }
+          }
+        ]
+      },
+      {
+        "name": "mistralai/Mistral-7B-Instruct-v0.3",
+        "uri": "hf://mistralai/Mistral-7B-Instruct-v0.3",
+        "description": "Mistral-7B-Instruct-v0.3 is an instruct fine-tuned version of the Mistral-7B-v0.3.",
+        "info": {
+          "parameter_count": "7.25B",
+          "tensor_type": "BF16",
+          "model_size": "14.5GB"
+        },
+        "tasks": [
+          {
+            "summarization": null
+          }
+        ]
+      },
+      {
+        "name": "gpt-4o-mini",
+        "uri": "oai://gpt-4o-mini",
+        "description": "OpenAI's GPT-4o-mini model.",
+        "info": null,
+        "tasks": [
+          {
+            "summarization": null
+          }
+        ]
+      },
+      {
+        "name": "gpt-4o",
+        "uri": "oai://gpt-4o",
+        "description": "OpenAI's GPT-4o model.",
+        "info": null,
+        "tasks": [
+          {
+            "summarization": null
+          }
+        ]
+      },
+      {
+        "name": "open-mistral-7b",
+        "uri": "mistral://open-mistral-7b",
+        "description": "Mistral's 7B model.",
+        "info": null,
+        "tasks": [
+          {
+            "summarization": null
+          }
+        ]
+      },
+      {
+        "name": "mistralai/Mistral-7B-Instruct-v0.2",
+        "uri": "llamafile://mistralai/Mistral-7B-Instruct-v0.2",
+        "description": "A llamafile package of Mistral's 7B Instruct model.",
+        "info": {
+          "parameter_count": "7.24B",
+          "tensor_type": "BF16",
+          "model_size": "14.5GB"
+        },
+        "tasks": [
+          {
+            "summarization": null
+          }
+        ]
+      }
+    ]
+  }

--- a/lumigator/python/mzai/schemas/lumigator_schemas/models.py
+++ b/lumigator/python/mzai/schemas/lumigator_schemas/models.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+
+
+class ModelInfo(BaseModel):
+    parameter_count: str
+    tensor_type: str
+    model_size: str
+
+
+class ModelsResponse(BaseModel):
+    name: str
+    uri: str
+    description: str
+    info: ModelInfo | None = None
+    tasks: list[dict[str, dict | None]]

--- a/lumigator/python/mzai/sdk/lumigator_sdk/lumigator.py
+++ b/lumigator/python/mzai/sdk/lumigator_sdk/lumigator.py
@@ -3,6 +3,7 @@ from lumigator_sdk.completions import Completions
 from lumigator_sdk.health import Health
 from lumigator_sdk.jobs import Jobs
 from lumigator_sdk.lm_datasets import Datasets
+from lumigator_sdk.models import Models
 
 
 class LumigatorClient:
@@ -35,3 +36,4 @@ class LumigatorClient:
         self.jobs = Jobs(self.client)
         self.health = Health(self.client)
         self.datasets = Datasets(self.client)
+        self.models = Models(self.client)

--- a/lumigator/python/mzai/sdk/lumigator_sdk/models.py
+++ b/lumigator/python/mzai/sdk/lumigator_sdk/models.py
@@ -1,0 +1,44 @@
+from lumigator_schemas.extras import ListingResponse
+from lumigator_schemas.models import ModelsResponse
+
+from lumigator_sdk.client import ApiClient
+
+
+class Models:
+    MODELS_ROUTE = "models"
+
+    def __init__(self, c: ApiClient):
+        """Construct a new instance of the Models class.
+
+        Args:
+            c (ApiClient): The API client to use for requests.
+
+        Returns:
+            Models: A new Models instance.
+        """
+        self.client = c
+
+    def get_suggested_models(self, task_name: str) -> ListingResponse[ModelsResponse]:
+        """Return information on all suggested models.
+
+        .. admonition:: Example
+
+            .. code-block:: python
+
+                from lumigator_sdk.lumigator import LumigatorClient
+
+                lm_client = LumigatorClient("localhost:8000")
+                lm_client.models.get_suggested_models("summarization")
+
+        Args:
+            task_name (str): The name of the task to get the suggested models for.
+
+        Returns:
+            ListingResponse[dic]: All suggested models.
+        """
+        response = self.client.get_response(f"{self.MODELS_ROUTE}/{task_name}")
+
+        if not response:
+            return []
+
+        return ListingResponse[ModelsResponse](**response.json())

--- a/lumigator/python/mzai/sdk/tests/conftest.py
+++ b/lumigator/python/mzai/sdk/tests/conftest.py
@@ -145,10 +145,16 @@ def json_data_job_response(resources_dir) -> Path:
     return resources_dir / "job-resp.json"
 
 
+@pytest.fixture(scope="session")
+def json_data_models(resources_dir) -> Path:
+    return resources_dir / "models.json"
+
+
 @pytest.fixture(scope="function")
 def dialog_data(common_resources_dir):
     with Path.open(common_resources_dir / "dialogsum_exc.csv") as file:
         yield file
+
 
 @pytest.fixture(scope="session")
 def simple_eval_template():

--- a/lumigator/python/mzai/sdk/tests/data/models.json
+++ b/lumigator/python/mzai/sdk/tests/data/models.json
@@ -1,0 +1,149 @@
+{
+    "total": 9,
+    "items": [
+      {
+        "name": "facebook/bart-large-cnn",
+        "uri": "hf://facebook/bart-large-cnn",
+        "description": "BART is a large-sized model fine-tuned on the CNN Daily Mail dataset.",
+        "info": {
+          "parameter_count": "406M",
+          "tensor_type": "F32",
+          "model_size": "1.63GB"
+        },
+        "tasks": [
+          {
+            "summarization": {
+              "max_length": 142,
+              "min_length": 56,
+              "length_penalty": 2,
+              "early_stopping": true,
+              "no_repeat_ngram_size": 3,
+              "num_beams": 4
+            }
+          }
+        ]
+      },
+      {
+        "name": "mikeadimech/longformer-qmsum-meeting-summarization",
+        "uri": "hf://mikeadimech/longformer-qmsum-meeting-summarization",
+        "description": "Longformer is a transformer model that is capable of processing long sequences.",
+        "info": {
+          "parameter_count": "162M",
+          "tensor_type": "F32",
+          "model_size": "648MB"
+        },
+        "tasks": [
+          {
+            "summarization": null
+          }
+        ]
+      },
+      {
+        "name": "mrm8488/t5-base-finetuned-summarize-news",
+        "uri": "hf://mrm8488/t5-base-finetuned-summarize-news",
+        "description": "Google's T5 base fine-tuned on News Summary dataset for summarization downstream task.",
+        "info": {
+          "parameter_count": "223M",
+          "tensor_type": "F32",
+          "model_size": "892MB"
+        },
+        "tasks": [
+          {
+            "summarization": {
+              "max_length": 200,
+              "min_length": 30,
+              "length_penalty": 2,
+              "early_stopping": true,
+              "no_repeat_ngram_size": 3,
+              "num_beams": 4
+            }
+          }
+        ]
+      },
+      {
+        "name": "Falconsai/text_summarization",
+        "uri": "hf://Falconsai/text_summarization",
+        "description": "A fine-tuned variant of the T5 transformer model, designed for the task of text summarization.",
+        "info": {
+          "parameter_count": "60.5M",
+          "tensor_type": "F32",
+          "model_size": "242MB"
+        },
+        "tasks": [
+          {
+            "summarization": {
+              "max_length": 200,
+              "min_length": 30,
+              "length_penalty": 2,
+              "early_stopping": true,
+              "no_repeat_ngram_size": 3,
+              "num_beams": 4
+            }
+          }
+        ]
+      },
+      {
+        "name": "mistralai/Mistral-7B-Instruct-v0.3",
+        "uri": "hf://mistralai/Mistral-7B-Instruct-v0.3",
+        "description": "Mistral-7B-Instruct-v0.3 is an instruct fine-tuned version of the Mistral-7B-v0.3.",
+        "info": {
+          "parameter_count": "7.25B",
+          "tensor_type": "BF16",
+          "model_size": "14.5GB"
+        },
+        "tasks": [
+          {
+            "summarization": null
+          }
+        ]
+      },
+      {
+        "name": "gpt-4o-mini",
+        "uri": "oai://gpt-4o-mini",
+        "description": "OpenAI's GPT-4o-mini model.",
+        "info": null,
+        "tasks": [
+          {
+            "summarization": null
+          }
+        ]
+      },
+      {
+        "name": "gpt-4o",
+        "uri": "oai://gpt-4o",
+        "description": "OpenAI's GPT-4o model.",
+        "info": null,
+        "tasks": [
+          {
+            "summarization": null
+          }
+        ]
+      },
+      {
+        "name": "open-mistral-7b",
+        "uri": "mistral://open-mistral-7b",
+        "description": "Mistral's 7B model.",
+        "info": null,
+        "tasks": [
+          {
+            "summarization": null
+          }
+        ]
+      },
+      {
+        "name": "mistralai/Mistral-7B-Instruct-v0.2",
+        "uri": "llamafile://mistralai/Mistral-7B-Instruct-v0.2",
+        "description": "A llamafile package of Mistral's 7B Instruct model.",
+        "info": {
+          "parameter_count": "7.24B",
+          "tensor_type": "BF16",
+          "model_size": "14.5GB"
+        },
+        "tasks": [
+          {
+            "summarization": null
+          }
+        ]
+      }
+    ]
+}

--- a/lumigator/python/mzai/sdk/tests/test_models.py
+++ b/lumigator/python/mzai/sdk/tests/test_models.py
@@ -1,0 +1,25 @@
+from pytest import raises
+from requests.exceptions import HTTPError
+
+from tests.helpers import load_json
+
+
+def test_sdk_suggested_models_ok(
+    mock_requests_response, mock_requests, lumi_client, json_data_models
+):
+    mock_requests_response.status_code = 200
+    data = load_json(json_data_models)
+    mock_requests_response.json = lambda: data
+
+    models = lumi_client.models.get_suggested_models("summarization")
+    assert models is not None
+    assert len(models.items) == models.total
+
+
+def test_sdk_suggested_models_invalid_task(mock_requests_response, mock_requests, lumi_client):
+    mock_requests_response.status_code = 400
+    error = HTTPError(response=mock_requests_response)
+    mock_requests.side_effect = error
+
+    with raises(HTTPError):
+        lumi_client.models.get_suggested_models("invalid_task")


### PR DESCRIPTION
## What's changing

This PR introduces a new `/models` endpoint that returns a list of suggested models for a given task. Currently, the only supported task is "summarization."

The suggested models are stored in a YAML file, along with details such as number of parameters, memory footprint, and default values. Not all information is available for every model. For example, OpenAI models do not provide memory footprint data, while other models may not include summarization-specific default parameters.

Additionally, this PR adds a new SDK function for calling the `/models` endpoint via Python, along with the corresponding documentation.

## How to test it

1. Run a local Lumigator deployment: `make local-up`
1. Run the following command:
    ```bash
    curl -s http://localhost:8000/api/v1/models/summarization | jq
    ```

## Additional notes for reviewers

If you request the suggested models for a task that Lumigator doesn't support (e.g., `curl -s http://localhost:8000/api/v1/models/translation | jq`), you should get an HTTP 400 error:

```bash
{
  "detail": "Unsupported task. Choose from: ['summarization']"
}
```

## I already...

- [x] added some tests for any new functionality
- [x] updated the documentation
- [ ] checked if a (backend) DB migration step was required and included it if required

Closes #381
