### PR TITLE
Add fakes for the S3 service and use the standalone localstack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,11 @@
 # .env.example
+
+# Lumigator container control
+# Set to "TRUE" if the containers need to be up and running after
+# a test target failed (e.g. in CI where containers are inspected
+# for logs after failed steps)
+CONTAINERS_UP_ON_ERROR="FALSE"
+
 # Lumigator API configuration
 # LUMI_API_CORS_ALLOWED_ORIGINS:
 # Comma separated list of origins (See: https://developer.mozilla.org/en-US/docs/Glossary/Origin)

--- a/.github/workflows/test_backend_uv.yaml
+++ b/.github/workflows/test_backend_uv.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - "**"
+  workflow_dispatch:
 
 jobs:
   backend-integration-tests:
@@ -31,4 +32,17 @@ jobs:
         run: make test-backend-unit
 
       - name: Run backend integration tests
-        run: AUTO_TEST_RUN=y make test-backend-integration
+        run: KEEP_CONTAINERS_UP=FALSE AUTO_TEST_RUN=y make test-backend-integration
+
+      - name: Collect Ray logs in case of failure
+        if: failure()
+        run: |
+          mkdir /tmp/raylogs
+          docker cp lumigator-ray-1:/tmp/ray/ /tmp/raylogs/
+
+      - name: Upload Ray logs in case of failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ray-logs
+          path: /tmp/raylogs/ray/session_*/logs/

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ UNAME:= $(shell uname -o)
 PROJECT_ROOT := $(shell git rev-parse --show-toplevel)
 CONTAINERS_RUNNING := $(shell docker ps -q --filter "name=lumigator-")
 
+-include .env
+
+KEEP_CONTAINERS_UP ?= "TRUE"
+
 #used in docker-compose to choose the right Ray image
 ARCH := $(shell uname -m)
 RAY_ARCH_SUFFIX :=
@@ -16,7 +20,7 @@ endif
 define run_with_containers
 	@echo "No Lumigator containers are running. Starting containers..."
 	make start-lumigator-build
-	trap "cd $(PROJECT_ROOT); make stop-lumigator" EXIT; \
+	@if [ $(KEEP_CONTAINERS_UP) = "TRUE" ]; then trap "cd $(PROJECT_ROOT); make stop-lumigator" EXIT; fi; \
 	make $(1)
 endef
 
@@ -118,13 +122,13 @@ else
 endif
 
 test-backend-unit:
-	cd lumigator/python/mzai/backend/backend/tests; \
-	SQLALCHEMY_DATABASE_URL=sqlite:///local.db uv run pytest -o python_files="backend/tests/unit/*/test_*.py"
+	cd lumigator/python/mzai/backend/; \
+	SQLALCHEMY_DATABASE_URL=sqlite:////tmp/local.db uv run pytest -o python_files="backend/tests/unit/*/test_*.py"
 
 test-backend-integration-target:
-	cd lumigator/python/mzai/backend/backend/tests;	\
-	RAY_WORKER_GPUS="0.0" RAY_WORKER_GPUS_FRACTION="0.0" \
-	SQLALCHEMY_DATABASE_URL=sqlite:///local.db uv run pytest -s -o python_files="backend/tests/integration/*/test_*.py"
+	cd lumigator/python/mzai/backend/; \
+	docker container list --all; \
+	SQLALCHEMY_DATABASE_URL=sqlite:////tmp/local.db RAY_WORKER_GPUS="0.0" RAY_WORKER_GPUS_FRACTION="0.0" INFERENCE_PIP_REQS=../jobs/inference/requirements_cpu.txt INFERENCE_WORK_DIR=../jobs/inference EVALUATOR_PIP_REQS=../jobs/evaluator/requirements.txt EVALUATOR_WORK_DIR=../jobs/evaluator uv run pytest -s -o python_files="backend/tests/integration/*/test_*.py"
 
 test-backend-integration:
 ifeq ($(CONTAINERS_RUNNING),)

