### PR TITLE
Add experiment record handling to experiment service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,8 @@ test-backend-integration:
 	INFERENCE_WORK_DIR=../jobs/inference \
 	EVALUATOR_PIP_REQS=../jobs/evaluator/requirements.txt \
 	EVALUATOR_WORK_DIR=../jobs/evaluator \
+	EVALUATOR_LITE_PIP_REQS=../jobs/evaluator_lite/requirements.txt \
+	EVALUATOR_LITE_WORK_DIR=../jobs/evaluator_lite \
 	uv run pytest -s -o python_files="backend/tests/integration/*/test_*.py"
 
 test-backend-integration-containers:

--- a/lumigator/python/mzai/backend/backend/api/deps.py
+++ b/lumigator/python/mzai/backend/backend/api/deps.py
@@ -64,8 +64,9 @@ JobServiceDep = Annotated[JobService, Depends(get_job_service)]
 def get_experiment_service(
     session: DBSessionDep, job_service: JobServiceDep, dataset_service: DatasetServiceDep
 ) -> ExperimentService:
+    job_repo = JobRepository(session)
     experiment_repo = ExperimentRepository(session)
-    return ExperimentService(experiment_repo, job_service, dataset_service)
+    return ExperimentService(experiment_repo, job_repo, job_service, dataset_service)
 
 
 ExperimentServiceDep = Annotated[ExperimentService, Depends(get_experiment_service)]

