### PR TITLE
Issue 556 retrieve models

### DIFF
--- a/lumigator/frontend/src/components/molecules/LExperimentForm.vue
+++ b/lumigator/frontend/src/components/molecules/LExperimentForm.vue
@@ -90,7 +90,6 @@
     </div>
     <div class="l-experiment-form__models-container">
       <h3>Model Selection</h3>
-      <h4>Hugging Face Model Hub & Mistral</h4>
       <div class="l-experiment-form__models">
         <l-model-cards  ref="modelSelection"/>
       </div>

--- a/lumigator/frontend/src/components/molecules/LExperimentForm.vue
+++ b/lumigator/frontend/src/components/molecules/LExperimentForm.vue
@@ -188,7 +188,6 @@ function resetForm() {
 }
 
 onMounted(async () => {
-  console.log("❗️ ❗️❗️ FORM mounted")
   if (datasets.value?.length === 0) {
     await datasetStore.loadDatasets();
   }

--- a/lumigator/frontend/src/components/molecules/LExperimentForm.vue
+++ b/lumigator/frontend/src/components/molecules/LExperimentForm.vue
@@ -153,7 +153,7 @@ async function triggerExperiment() {
   const experimentPayload = {
     name: experimentTitle.value,
     description: experimentDescription.value,
-    model: modelSelection.value.selectedModel.link,
+    model: modelSelection.value.selectedModel.uri,
     dataset: dataset.value.id,
     max_samples: maxSamples.value ? maxSamples.value : 0,
   }
@@ -188,6 +188,7 @@ function resetForm() {
 }
 
 onMounted(async () => {
+  console.log("❗️ ❗️❗️ FORM mounted")
   if (datasets.value?.length === 0) {
     await datasetStore.loadDatasets();
   }

--- a/lumigator/frontend/src/components/molecules/LModelCards.vue
+++ b/lumigator/frontend/src/components/molecules/LModelCards.vue
@@ -12,7 +12,7 @@
           name="dynamic"
           :value="model"
         />
-        <label :for="model.name">{{ model.name }}</label>
+        <label :for="model.uri">{{ model.name }}</label>
       </div>
     </div>
   </div>

--- a/lumigator/frontend/src/components/molecules/LModelCards.vue
+++ b/lumigator/frontend/src/components/molecules/LModelCards.vue
@@ -13,17 +13,6 @@
           :value="model"
         />
         <label :for="model.name">{{ model.name }}</label>
-        <!-- add eternal link to model documentation here -->
-        <!-- <Button
-          as="a"
-          icon="pi pi-external-link"
-          severity="secondary"
-          variant="text"
-          rounded
-          class="l-models__external-link"
-          :href="model.externalLink"
-          target="_blank"
-        /> -->
       </div>
     </div>
   </div>
@@ -33,7 +22,6 @@
 import { ref } from 'vue';
 import { storeToRefs } from 'pinia'
 import { useModelStore } from '@/stores/models/store';
-// import Button from 'primevue/button';
 import RadioButton from 'primevue/radiobutton';
 
 const modelStore = useModelStore();

--- a/lumigator/frontend/src/components/molecules/LModelCards.vue
+++ b/lumigator/frontend/src/components/molecules/LModelCards.vue
@@ -2,18 +2,19 @@
   <div class="l-models-list">
     <div class="l-models-list__options-container">
       <div
-        v-for="model in modelOptions"
+        v-for="model in models"
         :key="model.name"
         class="l-models-list__options-container--option"
       >
         <RadioButton
           v-model="selectedModel"
-          :inputId="model.link"
+          :inputId="model.uri"
           name="dynamic"
           :value="model"
         />
-        <label :for="model.link">{{ model.label }}</label>
-        <Button
+        <label :for="model.name">{{ model.name }}</label>
+        <!-- add eternal link to model documentation here -->
+        <!-- <Button
           as="a"
           icon="pi pi-external-link"
           severity="secondary"
@@ -22,7 +23,7 @@
           class="l-models__external-link"
           :href="model.externalLink"
           target="_blank"
-        />
+        /> -->
       </div>
     </div>
   </div>
@@ -30,44 +31,18 @@
 
 <script setup>
 import { ref } from 'vue';
-import Button from 'primevue/button';
+import { storeToRefs } from 'pinia'
+import { useModelStore } from '@/stores/models/store';
+// import Button from 'primevue/button';
 import RadioButton from 'primevue/radiobutton';
 
+const modelStore = useModelStore();
+const { models } = storeToRefs(modelStore);
 const selectedModel = ref('')
 
 defineProps({
   modelLink: String
 })
-
-const modelOptions = ref([
-  {
-    id: '1',
-    link: 'hf://facebook/bart-large-cnn',
-    externalLink: 'https://huggingface.co/facebook/bart-large-cnn',
-    label: 'facebook/bart-large-cnn'
-  },
-
-  {
-    id: '2',
-    link: 'hf://mikeadimech/longformer-qmsum-meeting-summarization',
-    externalLink: 'https://huggingface.co/mikeadimech/longformer-qmsum-meeting-summarization',
-    label: 'mikeadimech/longformer-qmsum-meeting-summarization'
-  },
-
-  {
-    id: '3',
-    link: 'hf://mrm8488/t5-base-finetuned-summarize-news',
-    externalLink: 'https://huggingface.co/mrm8488/t5-base-finetuned-summarize-news',
-    label: 'mrm8488/t5-base-finetuned-summarize-news'
-  },
-  {
-    id: '4',
-    link: 'hf://falconsai/text_summarization',
-    externalLink: 'https://huggingface.co/Falconsai/text_summarization',
-    label: 'falconsai/text_summarization'
-  },
-]);
-
 
 defineExpose({
   selectedModel

--- a/lumigator/frontend/src/components/pages/LExperiments.vue
+++ b/lumigator/frontend/src/components/pages/LExperiments.vue
@@ -69,6 +69,7 @@ import { onMounted, watch, ref } from 'vue'
 import { storeToRefs } from 'pinia';
 import { useExperimentStore } from '@/stores/experiments/store'
 import { useDatasetStore } from '@/stores/datasets/store'
+import { useModelStore } from '@/stores/models/store';
 import { useSlidePanel } from '@/composables/SlidingPanel';
 import LPageHeader from '@/components/molecules/LPageHeader.vue';
 import LExperimentTable from '@/components/molecules/LExperimentTable.vue';
@@ -82,6 +83,7 @@ import LExperimentsEmpty from '@/components/molecules/LExperimentsEmpty.vue'
 const { showSlidingPanel } = useSlidePanel();
 const experimentStore = useExperimentStore();
 const datasetStore = useDatasetStore();
+const modelStore = useModelStore();
 const { selectedDataset } = storeToRefs(datasetStore);
 const {
   experiments,
@@ -139,6 +141,7 @@ const resetDrawerContent = () => {
 }
 
 onMounted(async () => {
+  await modelStore.loadModels();
    if (selectedDataset.value) {
      onCreateExperiment();
   }

--- a/lumigator/frontend/src/services/models/api.js
+++ b/lumigator/frontend/src/services/models/api.js
@@ -1,0 +1,1 @@
+export const PATH_MODELS_ROOT = (task_name) => `models/${task_name}`

--- a/lumigator/frontend/src/services/models/modelsService.js
+++ b/lumigator/frontend/src/services/models/modelsService.js
@@ -1,0 +1,17 @@
+import http from '@/services/http';
+import { PATH_MODELS_ROOT } from './api';
+
+async function fetchModels(task_name = 'summarization') {
+  try {
+    const response = await http.get(PATH_MODELS_ROOT(task_name))
+    if (response) {
+      return response.data.items;
+    }
+  } catch (error) {
+    throw new Error('Fetching Models failed.', { cause: error });
+  }
+}
+
+export default {
+  fetchModels
+}

--- a/lumigator/frontend/src/stores/models/store.js
+++ b/lumigator/frontend/src/stores/models/store.js
@@ -1,0 +1,17 @@
+import { ref } from 'vue';
+import { defineStore } from 'pinia';
+import modelsService from '@/services/models/modelsService';
+
+export const useModelStore = defineStore('models', () => {
+  const models = ref([])
+
+
+  async function loadModels() {
+    models.value = await modelsService.fetchModels();
+  }
+
+  return {
+    models,
+    loadModels
+  }
+});


### PR DESCRIPTION
# What's changing
We use the `/models/{task_name}` endpoint to populate the list of models inside the experiment form

Refs #...
Closes #556 

# How to test it
Try to run a new experiment 

# Additional notes for reviewers

⚠️ Some of the new model options require an API key ⚠️ 

If the Lumigator operator hasn't configured the specific API key during setup, Lumigator won't be able to contact the API for the model successfully.

Currently there is no warning about this as the UI has no way to know:

1. If the API requires an API key
1. If Lumigator has the key configured or not

As a result, the experiment/job is registered in the backend but soon after receives a "Failed" status. The user will likely only notice the misconfiguration by examining the logs. 


<img width="644" alt="failed" src="https://github.com/user-attachments/assets/c3a4ff72-e050-41f2-adec-68ec613ec12a" />

> The link to the documentation website of each model is missing because it's not provided from the API. (previously it was hardcoded)

