### PR TITLE
Hotfix for container stop in tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 # Set to "TRUE" if the containers need to be up and running after
 # a test target failed (e.g. in CI where containers are inspected
 # for logs after failed steps)
-CONTAINERS_UP_ON_ERROR="FALSE"
+KEEP_CONTAINERS_UP="FALSE"
 
 # Lumigator API configuration
 # LUMI_API_CORS_ALLOWED_ORIGINS:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CONTAINERS_RUNNING := $(shell docker ps -q --filter "name=lumigator-")
 
 -include .env
 
-KEEP_CONTAINERS_UP ?= "TRUE"
+KEEP_CONTAINERS_UP ?= "FALSE"
 
 #used in docker-compose to choose the right Ray image
 ARCH := $(shell uname -m)
@@ -20,7 +20,7 @@ endif
 define run_with_containers
 	@echo "No Lumigator containers are running. Starting containers..."
 	make start-lumigator-build
-	@if [ $(KEEP_CONTAINERS_UP) = "TRUE" ]; then trap "cd $(PROJECT_ROOT); make stop-lumigator" EXIT; fi; \
+	@if [ $(KEEP_CONTAINERS_UP) = "FALSE" ]; then echo "The script will remove containers after tests"; trap "cd $(PROJECT_ROOT); make stop-lumigator" EXIT; fi; \
 	make $(1)
 endef
 


### PR DESCRIPTION
# What's changing

The `KEEP_CONTAINERS_UP` env var did not work correctly.

# How to test it

With the default config in `main`, use `make test-sdk-integration`. The containers will not stop after tests.

# Additional notes for reviewers

N/A

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
