### PR TITLE
GHA: Prevent merging a PR to main when 'do-not-merge' label is present

### DIFF
--- a/.github/workflows/pull_request_do_not_merge.yaml
+++ b/.github/workflows/pull_request_do_not_merge.yaml
@@ -1,0 +1,25 @@
+name: Do not merge
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+jobs:
+  do-not-merge:
+    name: Prevent merge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for label
+        run: |
+          if ${{ contains(github.event.pull_request.labels.*.name, 'do-not-merge') }}; then
+            echo "PR is labeled with 'do-not-merge', merging disabled"
+            exit 1
+          fi


### PR DESCRIPTION
## What's changing

Cherry picked commit from `main`: [`fbb3fec561f2f041e483e74e63f45e2082a010a6`](https://github.com/mozilla-ai/lumigator/commit/fbb3fec561f2f041e483e74e63f45e2082a010a6).

Adds the GHA to prevent accidental merges when `do-not-merge` label is present.
