### PR TITLE
Add support for Debugpy when in development mode

### DIFF
--- a/.devcontainer/docker-compose.override.yaml
+++ b/.devcontainer/docker-compose.override.yaml
@@ -12,7 +12,7 @@ services:
     ports:
       - "5678:5678"
     environment:
-      - DEBUG=1
+      - ENABLE_DEBUGPY=1
     develop:
       watch:
         - path: lumigator/python/mzai/backend/

--- a/.devcontainer/docker-compose.override.yaml
+++ b/.devcontainer/docker-compose.override.yaml
@@ -9,6 +9,10 @@ services:
       target: "dev_image"
     volumes:
       -  database_volume:/mzai/backend/local.db
+    ports:
+      - "5678:5678"
+    environment:
+      - DEBUG=1
     develop:
       watch:
         - path: lumigator/python/mzai/backend/

--- a/.gitignore
+++ b/.gitignore
@@ -168,9 +168,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
-# VS Code
-.vscode/launch.json
-
 # Ruff
 .ruff_cache
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach to Backend",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "/mzai"
+                }
+            ]
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,7 @@
             "name": "Attach to Backend",
             "type": "debugpy",
             "request": "attach",
+            "justMyCode":  false,
             "connect": {
                 "host": "localhost",
                 "port": 5678

--- a/lumigator/python/mzai/backend/backend/main.py
+++ b/lumigator/python/mzai/backend/backend/main.py
@@ -67,7 +67,7 @@ def create_app() -> FastAPI:
 
     app.include_router(api_router)
 
-    if os.environ.get("DEBUG"):
+    if os.environ.get("ENABLE_DEBUGPY"):
         import debugpy  # type: ignore
 
         debug_port = os.environ.get("DEBUG_PORT", 5678)

--- a/lumigator/python/mzai/backend/backend/main.py
+++ b/lumigator/python/mzai/backend/backend/main.py
@@ -67,6 +67,13 @@ def create_app() -> FastAPI:
 
     app.include_router(api_router)
 
+    if os.environ.get("DEBUG"):
+        import debugpy  # type: ignore
+
+        debug_port = os.environ.get("DEBUG_PORT", 5678)
+        logger.info(f"Starting debugpy on port {debug_port}")
+        debugpy.listen(("0.0.0.0", debug_port))
+
     @app.get("/")
     def get_root():
         return {"Hello": "Lumigator!🐊"}

--- a/lumigator/python/mzai/backend/pyproject.toml
+++ b/lumigator/python/mzai/backend/pyproject.toml
@@ -32,7 +32,8 @@ dev-dependencies = [
     "pytest>=8.3.3",
     "requests-mock>=1.12.1",
     "testcontainers>=4.8.2",
-    "moto[s3]>=5.0,<6"
+    "moto[s3]>=5.0,<6",
+    "debugpy>=1.8.11"
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
I'm sorry for the adding of all the PR reviewers, not quite sure yet who are the appropriate people to request reviews from.

I generally like to use a debugger so that I can follow the logic flow and inspect variables. Since the dev environment runs in docker, this PR is to expose and run debugpy when in dev mode (`make local-up`) so that we can have enhanced debugging tools.

I'm not sure where this would be documented since it doesn't appear that we yet have a source doc for a "developer guide" or anything like it yet. Perhaps for the backlog.

# What's changing

* Adds connection for debugpy when running in dev mode ("make local-up")
# How to test it

Steps to test the changes:

1. Run `make local-up`
2. In vscode, run the debug config "Attach to backend", set and hit a breakpoint

# Additional notes for reviewers

I saw in https://github.com/mozilla-ai/lumigator/commit/30c5ba6d8bd76e98479713a266214e84904f5748 that @dpoulopoulos  gitignored the launch.json, but wasn't sure of the reason. We could continue to ignore the launch.json but it might be helpful for integrating with this effort? If that's an issue, happy to undo that edit to the gitignore.

# I already...

- - [x] Tested the changes in a working environment to ensure they work as expected
- [🤷🏼] Added some tests for any new functionality
- [🤷🏼] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [NA] Checked if a (backend) DB migration step was required and included it if required
