### PR TITLE
Revert "Deployment: Add frontend profile to `start-lumigator`"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ local-logs:
 
 # Launches lumigator in 'user-local' mode (All services running locally, using latest docker container, no code mounted in)
 start-lumigator: .env
-	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose --profile local-fe -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d
+	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose --profile local -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d
 
 # Launches lumigator with no code mounted in, and forces build of containers (used in CI for integration tests)
 start-lumigator-build: .env


### PR DESCRIPTION
Reverts mozilla-ai/lumigator#452

The frontend container requires the `--build` flag to be supplied to `docker compose` in order to correctly run the UI build system to generate the UI (JS etc.), otherwise it just pulls the latest image which is based on `main` - currently this doesn't include all the UI work for a demoable UI.

`make start-lumigator` should be used when the intention is to run the UI locally via `npm run dev` and host it on port `3000`.