### PR TITLE
Push frontend to dockerhub in more cases

### DIFF
--- a/.github/workflows/build_images_frontend.yaml
+++ b/.github/workflows/build_images_frontend.yaml
@@ -51,6 +51,7 @@ jobs:
         with:
           file: "lumigator/frontend/Dockerfile"
           target: "server"
+          push: true
           tags: |
             ${{ contains(github.ref, 'refs/tags/') == false && format('mzdotai/lumigator-frontend:frontend_{0}', env.GITHUB_SHA_SHORT) || '' }}
             ${{ github.ref == 'refs/heads/main' && 'mzdotai/lumigator-frontend:latest' || '' }}

--- a/.github/workflows/build_images_frontend.yaml
+++ b/.github/workflows/build_images_frontend.yaml
@@ -11,7 +11,7 @@ on:
       - main
     tags:
       # Not the right semver regexp, but good enough
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - "v[0-9]+.[0-9]+.[0-9]+"
   # required to enable manual triggers on the GH web ui
   workflow_dispatch:
 
@@ -24,6 +24,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Use filter action here instead of path filter in main workflow so required checks
+      # are not blocked when workflow runs.
       - name: Check for modified paths
         uses: dorny/paths-filter@v3
         id: filter
@@ -38,7 +40,7 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
-        if: steps.filter.outputs.rebuild_fe == 'true'
+        if: steps.filter.outputs.rebuild_fe == 'true' || contains(github.ref, 'refs/tags/')
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -48,7 +50,6 @@ jobs:
         if: steps.filter.outputs.rebuild_fe == 'true' || contains(github.ref, 'refs/tags/')
         with:
           file: "lumigator/frontend/Dockerfile"
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/') }}
           target: "server"
           tags: |
             ${{ contains(github.ref, 'refs/tags/') == false && format('mzdotai/lumigator-frontend:frontend_{0}', env.GITHUB_SHA_SHORT) || '' }}

--- a/.github/workflows/build_images_frontend.yaml
+++ b/.github/workflows/build_images_frontend.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
-        if: steps.filter.outputs.rebuild_fe == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/')
+        if: steps.filter.outputs.rebuild_fe == 'true'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
# What's changing

This builds and pushes the frontend during PRs and not just on pushes to main or tag releases. This allows for easier testing on kubernetes and other platforms by giving a consistent and accessible container image.

# How to test it

N/A

# Additional notes for reviewers

This does not change our rules around running workflows for external contributors, who will still require approval before running workflows.