### PR TITLE
Fix: API website URL for model update

### DIFF
--- a/lumigator/python/mzai/backend/backend/models.yaml
+++ b/lumigator/python/mzai/backend/backend/models.yaml
@@ -17,7 +17,7 @@
 
 - name: mikeadimech/longformer-qmsum-meeting-summarization
   uri: hf://mikeadimech/longformer-qmsum-meeting-summarization
-  website_url: https://huggingface.co/mikeadimech/longformer-qmsum-meeting-summarization/discussions
+  website_url: https://huggingface.co/mikeadimech/longformer-qmsum-meeting-summarization
   description: Longformer is a transformer model that is capable of processing long sequences.
   info:
     parameter_count: 162M


### PR DESCRIPTION
# What's changing

Remove `/discussions` from the end of the URL as it shouldn't be there.

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
