### PR TITLE
backend: Refresh job status

### DIFF
--- a/lumigator/python/mzai/backend/backend/settings.py
+++ b/lumigator/python/mzai/backend/backend/settings.py
@@ -92,6 +92,12 @@ class BackendSettings(BaseSettings):
         # as the default shell in the container is /bin/sh
         return f'if [ `arch` = "aarch64" ]; then export LD_PRELOAD=$VIRTUAL_ENV/{lib_path}; fi;'
 
+    # URL for Ray jobs API
+    @computed_field
+    @property
+    def RAY_VERSION_URL(self) -> str:  # noqa: N802
+        return f"{self.RAY_DASHBOARD_URL}/api/version"
+
     @computed_field
     @property
     def RAY_WORKER_GPUS(self) -> float:  # noqa: N802

--- a/lumigator/python/mzai/backend/backend/tests/conftest.py
+++ b/lumigator/python/mzai/backend/backend/tests/conftest.py
@@ -203,6 +203,11 @@ def json_data_models(resources_dir) -> Path:
 
 
 @pytest.fixture(scope="session")
+def json_ray_version(resources_dir) -> Path:
+    return resources_dir / "ray_version.json"
+
+
+@pytest.fixture(scope="session")
 def json_data_health_job_metadata_ok(resources_dir) -> Path:
     return resources_dir / "health_job_metadata.json"
 

--- a/lumigator/python/mzai/backend/backend/tests/data/ray_version.json
+++ b/lumigator/python/mzai/backend/backend/tests/data/ray_version.json
@@ -1,0 +1,5 @@
+{
+    "version": "4",
+    "ray_version": "2.30.0",
+    "ray_commit": "97c37298df9e997b86ca9efed824e27024f3bd60"
+}

--- a/lumigator/python/mzai/backend/backend/tests/unit/api/routes/test_jobs.py
+++ b/lumigator/python/mzai/backend/backend/tests/unit/api/routes/test_jobs.py
@@ -1,0 +1,45 @@
+import json
+import urllib
+from pathlib import Path
+
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from backend.settings import settings
+
+
+def load_json(path: Path) -> str:
+    with Path.open(path) as file:
+        return json.load(file)
+
+
+def test_get_job_status(
+    app_client: TestClient,
+    job_repository,
+    request_mock,
+    json_ray_version,
+    json_data_health_job_metadata_ray,
+):
+    created_job = job_repository.create(name="test", description="")
+
+    # The Ray client will call the Ray API to get the version before gettting the job status
+    # Mock the Ray version API
+    request_mock.get(
+        url=settings.RAY_VERSION_URL,
+        status_code=status.HTTP_200_OK,
+        text=json.dumps(load_json(json_ray_version)),
+    )
+
+    request_mock.get(
+        url=urllib.parse.urljoin(f"{settings.RAY_JOBS_URL}", f"{created_job.id}"),
+        status_code=status.HTTP_200_OK,
+        text=json.dumps(load_json(json_data_health_job_metadata_ray)),
+    )
+
+    response = app_client.get(f"/jobs/{created_job.id}")
+
+    assert response is not None
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.json()
+    assert data["status"].lower() == "running"

--- a/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
+++ b/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
@@ -13,6 +13,7 @@ class JobType(str, Enum):
 
 class JobStatus(str, Enum):
     CREATED = "created"
+    PENDING = "pending"
     RUNNING = "running"
     FAILED = "failed"
     SUCCEEDED = "succeeded"
@@ -59,7 +60,7 @@ class JobEvalCreate(BaseModel):
     description: str = ""
     model: str
     dataset: UUID
-    max_samples: int = -1 # set to all samples by default
+    max_samples: int = -1  # set to all samples by default
     model_url: str | None = None
     system_prompt: str | None = None
     config_template: str | None = None
@@ -70,7 +71,7 @@ class JobInferenceCreate(BaseModel):
     description: str = ""
     model: str
     dataset: UUID
-    max_samples: int = -1 # set to all samples by default
+    max_samples: int = -1  # set to all samples by default
     model_url: str | None = None
     system_prompt: str | None = None
     output_field: str | None = "prediction"


### PR DESCRIPTION
## What's changing

The `/jobs` endpoint can return the status of a specific Ray job, but this status is not updated beyond "created".

Optionally refresh the database record before returning:

* Immediately return statuses "Succeeded" and "Failed" because they cannot change.
* Otherwise, consult Ray first, and if the status differs from the one in the DB, update the DB and return the updated record.

Closes #382

## How to test it

1. Upload a dataset
1. Launch a job (e.g. evaluation with BART)
1. List jobs, find the job_id of one (e.g., the one you just created)
1. GET /jobs/{job_id} --> created
1. Check on the ray dashboard until that job has finished
1. GET /jobs/{job_id} --> finished

## I already...

- [x] added some tests for any new functionality
- [NA] updated the documentation
- [NA] checked if a (backend) DB migration step was required and included it if required
