### PR TITLE
Fix frontend build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,4 @@
 # .env.example
-
 # Lumigator API configuration
 # LUMI_API_CORS_ALLOWED_ORIGINS:
 # Comma separated list of origins (See: https://developer.mozilla.org/en-US/docs/Glossary/Origin)
@@ -9,7 +8,6 @@
 # To allow CORS requests from anywhere specify "*" as any, or the only value.
 # e.g. "*"
 LUMI_API_CORS_ALLOWED_ORIGINS=${LUMI_API_CORS_ALLOWED_ORIGINS:-http://localhost,http://localhost:3000}
-
 # AWS Variables for S3 Object Storage
 # Configure these for AWS access, or use defaults for local development with LocalStack.
 AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test}
@@ -17,19 +15,19 @@ AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test}
 AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-2}
 AWS_ENDPOINT_URL=${AWS_ENDPOINT_URL:-http://localhost:4566}
 S3_BUCKET=${S3_BUCKET:-lumigator-storage}
-LOCALSTACK_AUTH_TOKEN=<your_localstack_auth_token>  # Optional: Required only if using LocalStack with advanced features/LocalStack Pro.
-
+# Optional: Required only if using LocalStack with advanced features/LocalStack Pro.
+LOCALSTACK_AUTH_TOKEN=<your_localstack_auth_token>
 # Ray Cluster Configuration
 # These settings are for the local Ray setup. To use an external Ray cluster, you MUST use an external S3-compatible storage
 # to ensure the Ray workers can access data from your Lumigator server.
 RAY_HEAD_NODE_HOST=${RAY_HEAD_NODE_HOST:-ray}
 RAY_DASHBOARD_PORT=${RAY_DASHBOARD_PORT:-8265}
-
 # External API Keys
 # Provide keys for external services as required by your application.
-MISTRAL_API_KEY=${MISTRAL_API_KEY:-}  # Optional: Key for Mistral API access.
-OPENAI_API_KEY=${OPENAI_API_KEY:-}    # Optional: Key for OpenAI API access.
-
+# Optional: Key for Mistral API access.
+MISTRAL_API_KEY=${MISTRAL_API_KEY:-}
+# Optional: Key for OpenAI API access.
+OPENAI_API_KEY=${OPENAI_API_KEY:-}
 # Frontend configuration
 # URL to connect with the backend
 VUE_APP_BASE_URL=http://localhost:8000/api/v1/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -133,7 +133,7 @@ services:
       dockerfile: "./lumigator/frontend/Dockerfile"
       target: "server"
       args:
-      - VUE_APP_BASE_URL=${VUE_APP_BASE_URL}
+       VUE_APP_BASE_URL: ${VUE_APP_BASE_URL}
     depends_on:
       backend:
         condition: "service_started"

--- a/lumigator/frontend/.env
+++ b/lumigator/frontend/.env
@@ -1,1 +1,0 @@
-VUE_APP_BASE_URL=http://localhost:8000/api/v1/

--- a/lumigator/frontend/Dockerfile
+++ b/lumigator/frontend/Dockerfile
@@ -6,6 +6,7 @@ FROM node:${NODE_VERSION}-alpine AS base
 COPY ../../ /mzai
 
 WORKDIR /mzai/
+ARG VUE_APP_BASE_URL
 
 # Install dependencies
 RUN npm --prefix /mzai/lumigator/frontend install

--- a/lumigator/frontend/package.json
+++ b/lumigator/frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "env $(grep -v '^#' ../../.env | grep -v '^$' | xargs) vite",
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --fix",


### PR DESCRIPTION
# What's changing

We found out currently our frontend bulid wasn't working properly. The root cause is that the .env file wasn't being passed properly to the npm command, which meant the VUE_APP_BASE_URL wasn't used inside the Dockerfile.

In order to fixed that I've modified several files to ensure consistency accross the project. One of the key things is that the .env.example file has changed to avoid inline comments , which means everyone will need to ensure their .env file is aligned with that once this is merged.


# How to test it

Steps to test the changes:

1. Spin up the Frontend locally (Run make local-up or start-lumigator-build)
2. Check that the frontend can connect to the backend)



# I already...

- [X] Tested the changes in a working environment to ensure they work as expected
- [N/A] Added some tests for any new functionality
- [N/A ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [X] Checked if a (backend) DB migration step was required and included it if required
