### PR TITLE
Frontend: support single page apps (SPA) when served with nginx

### DIFF
--- a/lumigator/frontend/Dockerfile
+++ b/lumigator/frontend/Dockerfile
@@ -19,4 +19,7 @@ FROM nginx:1.27.2-alpine-slim AS server
 # Copy built files to the Nginx image
 COPY --from=base  /mzai/lumigator/frontend/dist /usr/share/nginx/html
 
+# Copy a default nginx config, adjusted to support single page applications
+COPY --from=base /mzai/lumigator/frontend/nginx.conf /etc/nginx/conf.d/default.conf
+
 EXPOSE 80

--- a/lumigator/frontend/nginx.conf
+++ b/lumigator/frontend/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
## What's changing

Our frontend operates as a single page application (SPA), and we create a container to host it using nginx when we `make local-up` or `make start-build-lumigator`.

When using the app, the URL bar appears to show different paths (`/datasets`, `/experiments`) but they're all hosted from the same place. However, nginx doesn't know this and so if you attempt to browse directly to a page (rather than the root), or refresh a page you get a 404 not found.

This PR changes the default nginx daemon config so that it will reroute requests to the root index page. In order to add the single line:

```
try_files $uri $uri/ /index.html;
```

We need to supply the entire config file, as such we now have a copy of the `default.conf` modified that is copied by Docker.

## How to test it

* `make start-lumigator-build`
* Navigate to http://localhost in a browser
* Click datasets or experiments in the left hand nav (the URL will change to include this)
* Click refresh in the browser

## Additional notes for reviewers

`http://localhost/experiments`

Before: 

![image](https://github.com/user-attachments/assets/6a696401-4dcb-4d42-8e71-4983d24996e2)

After: 

![image](https://github.com/user-attachments/assets/7bae87c7-30aa-4ecf-b4c9-d8c82a9d9e23)

To check the default config file you can exec into a container then:

```
cat /etc/nginx/conf.d/default.conf
```

## I already...

- [x] added some tests for any new functionality
- [x] updated the documentation
- [x] checked if a (backend) DB migration step was required and included it if required
