### PR TITLE
Retrofit requests-mock in SDK

### DIFF
--- a/lumigator/python/mzai/sdk/pyproject.toml
+++ b/lumigator/python/mzai/sdk/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 [tool.uv]
 dev-dependencies = [
     "pytest>=8.3.3",
+    "requests-mock>=1.12.1",
 ]
 
 [tool.uv.sources]

--- a/lumigator/python/mzai/sdk/tests/integration/test_scenarios.py
+++ b/lumigator/python/mzai/sdk/tests/integration/test_scenarios.py
@@ -13,12 +13,12 @@ from lumigator_schemas.jobs import JobType
 from lumigator_sdk.strict_schemas import JobEvalCreate
 
 
-def test_sdk_healthcheck_ok(lumi_client):
+def test_sdk_healthcheck_ok(lumi_client_int):
     """Test the healthcheck endpoint."""
     healthy = False
     for i in range(10):
         try:
-            lumi_client.health.healthcheck()
+            lumi_client_int.health.healthcheck()
             healthy = True
             break
         except Exception as e:
@@ -27,47 +27,47 @@ def test_sdk_healthcheck_ok(lumi_client):
     assert healthy
 
 
-def test_get_datasets_remote_ok(lumi_client):
+def test_get_datasets_remote_ok(lumi_client_int):
     """Test the `get_datasets` endpoint."""
-    datasets = lumi_client.datasets.get_datasets()
+    datasets = lumi_client_int.datasets.get_datasets()
     assert datasets is not None
 
 
-def test_dataset_lifecycle_remote_ok(lumi_client, dialog_data):
+def test_dataset_lifecycle_remote_ok(lumi_client_int, dialog_data):
     """Test a complete dataset lifecycle test: add a new dataset,
     list datasets, remove the dataset
     """
-    datasets = lumi_client.datasets.get_datasets()
+    datasets = lumi_client_int.datasets.get_datasets()
     n_initial_datasets = datasets.total
-    lumi_client.datasets.create_dataset(dataset=dialog_data, format=DatasetFormat.JOB)
-    datasets = lumi_client.datasets.get_datasets()
+    lumi_client_int.datasets.create_dataset(dataset=dialog_data, format=DatasetFormat.JOB)
+    datasets = lumi_client_int.datasets.get_datasets()
     n_current_datasets = datasets.total
-    created_dataset = lumi_client.datasets.get_dataset(datasets.items[0].id)
+    created_dataset = lumi_client_int.datasets.get_dataset(datasets.items[0].id)
     assert created_dataset is not None
-    lumi_client.datasets.delete_dataset(datasets.items[0].id)
-    datasets = lumi_client.datasets.get_datasets()
+    lumi_client_int.datasets.delete_dataset(datasets.items[0].id)
+    datasets = lumi_client_int.datasets.get_datasets()
     assert n_current_datasets - n_initial_datasets == 1
 
 
-def test_job_lifecycle_remote_ok(lumi_client, dialog_data, simple_eval_template):
+def test_job_lifecycle_remote_ok(lumi_client_int, dialog_data, simple_eval_template):
     """Test a complete job lifecycle test: add a new dataset,
     create a new job, run the job, get the results
     """
     logger.info("Starting jobs lifecycle")
-    datasets = lumi_client.datasets.get_datasets()
+    datasets = lumi_client_int.datasets.get_datasets()
     if datasets.total > 0:
         for removed_dataset in datasets.items:
-            lumi_client.datasets.delete_dataset(removed_dataset.id)
-    datasets = lumi_client.datasets.get_datasets()
+            lumi_client_int.datasets.delete_dataset(removed_dataset.id)
+    datasets = lumi_client_int.datasets.get_datasets()
     n_initial_datasets = datasets.total
-    dataset = lumi_client.datasets.create_dataset(dataset=dialog_data, format=DatasetFormat.JOB)
-    datasets = lumi_client.datasets.get_datasets()
+    dataset = lumi_client_int.datasets.create_dataset(dataset=dialog_data, format=DatasetFormat.JOB)
+    datasets = lumi_client_int.datasets.get_datasets()
     n_current_datasets = datasets.total
     assert n_current_datasets - n_initial_datasets == 1
 
-    jobs = lumi_client.jobs.get_jobs()
+    jobs = lumi_client_int.jobs.get_jobs()
     assert jobs is not None
