### PR TITLE
API:include URL to website for models

### DIFF
--- a/lumigator/python/mzai/backend/backend/models.yaml
+++ b/lumigator/python/mzai/backend/backend/models.yaml
@@ -1,5 +1,6 @@
 - name: facebook/bart-large-cnn
   uri: hf://facebook/bart-large-cnn
+  website_url: https://huggingface.co/facebook/bart-large-cnn
   description: BART is a large-sized model fine-tuned on the CNN Daily Mail dataset.
   info:
     parameter_count: 406M
@@ -16,6 +17,7 @@
 
 - name: mikeadimech/longformer-qmsum-meeting-summarization
   uri: hf://mikeadimech/longformer-qmsum-meeting-summarization
+  website_url: https://huggingface.co/mikeadimech/longformer-qmsum-meeting-summarization/discussions
   description: Longformer is a transformer model that is capable of processing long sequences.
   info:
     parameter_count: 162M
@@ -26,6 +28,7 @@
 
 - name: mrm8488/t5-base-finetuned-summarize-news
   uri: hf://mrm8488/t5-base-finetuned-summarize-news
+  website_url: https://huggingface.co/mrm8488/t5-base-finetuned-summarize-news
   description: Google's T5 base fine-tuned on News Summary dataset for summarization downstream task.
   info:
     parameter_count: 223M
@@ -42,6 +45,7 @@
 
 - name: Falconsai/text_summarization
   uri: hf://Falconsai/text_summarization
+  website_url: https://huggingface.co/Falconsai/text_summarization
   description: A fine-tuned variant of the T5 transformer model, designed for the task of text summarization.
   info:
     parameter_count: 60.5M
@@ -58,6 +62,7 @@
 
 - name: mistralai/Mistral-7B-Instruct-v0.3
   uri: hf://mistralai/Mistral-7B-Instruct-v0.3
+  website_url: https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3
   description: Mistral-7B-Instruct-v0.3 is an instruct fine-tuned version of the Mistral-7B-v0.3.
   info:
     parameter_count: 7.25B
@@ -68,24 +73,28 @@
 
 - name: gpt-4o-mini
   uri: oai://gpt-4o-mini
+  website_url: https://platform.openai.com/docs/models#gpt-4o-mini
   description: OpenAI's GPT-4o-mini model.
   tasks:
     - summarization:
 
 - name: gpt-4o
   uri: oai://gpt-4o
+  website_url: https://platform.openai.com/docs/models#gpt-4o
   description: OpenAI's GPT-4o model.
   tasks:
     - summarization:
 
 - name: open-mistral-7b
   uri: mistral://open-mistral-7b
+  website_url: https://mistral.ai/technology/#models
   description: Mistral's 7B model.
   tasks:
     - summarization:
 
 - name: mistralai/Mistral-7B-Instruct-v0.2
   uri: llamafile://mistralai/Mistral-7B-Instruct-v0.2
+  website_url: https://mistral.ai/technology/#models
   description: A llamafile package of Mistral's 7B Instruct model.
   info:
     parameter_count: 7.24B

--- a/lumigator/python/mzai/schemas/lumigator_schemas/models.py
+++ b/lumigator/python/mzai/schemas/lumigator_schemas/models.py
@@ -10,6 +10,7 @@ class ModelInfo(BaseModel):
 class ModelsResponse(BaseModel):
     name: str
     uri: str
+    website_url: str
     description: str
     info: ModelInfo | None = None
     tasks: list[dict[str, dict | None]]

--- a/lumigator/python/mzai/sdk/tests/data/models.json
+++ b/lumigator/python/mzai/sdk/tests/data/models.json
@@ -4,6 +4,7 @@
       {
         "name": "facebook/bart-large-cnn",
         "uri": "hf://facebook/bart-large-cnn",
+        "website_url": "https://huggingface.co/facebook/bart-large-cnn",
         "description": "BART is a large-sized model fine-tuned on the CNN Daily Mail dataset.",
         "info": {
           "parameter_count": "406M",
@@ -26,6 +27,7 @@
       {
         "name": "mikeadimech/longformer-qmsum-meeting-summarization",
         "uri": "hf://mikeadimech/longformer-qmsum-meeting-summarization",
+        "website_url": "https://huggingface.co/mikeadimech/longformer-qmsum-meeting-summarization/discussions",
         "description": "Longformer is a transformer model that is capable of processing long sequences.",
         "info": {
           "parameter_count": "162M",
@@ -41,6 +43,7 @@
       {
         "name": "mrm8488/t5-base-finetuned-summarize-news",
         "uri": "hf://mrm8488/t5-base-finetuned-summarize-news",
+        "website_url": "https://huggingface.co/mrm8488/t5-base-finetuned-summarize-news",
         "description": "Google's T5 base fine-tuned on News Summary dataset for summarization downstream task.",
         "info": {
           "parameter_count": "223M",
@@ -63,6 +66,7 @@
       {
         "name": "Falconsai/text_summarization",
         "uri": "hf://Falconsai/text_summarization",
+        "website_url": "https://huggingface.co/Falconsai/text_summarization",
         "description": "A fine-tuned variant of the T5 transformer model, designed for the task of text summarization.",
         "info": {
           "parameter_count": "60.5M",
@@ -85,6 +89,7 @@
       {
         "name": "mistralai/Mistral-7B-Instruct-v0.3",
         "uri": "hf://mistralai/Mistral-7B-Instruct-v0.3",
+        "website_url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
         "description": "Mistral-7B-Instruct-v0.3 is an instruct fine-tuned version of the Mistral-7B-v0.3.",
         "info": {
           "parameter_count": "7.25B",
@@ -100,6 +105,7 @@
       {
         "name": "gpt-4o-mini",
         "uri": "oai://gpt-4o-mini",
+        "website_url": "https://platform.openai.com/docs/models#gpt-4o-mini",
         "description": "OpenAI's GPT-4o-mini model.",
         "info": null,
         "tasks": [
@@ -111,6 +117,7 @@
       {
         "name": "gpt-4o",
         "uri": "oai://gpt-4o",
+        "website_url": "https://platform.openai.com/docs/models#gpt-4o",
         "description": "OpenAI's GPT-4o model.",
         "info": null,
         "tasks": [
@@ -122,6 +129,7 @@
       {
         "name": "open-mistral-7b",
         "uri": "mistral://open-mistral-7b",
+        "website_url": " https://mistral.ai/technology/#models",
         "description": "Mistral's 7B model.",
         "info": null,
         "tasks": [
@@ -133,6 +141,7 @@
       {
         "name": "mistralai/Mistral-7B-Instruct-v0.2",
         "uri": "llamafile://mistralai/Mistral-7B-Instruct-v0.2",
+        "website_url": " https://mistral.ai/technology/#models",
         "description": "A llamafile package of Mistral's 7B Instruct model.",
         "info": {
           "parameter_count": "7.24B",


### PR DESCRIPTION
# What's changing

API responses for summarization models now include a link to the model (where possible), most models have a unique link but some mistral ones all appear on their website with the same URL.

Name `website_url` can be easily changed if required, thought about `model_card` but since some aren't exactly 'that' I just went for slightly more vague.

Refs https://github.com/mozilla-ai/lumigator/issues/589

# How to test it

Steps to test the changes:

1. `make local-up`
1. Visit the [API docs for models](http://localhost:8000/docs#/models/get_suggested_models_api_v1_models__task_name__get)
1. 'Try it out' for `summarization` 
1. Check the URL is being shown for each model

# Additional notes for reviewers

![image](https://github.com/user-attachments/assets/d6037f9e-baef-42e7-b05d-3a17604d8142)

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
