### PR TITLE
Fix FE build and push

### DIFF
--- a/.github/workflows/build_images_frontend.yaml
+++ b/.github/workflows/build_images_frontend.yaml
@@ -34,12 +34,12 @@ jobs:
               - 'lumigator/lumigator/frontend/**'
 
       - name: Truncate commit SHA
-        if: steps.filter.outputs.rebuild_fe == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/')
+        if: steps.filter.outputs.rebuild_fe == 'true' && github.event_name == 'push' || contains(github.ref, 'refs/tags/')
         run: echo "GITHUB_SHA_SHORT=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> $GITHUB_ENV
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
-        if: steps.filter.outputs.rebuild_fe == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/')
+        if: steps.filter.outputs.rebuild_fe == 'true' && github.event_name == 'push' || contains(github.ref, 'refs/tags/')
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
         if: steps.filter.outputs.rebuild_fe == 'true' || contains(github.ref, 'refs/tags/')
         with:
           file: "lumigator/frontend/Dockerfile"
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/') }}
+          push: ${{ github.event_name == 'push' || contains(github.ref, 'refs/tags/') }}
           target: "server"
           tags: |
             ${{ contains(github.ref, 'refs/tags/') == false && format('mzdotai/lumigator-frontend:frontend_{0}', env.GITHUB_SHA_SHORT) || '' }}

--- a/.github/workflows/build_images_frontend.yaml
+++ b/.github/workflows/build_images_frontend.yaml
@@ -34,11 +34,12 @@ jobs:
               - 'lumigator/lumigator/frontend/**'
 
       - name: Truncate commit SHA
-        run: echo "GITHUB_SHA_SHORT=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> $GITHUB_ENV
+        if: steps.filter.outputs.rebuild_fe == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/')
+        run: echo "GITHUB_SHA_SHORT=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
-        if: steps.filter.outputs.rebuild_fe == 'true' && github.event_name == 'push' || contains(github.ref, 'refs/tags/')
+        if: steps.filter.outputs.rebuild_fe == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/')
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -48,7 +49,7 @@ jobs:
         if: steps.filter.outputs.rebuild_fe == 'true' || contains(github.ref, 'refs/tags/')
         with:
           file: "lumigator/frontend/Dockerfile"
-          push: ${{ github.event_name == 'push' || contains(github.ref, 'refs/tags/') }}
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/') }}
           target: "server"
           tags: |
             ${{ contains(github.ref, 'refs/tags/') == false && format('mzdotai/lumigator-frontend:frontend_{0}', env.GITHUB_SHA_SHORT) || '' }}

--- a/.github/workflows/build_images_frontend.yaml
+++ b/.github/workflows/build_images_frontend.yaml
@@ -34,7 +34,6 @@ jobs:
               - 'lumigator/lumigator/frontend/**'
 
       - name: Truncate commit SHA
-        if: steps.filter.outputs.rebuild_fe == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/')
         run: echo "GITHUB_SHA_SHORT=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
 
       - name: Login to DockerHub

--- a/.github/workflows/build_images_frontend.yaml
+++ b/.github/workflows/build_images_frontend.yaml
@@ -34,7 +34,6 @@ jobs:
               - 'lumigator/lumigator/frontend/**'
 
       - name: Truncate commit SHA
-        if: steps.filter.outputs.rebuild_fe == 'true' && github.event_name == 'push' || contains(github.ref, 'refs/tags/')
         run: echo "GITHUB_SHA_SHORT=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> $GITHUB_ENV
 
       - name: Login to DockerHub


### PR DESCRIPTION
# What's changing

Fixing naming bug for frontend images generated when a PR is merged to main

# How to test it

Take a look to the action that builds the FE

e.g. 

commit: `e9408ee1e393824b3b8799e6dab1e6d2d86c6011`
shortened: `e9408ee`

https://github.com/mozilla-ai/lumigator/actions/runs/12432909639/job/34713333184?pr=545#step:4:2

```
 echo "GITHUB_SHA_SHORT=$(echo e9408ee1e393824b3b8799e6dab1e6d2d86c6011 | cut -c1-7)" >> $GITHUB_ENV
```

https://github.com/mozilla-ai/lumigator/actions/runs/12432909639/job/34713333184?pr=545#step:6:6

```
Run docker/build-push-action@v6
  with:
    file: lumigator/frontend/Dockerfile
    push: false
    target: server
    tags: mzdotai/lumigator-frontend:frontend_e9408ee

    load: false
    no-cache: false
    pull: false
    github-token: ***
  env:
    GITHUB_SHA_SHORT: e9408ee
```


# Additional notes for reviewers

N/A

# I already...

- [X] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
