### PR TITLE
Harden OpenAI and Mistral env var injection

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -113,8 +113,8 @@ services:
       - INFERENCE_WORK_DIR=/mzai/lumigator/python/mzai/jobs/inference
       - RAY_DASHBOARD_PORT
       - RAY_HEAD_NODE_HOST
-      - MISTRAL_API_KEY
-      - OPENAI_API_KEY
+      - MISTRAL_API_KEY=${MISTRAL_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
       - RAY_WORKER_GPUS=0
       - RAY_WORKER_GPUS_FRACTION=0
       - LUMI_API_CORS_ALLOWED_ORIGINS

--- a/lumigator/python/mzai/backend/backend/api/deps.py
+++ b/lumigator/python/mzai/backend/backend/api/deps.py
@@ -83,5 +83,5 @@ def get_openai_completion_service() -> OpenAICompletionService:
 
 
 OpenAICompletionServiceDep = Annotated[
-    OpenAICompletionService, Depends(get_mistral_completion_service)
+    OpenAICompletionService, Depends(get_openai_completion_service)
 ]

--- a/lumigator/python/mzai/backend/backend/services/completions.py
+++ b/lumigator/python/mzai/backend/backend/services/completions.py
@@ -16,6 +16,8 @@ class CompletionService(ABC):
 
 
 class MistralCompletionService(CompletionService):
+    pass
+
     def __init__(self):
         self.client = MistralClient(api_key=settings.MISTRAL_API_KEY)
         self.model = "open-mistral-7b"
@@ -51,8 +53,11 @@ class OpenAICompletionService(CompletionService):
         self.max_tokens = 256
         self.temperature = 1
         self.top_p = 1
+        self.prompt = """You are a helpful assistant, expert in text summarization.
+                For every prompt you receive,
+                provide a summary of its contents in at most two sentences."""
 
-    def get_models(self) -> mistralai.client.ModelList:
+    def get_models(self):
         response = self.client.list_models()
 
         return response

--- a/lumigator/python/mzai/backend/backend/services/completions.py
+++ b/lumigator/python/mzai/backend/backend/services/completions.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 
 import mistralai.client
+from loguru import logger
 from lumigator_schemas.completions import CompletionRequest, CompletionResponse
 from mistralai.client import MistralClient
 from mistralai.models.chat_completion import ChatMessage
@@ -63,6 +64,7 @@ class OpenAICompletionService(CompletionService):
         return response
 
     def get_completions_response(self, request: CompletionRequest) -> CompletionResponse:
+        logger.info(f"oai key...{settings.OAI_API_KEY}")
         response = self.client.chat.completions.create(
             model=self.model,
             messages=[

--- a/lumigator/python/mzai/backend/backend/services/completions.py
+++ b/lumigator/python/mzai/backend/backend/services/completions.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 
 import mistralai.client
-from loguru import logger
 from lumigator_schemas.completions import CompletionRequest, CompletionResponse
 from mistralai.client import MistralClient
 from mistralai.models.chat_completion import ChatMessage
@@ -17,16 +16,13 @@ class CompletionService(ABC):
 
 
 class MistralCompletionService(CompletionService):
-    pass
-
     def __init__(self):
         self.client = MistralClient(api_key=settings.MISTRAL_API_KEY)
         self.model = "open-mistral-7b"
         self.max_tokens = 256
         self.temperature = 1
         self.top_p = 1
-        self.prompt = """You are a helpful assistant, expert in text summarization.
-        For every prompt you receive, provide a summary of its contents in at most two sentences."""
+        self.prompt = settings.DEFAULT_SUMMARIZER_PROMPT
 
     def get_models(self) -> mistralai.client.ModelList:
         response = self.client.list_models()
@@ -54,9 +50,7 @@ class OpenAICompletionService(CompletionService):
         self.max_tokens = 256
         self.temperature = 1
         self.top_p = 1
-        self.prompt = """You are a helpful assistant, expert in text summarization.
-                For every prompt you receive,
-                provide a summary of its contents in at most two sentences."""
+        self.prompt = settings.DEFAULT_SUMMARIZER_PROMPT
 
     def get_models(self):
         response = self.client.list_models()
@@ -64,7 +58,6 @@ class OpenAICompletionService(CompletionService):
         return response
 
     def get_completions_response(self, request: CompletionRequest) -> CompletionResponse:
-        logger.info(f"oai key...{settings.OAI_API_KEY}")
         response = self.client.chat.completions.create(
             model=self.model,
             messages=[

--- a/lumigator/python/mzai/backend/backend/settings.py
+++ b/lumigator/python/mzai/backend/backend/settings.py
@@ -81,9 +81,15 @@ class BackendSettings(BaseSettings):
             if env_var is not None:
                 runtime_env_vars[env_var_name] = env_var
 
-    OAI_API_KEY: str = os.environ.get("OPENAI_API_KEY", "")
+    @computed_field
+    @property
+    def OAI_API_KEY(self) -> str:  # noqa: N802
+        return os.environ.get("OPENAI_API_KEY", "")
 
-    MISTRAL_API_KEY: str = os.environ.get("MISTRAL_API_KEY", "")
+    @computed_field
+    @property
+    def MISTRAL_API_KEY(self) -> str:  # noqa: N802
+        return os.environ.get("MISTRAL_API_KEY", "")
 
     @computed_field
     @property


### PR DESCRIPTION
# What's changing

We had an issue where we weren't able to hit `completions` endpoints for inference. (https://github.com/mozilla-ai/lumigator/issues/593) 

There were two core issues: 

1. Correctly propogating local environment variables to the application
2. Reading dynamic config properties from backend settings

Injecting the environment variables directly via the docker-config file fixes this and propogates Mistral and OpenAI correctly: 


In the process of fixing, we're cleaning up several completions issues: 


* Making sure env vars are computed fields
* Fixed the mistral backend service dependency
* Changed typing on model listing from OpenAI
* Getting summarizer prompt from config now

# How to test it

Steps to test the changes:

1. `make local-up` from this branch

2.  run: 
```bash
curl -X 'POST' \                                                           
  'http://localhost:8000/api/v1/completions/openai' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "text": "string"
}'

{"text":"It seems you've entered the word \"string.\" If you have a specific topic or text related to \"string\" that you would like summarized, please provide more details."}%

curl -X 'POST' \                                                            
  'http://localhost:8000/api/v1/completions/mistral' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "text": "string"
}
```


# I already...

- [X ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
