### PR TITLE
makefile: Run tests without altering state

### DIFF
--- a/.github/workflows/test_backend_uv.yaml
+++ b/.github/workflows/test_backend_uv.yaml
@@ -28,7 +28,7 @@ jobs:
         continue-on-error: false
 
       - name: Run backend unit tests
-        run: make backend-unit-test
+        run: make test-backend-unit
 
       - name: Run backend integration tests
-        run: make backend-integration-test
+        run: AUTO_TEST_RUN=y make test-backend-integration

--- a/.github/workflows/test_sdk_integration.yaml
+++ b/.github/workflows/test_sdk_integration.yaml
@@ -24,4 +24,4 @@ jobs:
         run: uv python install
 
       - name: Run SDK integration tests
-        run: make sdk-integration-test
+        run: AUTO_TEST_RUN=y make test-sdk-integration

--- a/.github/workflows/test_sdk_uv.yaml
+++ b/.github/workflows/test_sdk_uv.yaml
@@ -36,4 +36,4 @@ jobs:
 
       - name: Run SDK unit tests
         if: steps.filter.outputs.run_sdk_unit_tests == 'true'
-        run: make sdk-unit-test
+        run: make test-sdk-unit

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-.PHONY: local-up local-down local-logs clean-docker-buildcache clean-docker-images clean-docker-containers start-lumigator-external-services start-lumigator stop-lumigator test sdk-test sdk-unit-test sdk-integration-test-exec sdk-integration-test backend-test backend-unit-test backend-integration-test
+.PHONY: local-up local-down local-logs clean-docker-buildcache clean-docker-images clean-docker-containers start-lumigator-external-services start-lumigator stop-lumigator test-sdk-unit test-sdk-integration test-sdk-integration-target test-sdk-target test-backend-unit test-backend-integration test-backend-integration-target test-backend-target test-all-target test-%
 
 SHELL:=/bin/bash
 UNAME:= $(shell uname -o)
+PROJECT_ROOT := $(shell git rev-parse --show-toplevel)
+CONTAINERS_RUNNING := $(shell docker ps -q --filter "name=lumigator-")
 
 #used in docker-compose to choose the right Ray image
 ARCH := $(shell uname -m)
@@ -10,6 +12,50 @@ RAY_ARCH_SUFFIX :=
 ifeq ($(ARCH), arm64)
 	RAY_ARCH_SUFFIX := -aarch64
 endif
+
+define run_with_containers
+	@echo "No Lumigator containers are running. Starting containers..."
+	make start-lumigator-build
+	trap "cd $(PROJECT_ROOT); make stop-lumigator" EXIT; \
+	make $(1)
+endef
+
+define run_with_existing_containers
+	@echo "Lumigator containers are already running."
+	@if [ -n "$(AUTO_TEST_RUN)" ]; then \
+		echo "AUTO_TEST_RUN is set to '$(AUTO_TEST_RUN)'"; \
+		case "$(AUTO_TEST_RUN)" in \
+			[Yy]* ) \
+				echo "Running tests..."; \
+				make $(1); \
+				;; \
+			[Nn]* ) \
+				echo "Tests aborted due to AUTO_TEST_RUN setting."; \
+				exit 1; \
+				;; \
+			* ) \
+				echo "Invalid AUTO_TEST_RUN value: $(AUTO_TEST_RUN). Tests aborted."; \
+				exit 1; \
+				;; \
+		esac; \
+	else \
+		read -p "Do you want to run tests with the current Lumigator deployment? (Y/n): " choice; \
+		case $${choice:-Y} in \
+			[Yy]* ) \
+				echo "Running tests..."; \
+				make $(1); \
+				;; \
+			[Nn]* ) \
+				echo "Tests aborted."; \
+				exit 1; \
+				;; \
+			* ) \
+				echo "Invalid input. Tests aborted."; \
+				exit 1; \
+				;; \
+		esac; \
+	fi
+endef
 
 LOCAL_DOCKERCOMPOSE_FILE:= docker-compose.yaml
 DEV_DOCKER_COMPOSE_FILE:= .devcontainer/docker-compose.override.yaml
