### PR TITLE
Frontend: GHA tweak to add checkout action before checking for path changes

### DIFF
--- a/.github/workflows/build_images_frontend.yaml
+++ b/.github/workflows/build_images_frontend.yaml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Check for modified paths
         uses: dorny/paths-filter@v3


### PR DESCRIPTION
# What's changing

The GHA for the frontend container uses the dorny paths-filter to decide if all the steps are required, but when running against `main` the [GHA failed](https://github.com/mozilla-ai/lumigator/actions/runs/12070875284/job/33661341581).

![image](https://github.com/user-attachments/assets/639b50f6-12c0-48c7-8875-49e795586b08)

This PR adds the checkout action before the paths filters are used to ensure we have the latest code pulled in.

Related PR: https://github.com/mozilla-ai/lumigator/pull/418

# How to test it

Steps to test the changes:

1.
2.
3.

# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [ ] Tested the changes in a working envvironment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
