### PR TITLE
Ensure Frontend service starts with Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ start-lumigator: .env
 
 # Launches lumigator with no code mounted in, and forces build of containers (used in CI for integration tests)
 start-lumigator-build: .env
-	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose  -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d --build
+	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose --profile local -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d --build
 
 # Launches lumigator without local dependencies (ray, S3)
 start-lumigator-external-services: .env

--- a/Makefile
+++ b/Makefile
@@ -76,18 +76,18 @@ local-logs:
 
 # Launches lumigator in 'user-local' mode (All services running locally, using latest docker container, no code mounted in)
 start-lumigator: .env
-	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose --profile local-fe -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d
+	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose  --profile local -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d
 
 # Launches lumigator with no code mounted in, and forces build of containers (used in CI for integration tests)
 start-lumigator-build: .env
-	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose --profile local-fe -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d --build
+	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose  -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d --build
 
 # Launches lumigator without local dependencies (ray, S3)
 start-lumigator-external-services: .env
 	docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d
 
 stop-lumigator:
-	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose --profile local --profile local-fe -f $(LOCAL_DOCKERCOMPOSE_FILE) down
+	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose --profile local -f $(LOCAL_DOCKERCOMPOSE_FILE) down
 
 clean-docker-buildcache:
 	docker builder prune --all -f

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ local-logs:
 
 # Launches lumigator in 'user-local' mode (All services running locally, using latest docker container, no code mounted in)
 start-lumigator: .env
-	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose  --profile local -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d
+	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) docker compose --profile local -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d
 
 # Launches lumigator with no code mounted in, and forces build of containers (used in CI for integration tests)
 start-lumigator-build: .env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -79,7 +79,6 @@ services:
     profiles:
       - local
 
-
   backend:
     image: mzdotai/lumigator:latest
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,6 @@ services:
       - localstack-data:/var/lib/localstack
     profiles:
       - local
-      - local-fe
 
   localstack-create-bucket:
     image: localstack/localstack:3.4.0
@@ -35,7 +34,6 @@ services:
       - "localhost:host-gateway"
     profiles:
       - local
-      - local-fe
 
   ray:
     image: rayproject/ray:2.30.0-py311-cpu${RAY_ARCH_SUFFIX}
@@ -80,7 +78,7 @@ services:
       - "localhost:host-gateway"
     profiles:
       - local
-      - local-fe
+
 
   backend:
     image: mzdotai/lumigator:latest
@@ -143,8 +141,6 @@ services:
         required: true
     ports:
       - 80:80
-    profiles:
-      - local-fe
 
 volumes:
 


### PR DESCRIPTION
# What's changing

I've removed the local-fe profile from `docker-compose.yml` and our` Makefile` to ensure the frontend always starts. 

With this change, local-up, start-lumigator, start-lumigator-external-services will all start the frontend service pulling the latest image.

In a follow up PR I aim to create a different version for the `local-up` make target, as `local-up` should be a contributor mode (starting a dev container with npm run serve, instead of an nginx with the code already built)


# How to test it
Ensure all make targets that spin the environment start the Frontend, and all make targets that stop the environment stop the frontend container.

- [X] Tested the changes in a working environment to ensure they work as expected
- [N/A ] Added some tests for any new functionality
- [N/A] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [X] Checked if a (backend) DB migration step was required and included it if required
