### PR TITLE
Remove global include from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CONTAINERS_RUNNING := $(shell docker ps -q --filter "name=lumigator-")
 
 KEEP_CONTAINERS_UP := $(shell grep -E '^KEEP_CONTAINERS_UP=' .env | cut -d'=' -f2 | tr -d '"')
 
-KEEP_CONTAINERS_UP := $(or $(KEEP_CONTAINERS_UP),FALSE)
+KEEP_CONTAINERS_UP ?= "FALSE"
 
 #used in docker-compose to choose the right Ray image
 ARCH := $(shell uname -m)

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ DEV_DOCKER_COMPOSE_FILE:= .devcontainer/docker-compose.override.yaml
 .env:
 	@if [ ! -f .env ]; then cp .env.example .env; echo ".env created from .env.example"; fi
 
-
 # Launches Lumigator in 'development' mode (all services running locally, code mounted in)
 local-up: .env
 	uv run pre-commit install

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ UNAME:= $(shell uname -o)
 PROJECT_ROOT := $(shell git rev-parse --show-toplevel)
 CONTAINERS_RUNNING := $(shell docker ps -q --filter "name=lumigator-")
 
--include .env
+KEEP_CONTAINERS_UP := $(shell grep -E '^KEEP_CONTAINERS_UP=' .env | cut -d'=' -f2 | tr -d '"')
 
-KEEP_CONTAINERS_UP ?= "FALSE"
+KEEP_CONTAINERS_UP := $(or $(KEEP_CONTAINERS_UP),FALSE)
 
 #used in docker-compose to choose the right Ray image
 ARCH := $(shell uname -m)
@@ -66,6 +66,7 @@ DEV_DOCKER_COMPOSE_FILE:= .devcontainer/docker-compose.override.yaml
 
 .env:
 	@if [ ! -f .env ]; then cp .env.example .env; echo ".env created from .env.example"; fi
+
 
 # Launches Lumigator in 'development' mode (all services running locally, code mounted in)
 local-up: .env


### PR DESCRIPTION
# What's changing
Currently our Makefile includes the `.env` file to pull `KEEP_CONTAINERS_UP="FALSE" variable into the Makefile. That's causing issues because the way our variables are defined in the `.env` file. In this PR I remove the include and just pull the var in the Makefile to avoid general issues.



# How to test it

Steps to test the changes:

1. You can still use the Make targets for the SDK/Backend tests with the containers running while all the Vars are as they are in the `.env` file inside the containers

# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [X] Tested the changes in a working environment to ensure they work as expected
- [N/A ] Added some tests for any new functionality
- [N/A] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [N/A ] Checked if a (backend) DB migration step was required and included it if required
