### PR TITLE
[BUG] Limit auto-reload to relevant directories

### DIFF
--- a/.devcontainer/docker-compose.override.yaml
+++ b/.devcontainer/docker-compose.override.yaml
@@ -11,10 +11,15 @@ services:
       -  database_volume:/mzai/backend/local.db
     develop:
       watch:
-        - path: ./
-          target: /mzai
+        - path: lumigator/python/mzai/backend/
+          target: /mzai/lumigator/python/mzai/backend
           action: sync
           ignore:
-           - lumigator/python/mzai/backend/.venv/
+            - .venv/
+        - path: lumigator/python/mzai/schemas/
+          target: /mzai/lumigator/python/mzai/schemas
+          action: sync
+          ignore:
+            - .venv/
         - path: lumigator/python/mzai/backend/pyproject.toml
           action: rebuild


### PR DESCRIPTION
## What's changing

While automatic backend reloads are useful for testing code changes in real-time, the backend should not be impacted by updates in unrelated subdirectories (e.g., running `uv venv` in notebooks).

Update the docker-compose override file to watch only the directories relevant to the backend.

Closes #432

## How to test it

1. Run `make local-up`

2. Navigate into `notebooks`:

    ```
    cd notebooks
    ```

3. Run `uv venv` to create a new uv virtual environment. Docker should not detect any change.
4. Change somethin in a `.py` file in the `backend`. Docker should detect the change and sync the backend container. 

## I already...

- [NA] added some tests for any new functionality
- [NA] updated the documentation
- [NA] checked if a (backend) DB migration step was required and included it if required