--- a/lumigator/python/mzai/backend/backend/api/routes/experiments.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/experiments.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, BackgroundTasks, status
 from lumigator_schemas.experiments import (
     ExperimentCreate,
     ExperimentResponse,
@@ -19,10 +19,9 @@ router = APIRouter()
 
 @router.post("/", status_code=status.HTTP_201_CREATED)
 def create_experiment(
-    service: JobServiceDep,
-    request: ExperimentCreate,
+    service: JobServiceDep, request: ExperimentCreate, background_tasks: BackgroundTasks
 ) -> ExperimentResponse:
-    return service.create_job(JobEvalCreate.model_validate(request.model_dump()))
+    return service.create_job(JobEvalCreate.model_validate(request.model_dump()), background_tasks)
 
 
 @router.get("/{experiment_id}")

--- a/lumigator/python/mzai/backend/backend/api/routes/experiments_new.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/experiments_new.py
@@ -22,8 +22,8 @@ async def create_experiment(
 
 
 @router.get("/{experiment_id}")
-def get_experiment(service: JobServiceDep, experiment_id: UUID) -> ExperimentResponse:
-    return ExperimentResponse.model_validate(service.get_job(experiment_id).model_dump())
+def get_experiment(service: ExperimentServiceDep, experiment_id: UUID) -> ExperimentResponse:
+    return ExperimentResponse.model_validate(service.get_experiment(experiment_id).model_dump())
 
 
 @router.get("/")

--- a/lumigator/python/mzai/backend/backend/api/routes/experiments_new.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/experiments_new.py
@@ -26,6 +26,13 @@ def get_experiment(service: ExperimentServiceDep, experiment_id: UUID) -> Experi
     return ExperimentResponse.model_validate(service.get_experiment(experiment_id).model_dump())
 
 
+@router.get("/{experiment_id}/jobs")
+def get_experiment_jobs(
+    service: ExperimentServiceDep, experiment_id: UUID
+) -> ListingResponse[UUID]:
+    return service.get_all_owned_jobs(experiment_id)
+
+
 @router.get("/")
 def list_experiments(
     service: ExperimentServiceDep,

--- a/lumigator/python/mzai/backend/backend/api/routes/jobs.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/jobs.py
@@ -63,6 +63,7 @@ def create_annotation_job(
         model="hf://facebook/bart-large-cnn",
         output_field="ground_truth",
     )
+    inference_job_create_request.store_to_dataset = True
     job_response = service.create_job(inference_job_create_request, background_tasks)
 
     url = request.url_for(get_job.__name__, job_id=job_response.id)

--- a/lumigator/python/mzai/backend/backend/api/routes/jobs.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/jobs.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 import loguru
 import requests
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, HTTPException, status
 from lumigator_schemas.extras import ListingResponse
 from lumigator_schemas.jobs import (
     Job,
@@ -35,8 +35,9 @@ def create_inference_job(
     job_create_request: JobInferenceCreate,
     request: Request,
     response: Response,
+    background_tasks: BackgroundTasks,
 ) -> JobResponse:
-    job_response = service.create_job(job_create_request)
+    job_response = service.create_job(job_create_request, background_tasks)
 
     url = request.url_for(get_job.__name__, job_id=job_response.id)
     response.headers[HttpHeaders.LOCATION] = f"{url}"
@@ -50,6 +51,7 @@ def create_annotation_job(
     job_create_request: JobAnnotateCreate,
     request: Request,
     response: Response,
+    background_tasks: BackgroundTasks,
 ) -> JobResponse:
     """This uses a hardcoded model, that is, Lumigator's opinion on what
     reference model should be used to generate annotations.
@@ -60,7 +62,7 @@ def create_annotation_job(
         model="hf://facebook/bart-large-cnn",
         output_field="ground_truth",
     )
-    job_response = service.create_job(inference_job_create_request)
+    job_response = service.create_job(inference_job_create_request, background_tasks)
 
     url = request.url_for(get_job.__name__, job_id=job_response.id)
     response.headers[HttpHeaders.LOCATION] = f"{url}"
@@ -74,8 +76,9 @@ def create_evaluation_job(
     job_create_request: JobEvalCreate,
     request: Request,
     response: Response,
+    background_tasks: BackgroundTasks,
 ) -> JobResponse:
-    job_response = service.create_job(job_create_request)
+    job_response = service.create_job(job_create_request, background_tasks)
 
     url = request.url_for(get_job.__name__, job_id=job_response.id)
     response.headers[HttpHeaders.LOCATION] = f"{url}"

--- a/lumigator/python/mzai/backend/backend/config_templates.py
+++ b/lumigator/python/mzai/backend/backend/config_templates.py
@@ -99,7 +99,7 @@ default_infer_template = """{{
         "use_fast": "{use_fast}",
         "trust_remote_code": "{trust_remote_code}",
         "torch_dtype": "{torch_dtype}",
-        "max_new_tokens": 500
+        "max_length": 500
     }},
      "job": {{
         "max_samples": {max_samples},

--- a/lumigator/python/mzai/backend/backend/config_templates.py
+++ b/lumigator/python/mzai/backend/backend/config_templates.py
@@ -98,7 +98,8 @@ default_infer_template = """{{
         "revision": "{revision}",
         "use_fast": "{use_fast}",
         "trust_remote_code": "{trust_remote_code}",
-        "torch_dtype": "{torch_dtype}"
+        "torch_dtype": "{torch_dtype}",
+        "max_new_tokens": 500
     }},
      "job": {{
         "max_samples": {max_samples},

--- a/lumigator/python/mzai/backend/backend/repositories/jobs.py
+++ b/lumigator/python/mzai/backend/backend/repositories/jobs.py
@@ -10,14 +10,13 @@ class JobRepository(BaseRepository[JobRecord]):
     def __init__(self, session: Session):
         super().__init__(JobRecord, session)
 
+    def get_by_experiment_id(self, experiment_id: UUID) -> list[JobRecord]:
+        return self.session.query(JobRecord).where(JobRecord.experiment_id == experiment_id).all()
+
 
 class JobResultRepository(BaseRepository[JobResultRecord]):
     def __init__(self, session: Session):
         super().__init__(JobResultRecord, session)
 
     def get_by_job_id(self, job_id: UUID) -> JobResultRecord | None:
-        return (
-            self.session.query(JobResultRecord)
-            .where(JobResultRecord.job_id == job_id)
-            .first()
-        )
+        return self.session.query(JobResultRecord).where(JobResultRecord.job_id == job_id).first()

--- a/lumigator/python/mzai/backend/backend/services/experiments.py
+++ b/lumigator/python/mzai/backend/backend/services/experiments.py
@@ -42,6 +42,10 @@ class ExperimentService:
     def _get_all_owned_jobs(self, experiment_id: UUID) -> list[JobRecord]:
         return self._job_repo.get_by_experiment_id(experiment_id)
 
+    def get_all_owned_jobs(self, experiment_id: UUID) -> ListingResponse[UUID]:
+        jobs = [job.id for job in self._get_all_owned_jobs(experiment_id)]
+        return ListingResponse[UUID].model_validate({"total": len(jobs), "items": jobs})
+
     async def on_job_complete(self, job_id: UUID, task: Callable = None, *args):
         """Watches a submitted job and, when it terminates successfully, runs a given task.
 

--- a/lumigator/python/mzai/backend/backend/services/jobs.py
+++ b/lumigator/python/mzai/backend/backend/services/jobs.py
@@ -219,8 +219,6 @@ class JobService:
         # get dataset S3 path from UUID
         dataset_s3_path = self._dataset_service.get_dataset_s3_path(request.dataset)
 
-        model_url = self._set_model_type(request)
-
         # provide a reasonable system prompt for services where none was specified
         if job_type == JobType.EVALUATION or job_type == JobType.INFERENCE:
             if request.system_prompt is None and not request.model.startswith("hf://"):
@@ -235,7 +233,7 @@ class JobService:
                 "dataset_path": dataset_s3_path,
                 "max_samples": request.max_samples,
                 "storage_path": self.storage_path,
-                "model_url": model_url,
+                "model_url": self._set_model_type(request),
                 "system_prompt": request.system_prompt,
                 "skip_inference": request.skip_inference,
             }
@@ -262,7 +260,7 @@ class JobService:
                 "torch_dtype": request.torch_dtype,
                 "max_samples": request.max_samples,
                 "storage_path": self.storage_path,
-                "model_url": model_url,
+                "model_url": self._set_model_type(request),
                 "system_prompt": request.system_prompt,
                 "output_field": request.output_field,
                 "max_tokens": request.max_tokens,

--- a/lumigator/python/mzai/backend/backend/services/jobs.py
+++ b/lumigator/python/mzai/backend/backend/services/jobs.py
@@ -66,12 +66,12 @@ class JobService:
         job_repo: JobRepository,
         result_repo: JobResultRepository,
         ray_client: JobSubmissionClient,
-        data_service: DatasetService,
+        dataset_service: DatasetService,
     ):
         self.job_repo = job_repo
         self.result_repo = result_repo
         self.ray_client = ray_client
-        self._dataset_service = data_service
+        self._dataset_service = dataset_service
 
     def _raise_not_found(self, job_id: UUID):
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Job {job_id} not found.")
@@ -358,7 +358,7 @@ class JobService:
 
         # Inference jobs produce a new dataset
         # Add the dataset to the (local) database
-        if request.store_to_dataset:
+        if job_type == JobType.INFERENCE and request.store_to_dataset:
             background_tasks.add_task(
                 self.on_job_complete,
                 record.id,

--- a/lumigator/python/mzai/backend/backend/tests/conftest.py
+++ b/lumigator/python/mzai/backend/backend/tests/conftest.py
@@ -365,7 +365,7 @@ def simple_infer_template():
             "use_fast": "{use_fast}",
             "trust_remote_code": "{trust_remote_code}",
             "torch_dtype": "{torch_dtype}",
-            "max_new_tokens": 500
+            "max_length": 500
         }},
         "job": {{
             "max_samples": {max_samples},

--- a/lumigator/python/mzai/backend/backend/tests/conftest.py
+++ b/lumigator/python/mzai/backend/backend/tests/conftest.py
@@ -31,6 +31,7 @@ from backend.settings import BackendSettings, settings
 from backend.tests.fakes.fake_s3 import FakeS3Client
 
 TEST_CAUSAL_MODEL = "hf://hf-internal-testing/tiny-random-LlamaForCausalLM"
+TEST_SUMMARY_MODEL = "hf://hf-internal-testing/tiny-random-T5ForConditionalGeneration"
 TEST_INFER_MODEL = "hf://hf-internal-testing/tiny-random-t5"
 
 
@@ -343,7 +344,6 @@ def simple_eval_template():
         "dataset": {{ "path": "{dataset_path}" }},
         "evaluation": {{
             "metrics": ["meteor", "rouge"],
-            "use_pipeline": false,
             "max_samples": {max_samples},
             "return_input_data": true,
             "return_predictions": true,
@@ -365,7 +365,7 @@ def simple_infer_template():
             "use_fast": "{use_fast}",
             "trust_remote_code": "{trust_remote_code}",
             "torch_dtype": "{torch_dtype}",
-            "max_length": 200
+            "max_new_tokens": 500
         }},
         "job": {{
             "max_samples": {max_samples},

--- a/lumigator/python/mzai/backend/backend/tests/integration/api/routes/test_api_workflows.py
+++ b/lumigator/python/mzai/backend/backend/tests/integration/api/routes/test_api_workflows.py
@@ -264,17 +264,22 @@ def test_full_experiment_launch(
     assert get_experiments.total > 0
 
     get_experiment_response = local_client.get(f"/experiments_new/{get_experiments.items[0].id}")
+    logger.info(f"--> {get_experiment_response.text}")
     assert get_experiment_response.status_code == 200
 
     succeeded = False
     for _ in range(1, 200):
-        get_job_response = local_client.get(f"/jobs/{get_experiments.items[0].id}")
-        assert get_job_response.status_code == 200
-        get_job_response_model = JobResponse.model_validate(get_job_response.json())
-        if get_job_response_model.status == JobStatus.SUCCEEDED.value:
+        get_experiment_response = local_client.get(
+            f"/experiments_new/{get_experiments.items[0].id}"
+        )
+        assert get_experiment_response.status_code == 200
+        get_experiment_response_model = ExperimentResponse.model_validate(
+            get_experiment_response.json()
+        )
+        if get_experiment_response_model.status == JobStatus.SUCCEEDED.value:
             succeeded = True
             break
-        if get_job_response_model.status == JobStatus.FAILED.value:
+        if get_experiment_response_model.status == JobStatus.FAILED.value:
             succeeded = False
             break
         time.sleep(10)

--- a/lumigator/python/mzai/jobs/evaluator_lite/eval_lite.py
+++ b/lumigator/python/mzai/jobs/evaluator_lite/eval_lite.py
@@ -68,6 +68,8 @@ def run_eval(config: EvalJobConfig) -> Path:
         max_samples = len(dataset)
     dataset = dataset.select(range(max_samples))
 
+    logger.info(dataset)
+
     # run evaluation and append to results dict
     predictions = dataset["predictions"]
     ground_truth = dataset["ground_truth"]

--- a/lumigator/python/mzai/jobs/inference/inference.py
+++ b/lumigator/python/mzai/jobs/inference/inference.py
@@ -101,7 +101,7 @@ def run_inference(config: InferenceJobConfig) -> Path:
             model_client = OpenAIModelClient(base_url, config)
     elif config.hf_pipeline:
         if config.hf_pipeline.model_uri.startswith(PathPrefix.HUGGINGFACE):
-            logger.info("Using HuggingFace client.")
+            logger.info(f"Using HuggingFace client with model {config.hf_pipeline.model_uri}.")
             model_client = HuggingFaceModelClient(config)
             output_model_name = config.hf_pipeline.model
         else:
@@ -121,6 +121,7 @@ def run_inference(config: InferenceJobConfig) -> Path:
 
     output[config.job.output_field] = predict(dataset_iterable, model_client)
     output["model"] = output_model_name
+    logger.info(output)
 
     output_path = save_outputs(config, output)
     return output_path

--- a/lumigator/python/mzai/jobs/inference/inference_config.py
+++ b/lumigator/python/mzai/jobs/inference/inference_config.py
@@ -127,7 +127,7 @@ class HfPipelineConfig(BaseModel, arbitrary_types_allowed=True):
     torch_dtype: TorchDtype = "auto"
     accelerator: Accelerator = Field(title="Accelerator", default=Accelerator.AUTO, exclude=True)
     model_config = ConfigDict(extra="forbid")
-    max_new_tokens: int | None = None
+    max_length: int | None = None
 
     @computed_field
     @property

--- a/lumigator/python/mzai/jobs/inference/inference_config.py
+++ b/lumigator/python/mzai/jobs/inference/inference_config.py
@@ -127,6 +127,7 @@ class HfPipelineConfig(BaseModel, arbitrary_types_allowed=True):
     torch_dtype: TorchDtype = "auto"
     accelerator: Accelerator = Field(title="Accelerator", default=Accelerator.AUTO, exclude=True)
     model_config = ConfigDict(extra="forbid")
+    max_new_tokens: int
 
     @computed_field
     @property

--- a/lumigator/python/mzai/jobs/inference/inference_config.py
+++ b/lumigator/python/mzai/jobs/inference/inference_config.py
@@ -127,7 +127,7 @@ class HfPipelineConfig(BaseModel, arbitrary_types_allowed=True):
     torch_dtype: TorchDtype = "auto"
     accelerator: Accelerator = Field(title="Accelerator", default=Accelerator.AUTO, exclude=True)
     model_config = ConfigDict(extra="forbid")
-    max_new_tokens: int
+    max_new_tokens: int | None = None
 
     @computed_field
     @property

--- a/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
+++ b/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
@@ -65,7 +65,6 @@ class JobEvalCreate(BaseModel):
     system_prompt: str | None = None
     config_template: str | None = None
     skip_inference: bool = False
-    store_to_dataset: bool = False
 
 
 # TODO: this has to be renamed to JobEvalCreate and the code above
@@ -77,7 +76,6 @@ class JobEvalLiteCreate(BaseModel):
     dataset: UUID
     max_samples: int = -1  # set to all samples by default
     config_template: str | None = None
-    store_to_dataset: bool = False
 
 
 class JobInferenceCreate(BaseModel):
@@ -109,6 +107,7 @@ class JobAnnotateCreate(BaseModel):
     dataset: UUID
     max_samples: int = -1  # set to all samples by default
     task: str | None = "summarization"
+    store_to_dataset: bool = False
 
 
 class JobResponse(BaseModel, from_attributes=True):

--- a/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
+++ b/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
@@ -65,6 +65,7 @@ class JobEvalCreate(BaseModel):
     system_prompt: str | None = None
     config_template: str | None = None
     skip_inference: bool = False
+    store_to_dataset: bool = False
 
 
 # TODO: this has to be renamed to JobEvalCreate and the code above
@@ -98,6 +99,7 @@ class JobInferenceCreate(BaseModel):
     temperature: float = 1.0
     top_p: float = 1.0
     config_template: str | None = None
+    store_to_dataset: bool = False
 
 
 class JobAnnotateCreate(BaseModel):

--- a/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
+++ b/lumigator/python/mzai/schemas/lumigator_schemas/jobs.py
@@ -77,6 +77,7 @@ class JobEvalLiteCreate(BaseModel):
     dataset: UUID
     max_samples: int = -1  # set to all samples by default
     config_template: str | None = None
+    store_to_dataset: bool = False
 
 
 class JobInferenceCreate(BaseModel):


### PR DESCRIPTION
# What's changing

The creation of datasets for a job is indicated through a new parameter in the JobInferCreate, called `store_to_dataset`. The experiment will set this when it creates the appropriate jobs.

The experiment service (used by the `experiments_new` endpoint) will now use the experiment repository and keep track of its contained jobs to provide a status.

Closes #590

# How to test it

An inference job that includes `store_to_dataset = True` in the job config will also add a dataset with the results. The integration tests already check this.

There are additional checks in the experiment launch about the datasets created by the experiment jobs, as well as about the experiment status. The integration test logs the experiment status for manual inspection; only the final `SUCCEEDED` or `FAILED` status are actually checked.

# Additional notes for reviewers

N/A

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [x] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
  - No migration needed
