### PR TITLE
Take env vars from .env or shell vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,13 @@ UNAME:= $(shell uname -o)
 PROJECT_ROOT := $(shell git rev-parse --show-toplevel)
 CONTAINERS_RUNNING := $(shell docker ps -q --filter "name=lumigator-")
 
+-include .env
+# GPU related settings
+#
+RAY_WORKER_GPUS ?= "0.0"
+RAY_WORKER_GPUS_FRACTION ?= "0.0"
+INFERENCE_PIP_REQS ?= ../jobs/inference/requirements_cpu.txt
+
 #used in docker-compose to choose the right Ray image
 ARCH := $(shell uname -m)
 RAY_ARCH_SUFFIX :=

--- a/lumigator/python/mzai/backend/backend/tests/README.md
+++ b/lumigator/python/mzai/backend/backend/tests/README.md
@@ -30,6 +30,13 @@ class. This class inherits from the
 class and reads its values from the environment when instantiated. These settings are then used for
 instantiating various clients/controlling business logic throughout the application.
 
+The Makefile used to run tests will take the following environment variables from the environment
+or the `.env` file (with this file taking precedence) if they exist:
+
+* RAY_WORKER_GPUS (default value `0.0`)
+* RAY_WORKER_GPUS_FRACTION (default value `0.0`)
+* INFERENCE_PIP_REQS (default value `../jobs/inference/requirements_cpu.txt`)
+
 In cases where a test requires a different dependency than those defined by the `BackendSettings`
 class (e.g., for creating a test client for a mock service), a test dependency override can be
 pecified in the `conftest.py` fixture.

--- a/lumigator/python/mzai/jobs/inference/requirements_cpu.txt
+++ b/lumigator/python/mzai/jobs/inference/requirements_cpu.txt
@@ -1,0 +1,11 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
+accelerate==1.1.1
+datasets==2.20.0
+loguru==0.7.2
+mistralai==0.4.2
+openai==1.55.3
+python-box==7.2.0
+s3fs==2024.5.0
+sentencepiece==0.2.0
+torch==2.5.1
+transformers==4.46.3


### PR DESCRIPTION
# What's changing

The Makefile will now incorporate the `RAY_WORKER_GPUS`,  `RAY_WORKER_GPUS_FRACTION` and `INFERENCE_PIP_REQS` environment variables from the shell or the `.env` file (if it exists). This allows selective use of GPU and prevents tasks from being stuck in pending for cpu-only tests.

# How to test it

From the base directory:

1. export RAY_WORKER_GPUS="0.0"
2. export RAY_WORKER_GPUS_FRACTION="0.0"
3. make test-backend-integration-target

Tests shall pass, but the Ray dashboard will show failed jobs (instead of pending).

# Additional notes for reviewers

N/A

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [x] Added some tests for any new functionality
  - N/A
- [x] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
  - N/A 
