### PR TITLE
Tests: SDK integration tests stability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endif
 
 define run_with_containers
 	@echo "No Lumigator containers are running. Starting containers..."
-	make start-lumigator-build
+	make start-lumigator-build; sleep 5;
 	trap "cd $(PROJECT_ROOT); make stop-lumigator" EXIT; \
 	make $(1)
 endef


### PR DESCRIPTION
# What's changing

https://github.com/mozilla-ai/lumigator/issues/558 describes a problem where sometimes SDK integration tests don't appear to work. 

This PR adds a (possibly short term) simple fix of allowing the containers 5 seconds after they're running before the tests begin. This is intended to give the backend container which hosts the API (FastAPI) to fully start up and be ready to receive requests.

# How to test it

See the repro steps in the bug report, these can be followed and the problem will not occur.

# Additional notes for reviewers

**Readiness check**

As part of the investigation I looked into trying to use the docker compose health check for the backend to manually attempt to query the API's health endpoint so we knew when it was healthy and ready.

A drawback of this appears to be that the health check would run 'forever after' the container was healthy, not just during the startup phase. This isn't really what we want - to be making requests repeatedly to the API which might show up in logs etc.

I also considered whether we could add some code to the makefile which would perform the 'health check' manually before allowing the tests to start, but it introduces more code, more complexity, and potentially requirements like `jq` and `yq` to parse the port settings and results of the API calls. Which mean a lot more consideration for the GitHub runners.

If things change we can revisit this to add these readiness checks, but for now it felt like the most pragmatic thing to do was to introduce the simple 5s sleep before the tests begin.

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
