### PR TITLE
Change inference job's results file name

### DIFF
--- a/docs/source/user-guides/inference.md
+++ b/docs/source/user-guides/inference.md
@@ -73,7 +73,7 @@ Refer to the `.env.example` file in the repository for more details.
     lm_client.jobs.wait_for_job(job.id, poll_wait=10)
 
     # Retrieve the job results
-    url = f"http://{HOST}:{RAY_PORT}/{BUCKET}/jobs/results/{name}/{job.id}/inference_results.json"
+    url = f"http://{HOST}:{RAY_PORT}/{BUCKET}/jobs/results/{name}/{job.id}/results.json"
     response = requests.get(url=url)
 
     if response.status_code != 200:
@@ -81,7 +81,7 @@ Refer to the `.env.example` file in the repository for more details.
     results = response.json()
 
     # Write the JSON results to a file
-    with open("inference_results.json", "w") as f:
+    with open("results.json", "w") as f:
         json.dump(results, f, indent=4)
     ```
 
@@ -93,11 +93,11 @@ Refer to the `.env.example` file in the repository for more details.
 
 ## Verify
 
-Review the contents of the `inference_results.json` file to ensure that the inference job ran
+Review the contents of the `results.json` file to ensure that the inference job ran
 successfully:
 
 ```console
-user@host:~/lumigator$ cat inference_results.json | jq
+user@host:~/lumigator$ cat results.json | jq
 {
 "prediction": [
     "A man has trouble breathing. He is sent to see a pulmonary specialist. The doctor tests him for asthma. He does not have any allergies that he knows of. He also has a heavy feeling in his chest when he tries to breathe. This happens a lot when he works out, he says.",

--- a/lumigator/python/mzai/jobs/inference/inference.py
+++ b/lumigator/python/mzai/jobs/inference/inference.py
@@ -38,9 +38,7 @@ def save_to_disk(local_path: Path, data_dict: dict):
 def save_to_s3(config: InferenceJobConfig, local_path: Path, storage_path: str):
     s3 = s3fs.S3FileSystem()
     if storage_path.endswith("/"):
-        storage_path = "s3://" + str(
-            Path(storage_path[5:]) / config.name / "inference_results.json"
-        )
+        storage_path = "s3://" + str(Path(storage_path[5:]) / config.name / "results.json")
     logger.info(f"Storing into {storage_path}...")
     s3.put_file(local_path, storage_path)
 
@@ -51,9 +49,7 @@ def save_outputs(config: InferenceJobConfig, inference_results: dict) -> Path:
     # generate local temp file ANYWAY:
     # - if storage_path is not provided, it will be stored and kept into a default dir
     # - if storage_path is provided AND saving to S3 is successful, local file is deleted
-    local_path = Path(
-        Path.home() / ".lumigator" / "results" / config.name / "inference_results.json"
-    )
+    local_path = Path(Path.home() / ".lumigator" / "results" / config.name / "results.json")
 
     try:
         save_to_disk(local_path, inference_results)


### PR DESCRIPTION
# What's changing

Change the inference job's results file name to `results.json`.

Refs #503

# I already...

- - [x] Tested the changes in a working environment to ensure they work as expected
- [NA] Added some tests for any new functionality
- - [x] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [NA] Checked if a (backend) DB migration step was required and included it if required