-    logger.info(lumi_client.datasets.get_dataset(dataset.id))
+    logger.info(lumi_client_int.datasets.get_dataset(dataset.id))
 
     job = JobEvalCreate(
         name="test-job-int-001",
@@ -78,13 +78,13 @@ def test_job_lifecycle_remote_ok(lumi_client, dialog_data, simple_eval_template)
     logger.info(job)
     job.description = "This is a test job"
     job.max_samples = 2
-    job_creation_result = lumi_client.jobs.create_job(JobType.EVALUATION, job)
+    job_creation_result = lumi_client_int.jobs.create_job(JobType.EVALUATION, job)
     assert job_creation_result is not None
-    assert lumi_client.jobs.get_jobs() is not None
+    assert lumi_client_int.jobs.get_jobs() is not None
 
-    job_status = lumi_client.jobs.wait_for_job(job_creation_result.id)
+    job_status = lumi_client_int.jobs.wait_for_job(job_creation_result.id)
     logger.info(job_status)
 
-    download_info = lumi_client.jobs.get_job_download(job_creation_result.id)
+    download_info = lumi_client_int.jobs.get_job_download(job_creation_result.id)
     logger.info(f"getting result from {download_info.download_url}")
     requests.get(download_info.download_url, allow_redirects=True)

--- a/lumigator/python/mzai/sdk/tests/unit/test_jobs.py
+++ b/lumigator/python/mzai/sdk/tests/unit/test_jobs.py
@@ -3,19 +3,24 @@ from http import HTTPStatus
 from pathlib import Path
 
 from lumigator_schemas.jobs import JobType
+from lumigator_sdk.health import Health
+from lumigator_sdk.jobs import Jobs
 from lumigator_sdk.strict_schemas import JobEvalCreate
 from pydantic import ValidationError
 from pytest import raises
+from requests import Response
 from requests.exceptions import HTTPError
 from tests.helpers import load_json
 
 
 def test_create_job_ok_all(
-    mock_requests_response, mock_requests, lumi_client, json_data_job_response, json_data_job_all
+    lumi_client, json_data_job_response, json_data_job_all, request_mock
 ):
-    mock_requests_response.status_code = 200
-    data = load_json(json_data_job_response)
-    mock_requests_response.json = lambda: data
+    request_mock.post(
+        url=lumi_client.client._api_url + f"/{Jobs.JOBS_ROUTE}/{JobType.EVALUATION.value}/",
+        status_code=HTTPStatus.OK,
+        json=load_json(json_data_job_response),
+    )
 
     job_json = load_json(json_data_job_all)
     job_ret = lumi_client.jobs.create_job(
@@ -28,15 +33,16 @@ def test_create_job_ok_all(
 
 
 def test_create_job_ok_minimal(
-    mock_requests_response,
-    mock_requests,
     lumi_client,
     json_data_job_response,
     json_data_job_minimal,
+    request_mock
 ):
-    mock_requests_response.status_code = 200
-    data = load_json(json_data_job_response)
-    mock_requests_response.json = lambda: data
+    request_mock.post(
+        url=lumi_client.client._api_url + f"/{Jobs.JOBS_ROUTE}/{JobType.INFERENCE.value}/",
+        status_code=HTTPStatus.OK,
+        json=load_json(json_data_job_response),
+    )
 
     job_json = load_json(json_data_job_minimal)
     job_ret = lumi_client.jobs.create_job(JobType.INFERENCE, JobEvalCreate.model_validate(job_json))
@@ -47,46 +53,54 @@ def test_create_job_ok_minimal(
 
 
 def test_create_job_ok_extra(
-    mock_requests_response,
-    mock_requests,
     lumi_client,
     json_data_job_response,
     json_data_job_extra,
+    request_mock
 ):
-    mock_requests_response.status_code = 200
-    data = load_json(json_data_job_response)
-    mock_requests_response.json = lambda: data
+    request_mock.post(
+        url=lumi_client.client._api_url + f"/{Jobs.JOBS_ROUTE}/{JobType.INFERENCE.value}/",
+        status_code=HTTPStatus.OK,
+        json=load_json(json_data_job_response),
+    )
 
     job_json = load_json(json_data_job_extra)
     with raises(ValidationError):
         lumi_client.jobs.create_job(JobType.INFERENCE, JobEvalCreate.model_validate(job_json))
 
 
-def test_get_jobs_ok(mock_requests_response, mock_requests, lumi_client, json_data_jobs):
-    mock_requests_response.status_code = 200
-    data = load_json(json_data_jobs)
-    mock_requests_response.json = lambda: data
+def test_get_jobs_ok(lumi_client, json_data_jobs, request_mock):
+    request_mock.get(
+        url=lumi_client.client._api_url + f"/{Jobs.JOBS_ROUTE}",
+        status_code=HTTPStatus.OK,
+        json=load_json(json_data_jobs),
+    )
 
     jobs = lumi_client.jobs.get_jobs()
     assert jobs is not None
     assert len(jobs.items) == jobs.total
 
 
-def test_get_jobs_none(mock_requests_response, mock_requests, lumi_client):
-    mock_requests_response.status_code = 200
-    mock_requests_response.json = lambda: json.loads('{"total":0,"items":[]}')
+def test_get_jobs_none(lumi_client, request_mock):
+    request_mock.get(
+        url=lumi_client.client._api_url + f"/{Jobs.JOBS_ROUTE}",
+        status_code=HTTPStatus.OK,
+        json={"total":0,"items":[]},
+    )
 
     jobs = lumi_client.jobs.get_jobs()
     assert jobs is not None
     assert jobs.items == []
 
 
-def test_get_job_ok(mock_requests_response, mock_requests, lumi_client, json_data_job):
-    mock_requests_response.status_code = 200
-    data = load_json(json_data_job)
-    mock_requests_response.json = lambda: data
-
+def test_get_job_ok(lumi_client, json_data_job, request_mock):
     job_id = "6f6487ac-7170-4a11-af7a-0f6db1ec9a74"
+    request_mock.get(
+        url=lumi_client.client._api_url + f"/{Health.HEALTH_ROUTE}/{Jobs.JOBS_ROUTE}/{job_id}",
+        status_code=HTTPStatus.OK,
+        json=load_json(json_data_job),
+    )
+
     job = lumi_client.health.get_job(job_id)
 
     assert job is not None
@@ -95,12 +109,16 @@ def test_get_job_ok(mock_requests_response, mock_requests, lumi_client, json_dat
     assert job.submission_id == job_id
 
 
-def test_get_job_id_does_not_exist(mock_requests_response, mock_requests, lumi_client):
-    mock_requests_response.status_code = HTTPStatus.NOT_FOUND
-    mock_requests_response.json = lambda: None
-    error = HTTPError(response=mock_requests_response)
-    mock_requests.side_effect = error
+def test_get_job_id_does_not_exist(lumi_client, request_mock):
+    job_id = "00000000-0000-0000-0000-000000000000"
+    response = Response()
+    response.status_code = HTTPStatus.NOT_FOUND
+    error = HTTPError(response=response)
+    request_mock.get(
+        url=lumi_client.client._api_url + f"/{Health.HEALTH_ROUTE}/{Jobs.JOBS_ROUTE}/{job_id}",
+        exc = error
+    )
 
     # We expect the SDK to handle the 404 and return None.
-    job = lumi_client.health.get_job("00000000-0000-0000-0000-000000000000")
+    job = lumi_client.health.get_job(job_id)
     assert job is None

--- a/lumigator/python/mzai/sdk/tests/unit/test_models.py
+++ b/lumigator/python/mzai/sdk/tests/unit/test_models.py
@@ -1,24 +1,36 @@
+from http import HTTPStatus
+
+from lumigator_sdk.models import Models
 from pytest import raises
+from requests import Response
 from requests.exceptions import HTTPError
 from tests.helpers import load_json
 
 
 def test_sdk_suggested_models_ok(
-    mock_requests_response, mock_requests, lumi_client, json_data_models
+    lumi_client, json_data_models, request_mock
 ):
-    mock_requests_response.status_code = 200
-    data = load_json(json_data_models)
-    mock_requests_response.json = lambda: data
+    task = "summarization"
+    request_mock.get(
+        url=lumi_client.client._api_url + f"/{Models.MODELS_ROUTE}/{task}",
+        status_code=HTTPStatus.OK,
+        json=load_json(json_data_models),
+    )
 
-    models = lumi_client.models.get_suggested_models("summarization")
+    models = lumi_client.models.get_suggested_models(task)
     assert models is not None
     assert len(models.items) == models.total
 
 
-def test_sdk_suggested_models_invalid_task(mock_requests_response, mock_requests, lumi_client):
-    mock_requests_response.status_code = 400
-    error = HTTPError(response=mock_requests_response)
-    mock_requests.side_effect = error
+def test_sdk_suggested_models_invalid_task(lumi_client, request_mock):
+    task = "invalid_task"
+    response = Response()
+    response.status_code = HTTPStatus.BAD_REQUEST
+    error = HTTPError(response=response)
+    request_mock.get(
+        url=lumi_client.client._api_url + f"/{Models.MODELS_ROUTE}/{task}",
+        exc = error
+    )
 
     with raises(HTTPError):
-        lumi_client.models.get_suggested_models("invalid_task")
+        lumi_client.models.get_suggested_models(task)

--- a/lumigator/python/mzai/sdk/uv.lock
+++ b/lumigator/python/mzai/sdk/uv.lock
@@ -141,6 +141,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "requests-mock" },
 ]
 
 [package.metadata]
@@ -151,7 +152,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.3" }]
+dev = [
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "requests-mock", specifier = ">=1.12.1" },
+]
 
 [[package]]
 name = "packaging"
@@ -260,6 +264,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928 },
+]
+
+[[package]]
+name = "requests-mock"
+version = "1.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/32/587625f91f9a0a3d84688bf9cfc4b2480a7e8ec327cefd0ff2ac891fd2cf/requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401", size = 60901 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/ec/889fbc557727da0c34a33850950310240f2040f3b1955175fdb2b36a8910/requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563", size = 27695 },
 ]
 
 [[package]]


### PR DESCRIPTION
# What's changing

The `requests-mock` package has been retrofitted to the existing SDK tests, as a prerequisite to #488.

# How to test it

The automated tests should run ok.

# Additional notes for reviewers

This package makes it easier to understand how to mock HTTP requests.

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [x] Added some tests for any new functionality
- [x] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