--- a/lumigator/python/mzai/backend/README.md
+++ b/lumigator/python/mzai/backend/README.md
@@ -28,7 +28,7 @@ The backend needs to retrieve the location of the database used in tests via the
 SQLALCHEMY_DATABASE_URL=sqlite:///local.db uv run pytest
 ```
 
-Note that this will create an SQLite database file named `local.db` in the `backend` directory. Remove it before running another batch of tests.
+Note that this will create an SQLite database file named `local.db` in the `backend` directory. Remove it before running another batch of tests. Also note that the tests as invoked in the Makefile will remove and recreate a file called `local.db` in the `lumigator/python/mzai/backend` directory.
 
 The tests include a unit test suite and an integration test suite. There are make targets available at the root folder, as follows:
 
@@ -36,7 +36,7 @@ The tests include a unit test suite and an integration test suite. There are mak
   * `backend-unit-test`: runs tests in `backend/tests/unit/*/test_*.py` (any depth of subfolders)
   * `backend-int-test`: runs tests in `backend/tests/int/*/test_*.py` (any depth of subfolders)
 
-The SQLite configuration making use of a local file is used in both unit and integration tests. Test containers are started for integration tests.
+The SQLite configuration making use of a local file is used in both unit and integration tests. Test containers are needed for integration tests. Fake or mock services are used in unit tests, usually via the [`requests-mock`](https://pypi.org/project/requests-mock/) package in the case of HTTP APIs. Specifically, the S3 file system driver is replaced with an [in-memory implementation](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.implementations.memory.MemoryFileSystem) of the `AbstractFileSystem` interface via [registry modification](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.registry.register_implementation).
 
 ## Data models
 

--- a/lumigator/python/mzai/backend/backend/config_templates.py
+++ b/lumigator/python/mzai/backend/backend/config_templates.py
@@ -104,7 +104,7 @@ bart_infer_template = """{{
 causal_infer_template = """{{
     "name": "{job_name}/{job_id}",
     "model": {{ "path": "{model_uri}" }},
-    "dataset": {{ "path": "{dataset_path}" }},
+    "dataset": {{ "path": "{dataset_path}" }}
 }}"""
 
 

--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -1,4 +1,5 @@
 import csv
+import traceback
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import BinaryIO
@@ -94,6 +95,7 @@ class DatasetService:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dataset '{dataset_id}' not found.")
 
     def _raise_unhandled_exception(self, e: Exception) -> None:
+        traceback.print_exc()
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, str(e)) from e
 
     def _get_dataset_record(self, dataset_id: UUID) -> DatasetRecord | None:
@@ -122,6 +124,7 @@ class DatasetService:
             # Upload to S3
             dataset_key = self._get_s3_key(record.id, record.filename)
             dataset_path = self._get_s3_path(dataset_key)
+            # Deprecated!!!
             dataset_hf.save_to_disk(dataset_path, fs=self.s3_filesystem)
         except Exception as e:
             # if a record was already created, delete it from the DB

--- a/lumigator/python/mzai/backend/backend/services/jobs.py
+++ b/lumigator/python/mzai/backend/backend/services/jobs.py
@@ -241,12 +241,14 @@ class JobService:
 
     def get_job(self, job_id: UUID) -> JobResponse:
         record = self._get_job_record(job_id)
+        loguru.logger.info(f"Obtaining info for job {job_id}: {record}")
 
         if record.status == JobStatus.FAILED or record.status == JobStatus.SUCCEEDED:
             return JobResponse.model_validate(record)
 
         # get job status from ray
         job_status = self.ray_client.get_job_status(job_id)
+        loguru.logger.info(f"Obtaining info from ray for job {job_id}: {job_status}")
 
         # update job status in the DB if it differs from the current status
         if job_status.lower() != record.status.value.lower():
@@ -263,7 +265,7 @@ class JobService:
         records = self.job_repo.list(skip, limit)
         return ListingResponse(
             total=total,
-            items=[JobResponse.model_validate(x) for x in records],
+            items=[self.get_job(record.id) for record in records],
         )
 
     def update_job_status(

--- a/lumigator/python/mzai/backend/backend/tests/README.md
+++ b/lumigator/python/mzai/backend/backend/tests/README.md
@@ -14,6 +14,15 @@ library to provide some of these dependencies for testing.
 as part of the testing lifecycle. This is configured in the `conftest.py` file that contains
 fixtures for the entire test suite.
 
+## Test Dependencies
+
+The backend tests offer two sets of service dependencies as fixtures:
+
+* `dependency_overrides_fakes`, to be used in unit tests, mocks all external services.
+* `dependency_overrides_services`, to be used in integration tests, provides real clients for external services (except the DB).
+
+By default, an embedded SQLite database is used in both cases.
+
 ## Running Tests
 
 To run the tests, you can use the following command:

--- a/lumigator/python/mzai/backend/backend/tests/fakes/fake_ray_client.py
+++ b/lumigator/python/mzai/backend/backend/tests/fakes/fake_ray_client.py
@@ -1,7 +1,0 @@
-class FakeJobSubmissionClient:
-    """A mock implementation of Ray's JobSubmissionClient for testing purposes.
-    Simulates basic job submission and management functionality.
-    """
-    def __init__(self):
-        self.jobs: dict[str, dict] = {}  # Store jobs and their metadata
-        self.runtime_env = {}

--- a/lumigator/python/mzai/backend/backend/tests/fakes/fake_s3.py
+++ b/lumigator/python/mzai/backend/backend/tests/fakes/fake_s3.py
@@ -1,0 +1,44 @@
+from datetime import date
+from io import BytesIO, StringIO
+from urllib.parse import urlparse
+
+from fsspec.implementations.memory import MemoryFile
+
+
+# TODO use the storage from the MemoryFileSystem instead, right now the information
+# in both fakes will not be consistent
+class FakeS3Client:
+    def __init__(self, storage, **kwargs):
+        self.storage = storage
+
+    def get_storage(self):
+        return self.storage
+
+    def __map_entry_to_content(self, key):
+        entry = self.storage[key]
+        mod_date = entry.modified
+        content = {
+            "ETag": key,
+            "Key": key,
+            "LastModified": mod_date,
+            "Size": len(entry.getvalue()),
+            "StorageClass": "STANDARD",
+        }
+        return content
+
+    def list_objects_v2(self, **kwargs):
+        bucket = kwargs["Bucket"]
+        prefix = kwargs["Prefix"]
+        return {
+            "IsTruncated": False,
+            "Name": bucket,
+            "KeyCount": len(self.storage),
+            "Prefix": prefix,
+            "Contents": [self.__map_entry_to_content(key) for key in self.storage.keys()],
+        }
+
+    def generate_presigned_url(self, method, **kwargs):
+        params = kwargs["Params"]
+        bucket = params["Bucket"]
+        path = params["Key"]
+        return f"http://example.org/{bucket}/{path}"

--- a/lumigator/python/mzai/backend/backend/tests/integration/api/routes/test_api_workflows.py
+++ b/lumigator/python/mzai/backend/backend/tests/integration/api/routes/test_api_workflows.py
@@ -1,11 +1,18 @@
+import time
+from time import sleep
 from unittest.mock import patch
 
+import pytest
+import requests
 from fastapi.testclient import TestClient
+from loguru import logger
 from lumigator_schemas.datasets import DatasetFormat, DatasetResponse
 from lumigator_schemas.experiments import ExperimentResponse
 from lumigator_schemas.extras import ListingResponse
+from lumigator_schemas.jobs import JobLogsResponse, JobResponse, JobStatus
 
 from backend.main import app
+from backend.tests.conftest import TEST_CAUSAL_MODEL, TEST_INFER_MODEL
 
 
 @app.on_event("startup")
@@ -14,7 +21,13 @@ def test_health_ok(local_client: TestClient):
     assert response.status_code == 200
 
 
-def test_upload_data_launch_job(local_client: TestClient, dialog_dataset):
+def test_upload_data_launch_job(
+    local_client: TestClient,
+    dialog_dataset,
+    simple_eval_template,
+    simple_infer_template,
+    dependency_overrides_services,
+):
     response = local_client.get("/health")
     assert response.status_code == 200
 
@@ -27,33 +40,99 @@ def test_upload_data_launch_job(local_client: TestClient, dialog_dataset):
     assert create_response.status_code == 201
 
     created_dataset = DatasetResponse.model_validate(create_response.json())
+
     headers = {
         "accept": "application/json",
         "Content-Type": "application/json",
     }
-    payload = {
+    eval_payload = {
         "name": "test_run_hugging_face",
         "description": "Test run for Huggingface model",
-        "model": "hf://facebook/bart-large-cnn",
+        "model": TEST_CAUSAL_MODEL,
         "dataset": str(created_dataset.id),
+        "config_template": simple_eval_template,
         "max_samples": 10,
-        "model_url": "string",
-        "system_prompt": "string",
-        "config_template": "string",
     }
 
     create_evaluation_job_response = local_client.post(
-        "/jobs/evaluate/", headers=headers, json=payload
+        "/jobs/evaluate/", headers=headers, json=eval_payload
     )
     assert create_evaluation_job_response.status_code == 201
 
+    create_evaluation_job_response_model = JobResponse.model_validate(
+        create_evaluation_job_response.json()
+    )
+
+    succeeded = False
+    for _ in range(1, 200):
+        get_job_response = local_client.get(f"/jobs/{create_evaluation_job_response_model.id}")
+        assert get_job_response.status_code == 200
+        get_job_response_model = JobResponse.model_validate(get_job_response.json())
+        if get_job_response_model.status == JobStatus.SUCCEEDED.value:
+            succeeded = True
+            break
+        if get_job_response_model.status == JobStatus.FAILED.value:
+            succeeded = False
+            break
+        time.sleep(10)
+    assert succeeded
+
+    logs_evaluation_job_response = local_client.get(
+        f"/health/jobs/{create_evaluation_job_response_model.id}/logs"
+    )
+    logs_evaluation_job_response_model = JobLogsResponse.model_validate(
+        logs_evaluation_job_response.json()
+    )
+    logger.info(f"-- eval logs -- {create_evaluation_job_response_model.id}")
+    logger.info(f"#{logs_evaluation_job_response_model.logs}#")
+
+    infer_payload = {
+        "name": "test_run_hugging_face",
+        "description": "Test run for Huggingface model",
+        "model": TEST_INFER_MODEL,
+        "dataset": str(created_dataset.id),
+        "max_samples": 10,
+    }
     create_inference_job_response = local_client.post(
-        "/jobs/inference/", headers=headers, json=payload
+        "/jobs/inference/", headers=headers, json=infer_payload
     )
     assert create_inference_job_response.status_code == 201
 
+    create_inference_job_response_model = JobResponse.model_validate(
+        create_inference_job_response.json()
+    )
 
-def test_full_experiment_launch(local_client: TestClient, dialog_dataset):
+    succeeded = False
+    for _ in range(1, 200):
+        get_job_response = local_client.get(f"/jobs/{create_inference_job_response_model.id}")
+        assert get_job_response.status_code == 200
+        get_job_response_model = JobResponse.model_validate(get_job_response.json())
+        logs_infer_job_response = local_client.get(
+            f"/health/jobs/{create_inference_job_response_model.id}/logs"
+        )
+        logs_infer_job_response_model = JobLogsResponse.model_validate(
+            logs_infer_job_response.json()
+        )
+        if get_job_response_model.status == JobStatus.SUCCEEDED.value:
+            succeeded = True
+            break
+        if get_job_response_model.status == JobStatus.FAILED.value:
+            succeeded = False
+            break
+        time.sleep(10)
+    assert succeeded
+
+    logs_infer_job_response = local_client.get(
+        f"/health/jobs/{create_inference_job_response_model.id}/logs"
+    )
+    logs_infer_job_response_model = JobLogsResponse.model_validate(logs_infer_job_response.json())
+    logger.info(f"-- infer logs -- {create_inference_job_response_model.id}")
+    logger.info(f"#{logs_infer_job_response_model.logs}#")
+
+
+def test_full_experiment_launch(
+    local_client: TestClient, dialog_dataset, dependency_overrides_services
+):
     response = local_client.get("/health")
     assert response.status_code == 200
     create_response = local_client.post(
@@ -70,7 +149,7 @@ def test_full_experiment_launch(local_client: TestClient, dialog_dataset):
     payload = {
         "name": "test_run_hugging_face",
         "description": "Test run for Huggingface model",
-        "model": "hf://facebook/bart-large-cnn",
+        "model": TEST_CAUSAL_MODEL,
         "dataset": str(created_dataset.id),
         "max_samples": 2,
     }
@@ -87,24 +166,36 @@ def test_full_experiment_launch(local_client: TestClient, dialog_dataset):
     get_experiment_response = local_client.get(f"/experiments/{get_experiments.items[0].id}")
     assert get_experiment_response.status_code == 200
 
+    succeeded = False
+    for _ in range(1, 200):
+        get_job_response = local_client.get(f"/jobs/{get_experiments.items[0].id}")
+        assert get_job_response.status_code == 200
+        get_job_response_model = JobResponse.model_validate(get_job_response.json())
+        if get_job_response_model.status == JobStatus.SUCCEEDED.value:
+            succeeded = True
+            break
+        if get_job_response_model.status == JobStatus.FAILED.value:
+            succeeded = False
+            break
+        time.sleep(10)
+    assert succeeded
 
-def test_experiment_non_existing(local_client: TestClient):
+
+def test_experiment_non_existing(local_client: TestClient, dependency_overrides_services):
     non_existing_id = "71aaf905-4bea-4d19-ad06-214202165812"
     response = local_client.get(f"/experiments/{non_existing_id}")
     assert response.status_code == 404
     assert response.json()["detail"] == f"Job {non_existing_id} not found."
 
 
-def test_job_non_existing(local_client: TestClient):
+def test_job_non_existing(local_client: TestClient, dependency_overrides_services):
     non_existing_id = "71aaf905-4bea-4d19-ad06-214202165812"
     response = local_client.get(f"/jobs/{non_existing_id}")
     assert response.status_code == 404
     assert response.json()["detail"] == f"Job {non_existing_id} not found."
 
 
-def test_annotation_job(
-    local_client: TestClient,
-):
+def test_annotation_job(local_client: TestClient, dependency_overrides_services):
     payload = {
         "name": "test_annotate",
         "description": "Test run for Huggingface model",

--- a/lumigator/python/mzai/backend/backend/tests/unit/api/routes/test_jobs.py
+++ b/lumigator/python/mzai/backend/backend/tests/unit/api/routes/test_jobs.py
@@ -13,13 +13,13 @@ def load_json(path: Path) -> str:
     with Path.open(path) as file:
         return json.load(file)
 
-
 def test_get_job_status(
     app_client: TestClient,
     job_repository,
     request_mock,
     json_ray_version,
     json_data_health_job_metadata_ray,
+    dependency_overrides_fakes
 ):
     created_job = job_repository.create(name="test", description="test desc")
 
@@ -57,6 +57,7 @@ def test_get_job_results(
     request_mock,
     json_ray_version,
     json_data_health_job_metadata_ray,
+    dependency_overrides_fakes,
 ):
     created_job = job_repository.create(name="test", description="")
     expected_url_path = f"lumigator-storage/jobs/results/test/{created_job.id}/results.json"

--- a/lumigator/python/mzai/backend/backend/tests/unit/services/test_dataset_service.py
+++ b/lumigator/python/mzai/backend/backend/tests/unit/services/test_dataset_service.py
@@ -4,7 +4,7 @@ from backend.repositories.datasets import DatasetRepository
 from backend.services.datasets import DatasetService
 
 
-def test_delete_dataset_file_not_found(db_session, s3_client):
+def test_delete_dataset_file_not_found(db_session, fake_s3_client, fake_s3fs):
     filename = "dataset.csv"
     format = "job"
     dataset_repo = DatasetRepository(db_session)
@@ -14,7 +14,7 @@ def test_delete_dataset_file_not_found(db_session, s3_client):
     assert dataset_record is not None
     assert dataset_record.filename == filename
     assert dataset_record.format == format
-    dataset_service = DatasetService(dataset_repo, s3_client, S3FileSystem())
+    dataset_service = DatasetService(dataset_repo, fake_s3_client, fake_s3fs)
     dataset_service.delete_dataset(dataset_record.id)
     dataset_record = dataset_service._get_dataset_record(dataset_record.id)
     assert dataset_record is None

--- a/lumigator/python/mzai/jobs/inference/requirements_cpu.txt
+++ b/lumigator/python/mzai/jobs/inference/requirements_cpu.txt
@@ -1,0 +1,11 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
+accelerate==1.1.1
+datasets==2.20.0
+loguru==0.7.2
+mistralai==0.4.2
+openai==1.55.3
+python-box==7.2.0
+s3fs==2024.5.0
+sentencepiece==0.2.0
+torch==2.5.1
+transformers==4.46.3

--- a/lumigator/python/mzai/sdk/lumigator_sdk/client.py
+++ b/lumigator/python/mzai/sdk/lumigator_sdk/client.py
@@ -4,7 +4,6 @@ from typing import Any, Dict  # noqa: UP035
 
 import requests
 from loguru import logger
-from requests.exceptions import HTTPError
 
 
 def _make_request(
@@ -129,7 +128,7 @@ class ApiClient:
         data=None,
         files=None,
         json_data=None,
-        verbose= True,
+        verbose=True,
     ) -> requests.Response:
         """Make a request to the specified endpoint.
 

--- a/lumigator/python/mzai/sdk/lumigator_sdk/experiments.py
+++ b/lumigator/python/mzai/sdk/lumigator_sdk/experiments.py
@@ -1,4 +1,4 @@
-from http import HTTPMethod, HTTPStatus
+from http import HTTPMethod
 from json import dumps
 from uuid import UUID
 

--- a/lumigator/python/mzai/sdk/tests/integration/test_scenarios.py
+++ b/lumigator/python/mzai/sdk/tests/integration/test_scenarios.py
@@ -71,7 +71,7 @@ def test_job_lifecycle_remote_ok(lumi_client_int, dialog_data, simple_eval_templ
 
     job = JobEvalCreate(
         name="test-job-int-001",
-        model="hf://trl-internal-testing/tiny-random-LlamaForCausalLM",
+        model="hf://hf-internal-testing/tiny-random-LlamaForCausalLM",
         dataset=dataset.id,
         config_template=simple_eval_template,
     )
@@ -82,7 +82,7 @@ def test_job_lifecycle_remote_ok(lumi_client_int, dialog_data, simple_eval_templ
     assert job_creation_result is not None
     assert lumi_client_int.jobs.get_jobs() is not None
 
-    job_status = lumi_client_int.jobs.wait_for_job(job_creation_result.id)
+    job_status = lumi_client_int.jobs.wait_for_job(job_creation_result.id, retries=11, poll_wait=30)
     logger.info(job_status)
 
     download_info = lumi_client_int.jobs.get_job_download(job_creation_result.id)


### PR DESCRIPTION
## What's changing

Unit tests in the backend can benefit from a BytesIO/StringIO backed fake S3, with both FakeS3Client and FakeS3FS. Integration tests will use an existing localstack, if any.

The previously used localstack started by testcontainers has been removed.

## How to test it

Just run the unit tests without the auxiiliary containers, and run the integration tests with the auxiliary containers.

## Additional notes for reviewers

Fixes https://github.com/mozilla-ai/lumigator/issues/422

## I already...

- [x] added some tests for any new functionality
- [x] updated the documentation
- [x] checked if a (backend) DB migration step was required and included it if required
  - Not needed since this is a test improvement.
