### PR TITLE
Deployment: Add frontend profile to `start-lumigator`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ local-logs:
 
 # Launches lumigator in 'user-local' mode (All services running locally, using latest docker container, no code mounted in)
 start-lumigator: .env
-	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose --profile local -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d
+	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose --profile local-fe -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d
 
 # Launches lumigator with no code mounted in, and forces build of containers (used in CI for integration tests)
 start-lumigator-build: .env


### PR DESCRIPTION
## What's changing

`start-lumigator-build` already uses the `local-fe` profile, this PR adds it to `start-lumigator` too.

`stop-lumigator` uses the same profile to shutdown the containers.

## How to test it

* `make start-lumigator`
* Should see the frontend container deployed alongside everything else

![image](https://github.com/user-attachments/assets/2ee0d13e-8b38-42f3-8e3e-5bdbc8c5f2d8)


## Additional notes for reviewers

## I already...

- [ ] added some tests for any new functionality
- [ ] updated the documentation
- [ ] checked if a (backend) DB migration step was required and included it if required
