### PR TITLE
Disable results btn on failed experiments

### DIFF
--- a/lumigator/frontend/src/components/molecules/LExperimentDetails.vue
+++ b/lumigator/frontend/src/components/molecules/LExperimentDetails.vue
@@ -112,8 +112,7 @@
         size="small"
         icon="pi pi-external-link"
         label="View Results"
-        :disabled="!(selectedExperiment.status === 'SUCCEEDED'
-          || selectedExperiment.status === 'FAILED')"
+        :disabled="selectedExperiment.status !== 'SUCCEEDED'"
         @click="emit('l-results', selectedExperiment)"
       />
     </div>

--- a/lumigator/frontend/src/styles/_lumigator-theme.scss
+++ b/lumigator/frontend/src/styles/_lumigator-theme.scss
@@ -11,6 +11,11 @@
   &:hover {
     background-color: $l-button-hover-bg;
   }
+
+  &:disabled:hover {
+    background-color: var(--l-button-secondary-background);
+    cursor:not-allowed;
+  }
 }
 
 .p-card {


### PR DESCRIPTION
# Disable _"Show results"_ button when experiment has failed.

Experiments that have failed do not yield an endpoint to fetch their results which leads to unwanted behavior when users click the _"Show results"_ button. 

