### PR TITLE
Update typos in API docs

### DIFF
--- a/lumigator/python/mzai/backend/backend/api/routes/datasets.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/datasets.py
@@ -33,9 +33,9 @@ def upload_dataset(
     request: Request,
     response: Response,
     run_id: Annotated[
-        UUID | None, Form(description="Provide the Jod ID that generated this dataset.")
+        UUID | None, Form(description="Provide the Job ID that generated this dataset.")
     ] = None,
-    generated: Annotated[bool, Form(description="Is the dataset is AI-generated?")] = False,
+    generated: Annotated[bool, Form(description="Is the dataset AI-generated?")] = False,
     generated_by: Annotated[
         str | None, Form(description="The name of the AI model that generated this dataset.")
     ] = None,

--- a/lumigator/python/mzai/backend/backend/services/experiments.py
+++ b/lumigator/python/mzai/backend/backend/services/experiments.py
@@ -145,7 +145,7 @@ class ExperimentService:
         self, request: ExperimentCreate, background_tasks: BackgroundTasks
     ) -> ExperimentResponse:
         # The FastAPI BackgroundTasks object is used to run a function in the background.
-        # It is a wrapper arount Starlette's BackgroundTasks object.
+        # It is a wrapper around Starlette's BackgroundTasks object.
         # A background task should be attached to a response,
         # and will run only once the response has been sent.
         # See here: https://www.starlette.io/background/


### PR DESCRIPTION
# What's changing

Small PR to fix typos in API documentation.

# How to test it

Steps to test the changes:

1. `make local-up`
2. Go to the API docs [upload dataset](http://localhost:8000/docs#/datasets/upload_dataset_api_v1_datasets__post)
3. Check documentation


# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
