### PR TITLE
Frontend: ensure .env file is available to container during build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -75,6 +75,10 @@ target/
 .venv/
 venv/
 
+# Environment variable files
+# ALLOW .env files
+!.env
+
 # PyCharm
 .idea
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -75,10 +75,6 @@ target/
 .venv/
 venv/
 
-# Environment variable files
-# ALLOW .env files
-!.env
-
 # PyCharm
 .idea
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -133,6 +133,8 @@ services:
       context: .
       dockerfile: "./lumigator/frontend/Dockerfile"
       target: "server"
+      args:
+      - VUE_APP_BASE_URL=${VUE_APP_BASE_URL}
     depends_on:
       backend:
         condition: "service_started"

--- a/lumigator/frontend/Dockerfile
+++ b/lumigator/frontend/Dockerfile
@@ -7,13 +7,6 @@ COPY ../../ /mzai
 
 WORKDIR /mzai/
 
-# Copy the .env file for the entire project, and perform some transformation on it.
-# Only env vars starting with the 'VUE_APP_' prefix are made visible by the Vite build system (See: vite.config.js),
-# but we extract only these variables in a kind of 'least privilege' way.
-# See: https://cli.vuejs.org/guide/mode-and-env.html#environment-variables
-COPY .env /mzai/lumigator/frontend/
-RUN cat .env | grep -E ^VUE_APP_ > /mzai/lumigator/frontend/.env
-
 # Install dependencies
 RUN npm --prefix /mzai/lumigator/frontend install
 

--- a/lumigator/frontend/Dockerfile
+++ b/lumigator/frontend/Dockerfile
@@ -7,6 +7,13 @@ COPY ../../ /mzai
 
 WORKDIR /mzai/
 
+# Copy the .env file for the entire project, and perform some transformation on it.
+# Only env vars starting with the 'VUE_APP_' prefix are made visible by the Vite build system (See: vite.config.js),
+# but we extract only these variables in a kind of 'least privilege' way.
+# See: https://cli.vuejs.org/guide/mode-and-env.html#environment-variables
+COPY .env /mzai/lumigator/frontend/
+RUN cat .env | grep -E ^VUE_APP_ > /mzai/lumigator/frontend/.env
+
 # Install dependencies
 RUN npm --prefix /mzai/lumigator/frontend install
 
@@ -17,7 +24,7 @@ RUN npm --prefix /mzai/lumigator/frontend run build
 FROM nginx:1.27.2-alpine-slim AS server
 
 # Copy built files to the Nginx image
-COPY --from=base  /mzai/lumigator/frontend/dist /usr/share/nginx/html
+COPY --from=base /mzai/lumigator/frontend/dist /usr/share/nginx/html
 
 # Copy a default nginx config, adjusted to support single page applications
 COPY --from=base /mzai/lumigator/frontend/nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## What's changing

When running from a clean clone of the repository, the frontend container is deployed, but is missing environment variables to during the multi stage build process to configure the API URL (`VUE_APP_BASE_URL`).

Reasons for this appear to be:

1. The `.env` file in the root of the repository is ignored by the `.dockerignore` value: `.env/` which was designed to prevent virtual environment folders being uploaded. This means it is not copied to the `/mzai/` WORKDIR.
2. The build system expects the `.env` file to be present locally within the `/frontend` folder.

~This PR allows Docker to copy the `.env` file to the intermediate 'build' stage (by modifying the `.dockerignore` file), and then copies the frontend specific variables to a new (temporary) `.env` file in the `/frontend` folder.~

This PR supplies the environment variable to the intermediate build stage as an `ARG` which will be visible to the `Vite` build system as an env var.

## How to test it

* Clone the repo: `git clone git@github.com:mozilla-ai/lumigator.git`, or navigate to your already cloned repo
* Run `rm lumigator/frontend/.env` (to ensure you have no local artefacts around)
* Checkout the PR (`gh pr checkout 431` if you have the GitHub CLI)
* Run `make start-lumigator-build` (the containers should deploy without error)
* In the browser navigate to http://localhost and attempt to upload a dataset

The developer tools network tab should report no errors, and you should be able to see the dataset appear in the table in the UI.

![image](https://github.com/user-attachments/assets/a81e4435-73e3-46d1-823a-4deaf3c0d6c2)

![image](https://github.com/user-attachments/assets/3726b22e-3cd1-4289-bd76-10e0851985d4)

## Additional notes for reviewers

This is what it looks like on `main` currently:

![image](https://github.com/user-attachments/assets/e0f2c10f-be1f-4b8f-a3fd-11e0964658da)

![image](https://github.com/user-attachments/assets/b875f5b5-e9d7-4f4f-8b20-c7419d92e230)

## I already...

- [x] added some tests for any new functionality
- [x] updated the documentation
- [x] checked if a (backend) DB migration step was required and included it if required
