### PR TITLE
337 annotation/ground truth generation uses new inference job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,8 @@ test-backend-unit:
 
 test-backend-integration-target:
 	cd lumigator/python/mzai/backend/backend/tests;	\
-	SQLALCHEMY_DATABASE_URL=sqlite:///local.db uv run pytest -o python_files="backend/tests/integration/*/test_*.py"
+	RAY_WORKER_GPUS="0.0" RAY_WORKER_GPUS_FRACTION="0.0" \
+	SQLALCHEMY_DATABASE_URL=sqlite:///local.db uv run pytest -s -o python_files="backend/tests/integration/*/test_*.py"
 
 test-backend-integration:
 ifeq ($(CONTAINERS_RUNNING),)

--- a/docs/source/get-started/suggested-models.md
+++ b/docs/source/get-started/suggested-models.md
@@ -185,3 +185,35 @@ weights for a given open LLM, as well as everything needed to actually run that 
 computer. There's nothing to install or configure.
 
 There are no summarization-specific parameters for this model.
+
+
+# Reference models
+
+Before you jump into evaluating datasets, you should consider the following importance of quality ground-truth and annotations.
+
+Ground-truth would be the actual, expected output or correct answer in for a given task (such as summarization), serving as a reference to compare the model's predictions. Typically, a human with enough expertise in the task will annotate or label a dataset with those references for each sample (for example, an acceptable summary of the input text).
+
+To evaluate a model as reliably as possible, we encourage using human-provided ground-truth to compare against. Failing that, Lumigator enables the user to do automatic annotation with a [well tested model](https://blog.mozilla.ai/on-model-selection-for-text-summarization/) to get you started.
+
+You can do this through the API, using one of Lumigator jobs: `/jobs/annotate`.
+
+::::{tab-set}
+
+:::{tab-item} cURL
+:sync: tab1
+
+```console
+user@host:~/lumigator$
+curl -X 'POST' \
+  'http://localhost:8000/api/v1/jobs/annotate/' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "name": "test_annotate",
+  "description": "annotate",
+  "dataset": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "max_samples": -1,
+  "task": "summarization"
+}'
+```
+Under the hood, this will launch an inference job with the reference model for summarization (BART, described above).

--- a/lumigator/python/mzai/backend/backend/api/routes/jobs.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/jobs.py
@@ -50,7 +50,7 @@ def create_annotation_job(
     request: Request,
     response: Response,
 ) -> JobResponse:
-    """This uses a hardcoded model, that is, Lumigator's opinion on what
+    """This uses a hardcoded model, that is, Lumigator's opinion on the what
     reference model should be used to generate annotations.
     See more: https://blog.mozilla.ai/lets-build-an-app-for-evaluating-llms/
     """

--- a/lumigator/python/mzai/backend/backend/api/routes/jobs.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/jobs.py
@@ -50,7 +50,7 @@ def create_annotation_job(
     request: Request,
     response: Response,
 ) -> JobResponse:
-    """This uses a hardcoded model, that is, Lumigator's opinion on the what
+    """This uses a hardcoded model, that is, Lumigator's opinion on what
     reference model should be used to generate annotations.
     See more: https://blog.mozilla.ai/lets-build-an-app-for-evaluating-llms/
     """

--- a/lumigator/python/mzai/backend/backend/tests/integration/api/routes/test_api_workflows.py
+++ b/lumigator/python/mzai/backend/backend/tests/integration/api/routes/test_api_workflows.py
@@ -100,3 +100,27 @@ def test_job_non_existing(local_client: TestClient):
     response = local_client.get(f"/jobs/{non_existing_id}")
     assert response.status_code == 404
     assert response.json()["detail"] == f"Job {non_existing_id} not found."
+
+
+def test_annotation_job(
+    local_client: TestClient,
+):
+    payload = {
+        "name": "test_annotate",
+        "description": "Test run for Huggingface model",
+        "dataset": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "max_samples": 2,
+        "task": "summarization",
+    }
+
+    post_response = local_client.post(
+        "/jobs/annotate/",
+        json=payload,
+    )
+
+    assert post_response.status_code == 201
+
+    job_id = post_response.json()["id"]
+    response = local_client.get(f"/jobs/{job_id}")
+
+    assert response.status_code == 200

--- a/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
+++ b/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
@@ -88,6 +88,14 @@ class JobInferenceCreate(BaseModel):
     config_template: str | None = None
 
 
+class JobAnnotateCreate(BaseModel):
+    name: str
+    description: str = ""
+    dataset: UUID
+    max_samples: int = -1  # set to all samples by default
+    task: str | None = "summarization"
+
+
 class JobResponse(BaseModel, from_attributes=True):
     id: UUID
     name: str
@@ -122,4 +130,5 @@ class Job(JobResponse, JobSubmissionResponse):
     consumers. Tt was not conceived as a type that will be around for long, as
     the API needs to be refactored to better support experiments.
     """
+
     pass


### PR DESCRIPTION
# Context
Lumigator used to offer a service, /groundtruth, to annotate a dataset when it did not have human-provided ground-truth to compare against in evaluation. This PR does not address whether this is a good practice; inference marks its results as AI-generated (with the field "model: ai_model_that_generated_them" as an output attribute). The user can use this information to trust accordingly.

# What's changing

* Adds annotation using the new, independent inference job with a model selected by us (bart).
* Exposes the service as /jobs/annotate
* Introduces JobAnnotationCreate, which does not allow setting model or temperature. It hands over to a JobInferenceCreate which sets the model and temperature we decided. 

Closes #337 

# How to test it

Steps to test the changes:

1. Start lumigator (make local-up or start-lumigator build)
2. Navigate to localhost:8000/docs
3. Update a dataset, notice the dataset_id
4. Go to /jobs/annotate, set the dataset_id you obtained, a low number of samples, a random name and description, launch
5. Go to the ray dashboard (http://localhost:8265)
6. The new job should succeed and the results should show annotations.

# Additional notes for reviewers
I've considered:
* /annotate, to keep in line with the old /groundtruth
* Waiting until we have a ~~workflow~~ composite task from #485 and introduce this as a silent and optional step there (but that would be, rather, #406)
* Creating a composite task of 1 and expose through experiments

The two latter feel overkill, since we are considering introducing actual orchestration. Using /jobs/annotate acknowledges (hopefully signals to the user) that this is just another variant of the existing jobs).

This job will be called from the UI separately, after the user gets asked whether they are OK with generating some ground-truth as second best option for their dataset.

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [x] Added some tests for any new functionality
- [x] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
