### PR TITLE
Fix job's results file name

### DIFF
--- a/docs/source/get-started/quickstart.md
+++ b/docs/source/get-started/quickstart.md
@@ -240,7 +240,7 @@ user@host:~/lumigator$ curl -s http://localhost:8000/api/v1/jobs/$SUBMISSION_ID/
   -H 'accept: application/json' | jq
 {
   "id": "5195c9a5-938d-475e-b0fc-cf866492909d",
-  "download_url": "http://localhost:4566/lumigator-storage/jobs/results/lumigator_enthusiasts/5195c9a5-938d-475e-b0fc-cf866492909d/eval_results.json?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test%2F20241031%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20241031T104126Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=0309fe4825bc2358180c607a4a4ad4e8d36946133574d8b9416df228ce62944e"
+  "download_url": "http://localhost:4566/lumigator-storage/jobs/results/lumigator_enthusiasts/5195c9a5-938d-475e-b0fc-cf866492909d/results.json?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test%2F20241031%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20241031T104126Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=0309fe4825bc2358180c607a4a4ad4e8d36946133574d8b9416df228ce62944e"
 }
 ```
 

--- a/lumigator/python/mzai/backend/backend/ray_submit/submission.py
+++ b/lumigator/python/mzai/backend/backend/ray_submit/submission.py
@@ -10,6 +10,7 @@ from ray.job_submission import JobSubmissionClient
 @dataclass(kw_only=True)
 class RayJobEntrypoint(ABC):
     config: JobConfig
+    metadata: dict[str, Any] | None = None
     runtime_env: dict[str, Any] | None = None
     num_cpus: int | float | None = None
     num_gpus: int | float | None = None
@@ -36,6 +37,7 @@ def submit_ray_job(client: JobSubmissionClient, entrypoint: RayJobEntrypoint) ->
     loguru.logger.info(f"Submitting {entrypoint.command_with_params}...{entrypoint.runtime_env}")
     return client.submit_job(
         entrypoint=entrypoint.command_with_params,
+        metadata=entrypoint.metadata,
         entrypoint_num_cpus=entrypoint.num_cpus,
         entrypoint_num_gpus=entrypoint.num_gpus,
         entrypoint_memory=entrypoint.memory,

--- a/lumigator/python/mzai/backend/backend/services/jobs.py
+++ b/lumigator/python/mzai/backend/backend/services/jobs.py
@@ -220,11 +220,13 @@ class JobService:
             "env_vars": runtime_env_vars,
         }
 
+        metadata = {"job_type": job_type}
+
         loguru.logger.info("runtime env setup...")
         loguru.logger.info(f"{runtime_env}")
 
         entrypoint = RayJobEntrypoint(
-            config=ray_config, runtime_env=runtime_env, num_gpus=worker_gpus
+            config=ray_config, metadata=metadata, runtime_env=runtime_env, num_gpus=worker_gpus
         )
         loguru.logger.info("Submitting Ray job...")
         submit_ray_job(self.ray_client, entrypoint)

--- a/lumigator/python/mzai/backend/backend/settings.py
+++ b/lumigator/python/mzai/backend/backend/settings.py
@@ -28,7 +28,7 @@ class BackendSettings(BaseSettings):
     S3_URL_EXPIRATION: int = 3600  # Time in seconds for pre-signed url expiration
     S3_DATASETS_PREFIX: str = "datasets"
     S3_JOB_RESULTS_PREFIX: str = "jobs/results"
-    S3_JOB_RESULTS_FILENAME: str = "{job_name}/{job_id}/eval_results.json"
+    S3_JOB_RESULTS_FILENAME: str = "{job_name}/{job_id}/results.json"
 
     # Ray
     RAY_HEAD_NODE_HOST: str = "localhost"

--- a/lumigator/python/mzai/backend/backend/tests/data/health_job_metadata.json
+++ b/lumigator/python/mzai/backend/backend/tests/data/health_job_metadata.json
@@ -9,7 +9,7 @@
   "error_type": null,
   "start_time": "2024-11-07T17:04:28.650000Z",
   "end_time": null,
-  "metadata": {},
+  "metadata": {"job_type": "evaluate"},
   "runtime_env": {
     "working_dir": "gcs://_ray_pkg_d5f068763637bcac.zip",
     "pip": {

--- a/lumigator/python/mzai/backend/backend/tests/data/health_job_metadata_ray.json
+++ b/lumigator/python/mzai/backend/backend/tests/data/health_job_metadata_ray.json
@@ -9,7 +9,7 @@
   "error_type": null,
   "start_time": 1730999068650,
   "end_time": null,
-  "metadata": {},
+  "metadata": {"job_type": "evaluate"},
   "runtime_env": {
     "working_dir": "gcs://_ray_pkg_d5f068763637bcac.zip",
     "pip": {

--- a/lumigator/python/mzai/jobs/evaluator/evaluator/jobs/evaluation/hf_evaluate.py
+++ b/lumigator/python/mzai/jobs/evaluator/evaluator/jobs/evaluation/hf_evaluate.py
@@ -57,13 +57,13 @@ def save_outputs(config: HuggingFaceEvalJobConfig, evaluation_results: dict) -> 
     def save_to_s3(local_path: Path, storage_path: str):
         s3 = s3fs.S3FileSystem()
         if storage_path.endswith("/"):
-            storage_path = "s3://" + str(Path(storage_path[5:]) / config.name / "eval_results.json")
+            storage_path = "s3://" + str(Path(storage_path[5:]) / config.name / "results.json")
         logger.info(f"Storing into {storage_path}...")
         s3.put_file(local_path, storage_path)
 
     # generate local temp file ANYWAY
     # (we don't want to lose all eval data if there is an issue wth s3)
-    local_path = Path(EVALUATOR_RESULTS_PATH) / config.name / "eval_results.json"
+    local_path = Path(EVALUATOR_RESULTS_PATH) / config.name / "results.json"
 
     try:
         save_to_disk(local_path)

--- a/lumigator/python/mzai/jobs/evaluator/examples/configs/evaluation/hf_evaluate_config.yaml
+++ b/lumigator/python/mzai/jobs/evaluator/examples/configs/evaluation/hf_evaluate_config.yaml
@@ -18,7 +18,7 @@ evaluation:
   max_samples: 10
   # output file path
   # - if you provide a path complete with a filename, results will be stored in it
-  # - if you provide a dir, results will be stored in <dir>/<config.name>/eval_results.json
+  # - if you provide a dir, results will be stored in <dir>/<config.name>/results.json
   # - if you don't provide a storage path, results will be stored locally (see ~/.lm-buddy/results)
   # storage_path: "s3://platform-storage/experiments/results/"
   # return input data in the output file

--- a/lumigator/python/mzai/jobs/evaluator/examples/configs/evaluation/hf_evaluate_inference_server_config.yaml
+++ b/lumigator/python/mzai/jobs/evaluator/examples/configs/evaluation/hf_evaluate_inference_server_config.yaml
@@ -18,7 +18,7 @@ evaluation:
   max_samples: 10
   # output file path
   # - if you provide a path complete with a filename, results will be stored in it
-  # - if you provide a dir, results will be stored in <dir>/<config.name>/eval_results.json
+  # - if you provide a dir, results will be stored in <dir>/<config.name>/results.json
   # - if you don't provide a storage path, results will be stored locally (see ~/.lm-buddy/results)
   # storage_path: "s3://platform-storage/experiments/results/"
   # return input data in the output file

--- a/lumigator/python/mzai/jobs/evaluator/examples/configs/evaluation/hf_evaluate_openai_config.yaml
+++ b/lumigator/python/mzai/jobs/evaluator/examples/configs/evaluation/hf_evaluate_openai_config.yaml
@@ -18,7 +18,7 @@ evaluation:
   max_samples: 10
   # output file path
   # - if you provide a path complete with a filename, results will be stored in it
-  # - if you provide a dir, results will be stored in <dir>/<config.name>/eval_results.json
+  # - if you provide a dir, results will be stored in <dir>/<config.name>/results.json
   # - if you don't provide a storage path, results will be stored locally (see ~/.lm-buddy/results)
   # storage_path: "s3://platform-storage/experiments/results/"
   # return input data in the output file


### PR DESCRIPTION
# What's changing

When an inference or evaluation job completes successfully, it creates a results file and stores it in object storage. The file is named either `eval_results.json` or `inference_results.json`, depending on the job type.

However, when attempting to generate a download URL through `/api/v1/jobs/{job_id}/result/download`, the URL always points to a file named eval_results.json. For inference jobs, this file does not exist, resulting in a broken download process.

Dynamically assign the file name based on the job type.

Also, change `eval_results` to `evaluation_results` for uniformity.

Closes #503

# How to test it

Steps to Reproduce:

1. Run an inference job to completion.
1. Check the S3 URI that points to the results file. The file name is `inference_results.json`.
1. Try to download the file, by retrieving a download URL through the API. It should point to a file called `inference_results.json`.

# I already...

- - [x] Tested the changes in a working environment to ensure they work as expected
- - [x] Added some tests for any new functionality
- [NA] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [NA] Checked if a (backend) DB migration step was required and included it if required
