### PR TITLE
Restoring models' website urls

### DIFF
--- a/lumigator/frontend/src/components/molecules/LModelCards.vue
+++ b/lumigator/frontend/src/components/molecules/LModelCards.vue
@@ -5,12 +5,14 @@
         v-for="model in models"
         :key="model.name"
         class="l-models-list__options-container--option"
+        @click="selectModel(model)"
       >
         <RadioButton
           v-model="selectedModel"
           :inputId="model.uri"
           name="dynamic"
           :value="model"
+          @click.stop
         />
         <label :for="model.uri">{{ model.name }}</label>
       </div>
@@ -20,13 +22,13 @@
 
 <script setup>
 import { ref } from 'vue';
-import { storeToRefs } from 'pinia'
+import { storeToRefs } from 'pinia';
 import { useModelStore } from '@/stores/models/store';
 import RadioButton from 'primevue/radiobutton';
 
 const modelStore = useModelStore();
 const { models } = storeToRefs(modelStore);
-const selectedModel = ref('')
+const selectedModel = ref('');
 
 defineProps({
   modelLink: String
@@ -35,6 +37,10 @@ defineProps({
 defineExpose({
   selectedModel
 })
+
+function selectModel(model) {
+  selectedModel.value = model;
+}
 </script>
 
 <style scoped lang="scss">
@@ -47,18 +53,25 @@ defineExpose({
     padding-top: $l-spacing-1;
     gap: $l-spacing-1;
 
-
     &--option {
       display: grid;
       grid-template-columns: 30px 80% 1fr;
       grid-gap: 5px;
       background-color: $l-grey-300;
+      border: 1px solid $l-gridlines-stroke;
       padding: $l-spacing-1;
       border-radius: $l-main-radius;
+      cursor: pointer;
+      align-items: CENTER;
 
       label {
         font-size: $l-font-size-sm;
+      cursor: pointer;
         color: $l-grey-100;
+      }
+
+      &:hover {
+        border-color: #52525b;
       }
     }
 

--- a/lumigator/frontend/src/components/molecules/LModelCards.vue
+++ b/lumigator/frontend/src/components/molecules/LModelCards.vue
@@ -15,6 +15,17 @@
           @click.stop
         />
         <label :for="model.uri">{{ model.name }}</label>
+        <Button
+          as="a"
+          icon="pi pi-external-link"
+          severity="secondary"
+          variant="text"
+          rounded
+          class="l-models__external-link"
+          :href="model.website_url"
+          target="_blank"
+          @click.stop
+        />
       </div>
     </div>
   </div>
@@ -25,6 +36,7 @@ import { ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useModelStore } from '@/stores/models/store';
 import RadioButton from 'primevue/radiobutton';
+import Button from 'primevue/button';
 
 const modelStore = useModelStore();
 const { models } = storeToRefs(modelStore);


### PR DESCRIPTION
# What's changing

- `models/` endpoint was updated and now provides links for every model's website. Therefore the link in the UI is restored.
- UX improvement: enable user to select model not only by clicking on the radio button explicitly but anywhere on model's card

# How to test it

1. Open form for a new experiment
2. At _"select model"_ section of the form click on the right icon of each card.
3. Select a model by clicking on card's label (text).
