### PR TITLE
missing .env file from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ To start Lumigator locally, follow these steps:
     cd lumigator
     ```
 
+1. Create a `.env` file and copy the content of `.env.example`:
+
+    ```bash
+    cp .env.example .env
+    ```
+
 1. Start Lumigator using Docker Compose:
 
     ```bash


### PR DESCRIPTION
# What's changing

Front end doesn't work properly in _user mode_ without the `.env` file and we need to add a step for setting it up

# How to test it

1. Install Lumigator to a new directory
2. Run Lumigator as a user with `make start-lumigator`
3. Try to upload dataset in the UI (notice the errors in the browser console)
4. Stop Lumigator `make stop-lumigator`
5. Create a `.env` file with `cp .env.example .env`
6. Start Lumigator again  with `make start-lumigator`
7. As soon as the setup is finished try again uploading a dataset.

