### PR TITLE
Fix results caching

### DIFF
--- a/lumigator/frontend/src/components/pages/LExperiments.vue
+++ b/lumigator/frontend/src/components/pages/LExperiments.vue
@@ -39,7 +39,7 @@
       v-if="showDrawer && selectedExperimentRslts.length"
       ref="resultsDrawer"
       :header="selectedExperiment.name"
-      @l-close-results="showDrawer = false"
+      @l-close-results="resetResults()"
     >
       <l-experiment-results
         v-if="selectedExperimentRslts &&  selectedExperimentRslts.length"
@@ -100,6 +100,11 @@ const onDismissForm = () => {
 
 const onCloseDetails = () => {
   showSlidingPanel.value = false;
+}
+
+const resetResults = () => {
+  selectedExperimentRslts.value = [];
+  showDrawer.value = false
 }
 
 onMounted(async () => {


### PR DESCRIPTION
## What's changing
This is a bug fix. When the user is switching from one experiment' results to another's the table component doesn't update it contents.
## How to test it

1. Open results for an experiment
2. Close results panel
3. Open results for another one with different number of samples