@@ -56,24 +102,45 @@ clean-docker-all: clean-docker-containers clean-docker-buildcache clean-docker-i
 
 clean-all: clean-docker-buildcache clean-docker-containers
 
-sdk-unit-test:
-	cd lumigator/python/mzai/sdk/tests;	uv run pytest -o python_files="unit/*/test_*.py unit/test_*.py"
+test-sdk-unit:
+	cd lumigator/python/mzai/sdk/tests; \
+	uv run pytest -o python_files="unit/*/test_*.py unit/test_*.py"
 
-sdk-integration-test-exec:
-	cd lumigator/python/mzai/sdk/tests; uv run pytest -o python_files="integration/test_*.py integration/*/test_*.py"
+test-sdk-integration-target:
+	cd lumigator/python/mzai/sdk/tests; \
+	uv run pytest -o python_files="integration/test_*.py integration/*/test_*.py"
 
-sdk-integration-test: | start-lumigator-build sdk-integration-test-exec stop-lumigator
+test-sdk-integration:
+ifeq ($(CONTAINERS_RUNNING),)
+	$(call run_with_containers, test-sdk-integration-target)
+else
+	$(call run_with_existing_containers, test-sdk-integration-target)
+endif
 
-sdk-test: sdk-unit-test sdk-integration-test
+test-backend-unit:
+	cd lumigator/python/mzai/backend/backend/tests; \
+	SQLALCHEMY_DATABASE_URL=sqlite:///local.db uv run pytest -o python_files="backend/tests/unit/*/test_*.py"
 
-backend-unit-test:
-	cd lumigator/python/mzai/backend/backend/tests; SQLALCHEMY_DATABASE_URL=sqlite:///local.db uv run pytest -o python_files="backend/tests/unit/*/test_*.py"
+test-backend-integration-target:
+	cd lumigator/python/mzai/backend/backend/tests;	\
+	SQLALCHEMY_DATABASE_URL=sqlite:///local.db uv run pytest -o python_files="backend/tests/integration/*/test_*.py"
 
-backend-integration-test-exec:
-	cd lumigator/python/mzai/backend/backend/tests;	SQLALCHEMY_DATABASE_URL=sqlite:///local.db uv run pytest -o python_files="backend/tests/integration/*/test_*.py"
+test-backend-integration:
+ifeq ($(CONTAINERS_RUNNING),)
+	$(call run_with_containers, test-backend-integration-target)
+else
+	$(call run_with_existing_containers, test-backend-integration-target)
+endif
 
-backend-integration-test: | start-lumigator-build backend-integration-test-exec stop-lumigator
+test-sdk-target: test-sdk-unit test-sdk-integration
 
-backend-test: backend-unit-test backend-integration-test
+test-backend-target: test-backend-unit test-backend-integration
 
-test: sdk-test backend-test
+test-all-target: test-sdk-target test-backend-target
+
+# Check whether there are already running containers before starting tests:
+#   If so, ask user if they want to proceed with the current deployment.
+#   If not: (1) start containers, (2) run tests, (3) tear down containers
+#   (regardless of tests outcome).
+test-%:
+	$(MAKE) test-$*-target


### PR DESCRIPTION
## What's changing

Currently, running `make test` has the following consequences:

* Containers are started, ignoring any container that is already running.
* If everything works, all containers are teared down including those started with `make local-up`.
* If anything breaks during tests, `make stop-lumigator` is not run and the containers stay up.

Transform the `make test` target to check whether there are already running containers before starting tests:
  - If so, simply run tests.
  - If not: (1) start containers, (2) run tests, (3) tear down containers (regardless of tests outcome).

## How to test it

1. Run `make local-up`.
1. Run `make test` in another window.
1. If the tests complete successfully, all the containers started with `make local-up` should remain running.
1. Run `make stop-lumigator`.
1. Run `make test`. New containers should start and be removed when the tests finish, regardless of whether they succeed or fail.

## I already...

- [NA] added some tests for any new functionality
- [NA] updated the documentation
- [NA] checked if a (backend) DB migration step was required and included it if required

Closes #414