### PR TITLE
fix: install schemas explicitly

### DIFF
--- a/notebooks/requirements.txt
+++ b/notebooks/requirements.txt
@@ -1,3 +1,4 @@
+-e ../lumigator/python/mzai/schemas
 -e ../lumigator/python/mzai/sdk
 datasets==2.20.0
 ipywidgets==8.1.3


### PR DESCRIPTION
## What's changing
An explicit installation of schemas before sdk in the notebooks requirements.txt

It was initially removed due to not being able to reproduce on a new [this](https://github.com/mozilla-ai/lumigator/pull/416#discussion_r1851727231), but the problem has been reproduced locally by @aittalam .



## How to test it

*    Follow the instructions to run the notebook here.
*    Run the imports cell.
*    Walkthrough notebook imports should work.


## Additional notes for reviewers
Eventually the solution will be installing from PyPI, but in the meantime, this redundant install at least does no harm, at best fixes a problem folks on local install are encountering.

## I already...

- [N/A] added some tests for any new functionality
- [] updated the documentation
- [x] checked if a (backend) DB migration step was required and included it if required
