### PR TITLE
UI: Ensure (all) experiments which can have their status updated, get their status updated.

### DIFF
--- a/lumigator/frontend/src/stores/experiments/store.js
+++ b/lumigator/frontend/src/stores/experiments/store.js
@@ -130,6 +130,10 @@ export const useExperimentStore = defineStore('experiment', () => {
   async function updateJobStatus(jobId) {
     try {
       const status = await experimentService.fetchJobStatus(jobId);
+      const experiment = experiments.value.find((experiment) => experiment.id === jobId);
+      if (experiment) {
+        experiment.status = status.toUpperCase();
+      }
       const job = runningJobs.value.find((job) => job.id === jobId);
       if (job) {
         job.status = status.toUpperCase();


### PR DESCRIPTION
# What's changing

This PR fixes a UI bug where the status of an experiment is updated each time the page/route is navigated away and back to.

The experiments are loaded once to populate the table, then we mainly deal with updating the running jobs. 

The change here just aligns the experiment and running job status when their IDs match. It's a short term/easy fix to keep the change small.

# How to test it

Steps to test the changes:

1. Start Lumigator and the UI
2.Upload a dataset and create an experiment, then fairly quicky...
3. Navigate to datasets, then back to experiments - as the experiments table renders it shouldn't change from 'created' to 'pending' it should already show 'pending'

# Additional notes for reviewers

A cleaner potential solution would probably look at how the experiments are updated in a single place.

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
