### PR TITLE
Frontend: Change to relative backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,5 +29,3 @@ S3_BUCKET=${S3_BUCKET:-lumigator-storage}
 RAY_HEAD_NODE_HOST=${RAY_HEAD_NODE_HOST:-ray}
 RAY_DASHBOARD_PORT=${RAY_DASHBOARD_PORT:-8265}
 # Frontend configuration
-# URL to connect with the backend
-VUE_APP_BASE_URL=http://localhost:8000/api/v1/

--- a/.github/workflows/lumigator_pipeline.yaml
+++ b/.github/workflows/lumigator_pipeline.yaml
@@ -211,8 +211,6 @@ jobs:
           file: "lumigator/frontend/Dockerfile"
           push: true
           target: "server"
-          build-args: |
-            "VUE_APP_BASE_URL=http://localhost:8000/api/v1/"
           tags: |
             ${{ contains(github.ref, 'refs/tags/') == false && format('mzdotai/lumigator-frontend:frontend_{0}', env.GITHUB_SHA_SHORT) || '' }}
             ${{ github.ref == 'refs/heads/main' && 'mzdotai/lumigator-frontend:latest' || '' }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -145,13 +145,6 @@ services:
       context: .
       dockerfile: "./lumigator/frontend/Dockerfile"
       target: "server"
-      args:
-       VUE_APP_BASE_URL: http://localhost/api/v1/
-    environment:
-      LUMIGATOR_API_PORT: 8000
-      LUMIGATOR_API_HOST: backend
-    volumes:
-      - ./lumigator/frontend/nginx/:/etc/nginx/templates/
     depends_on:
       backend:
         condition: "service_started"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -145,6 +145,13 @@ services:
       context: .
       dockerfile: "./lumigator/frontend/Dockerfile"
       target: "server"
+      args:
+       VUE_APP_BASE_URL: http://localhost/api/v1/
+    environment:
+      LUMIGATOR_API_PORT: 8000
+      LUMIGATOR_API_HOST: backend
+    volumes:
+      - ./lumigator/frontend/nginx/:/etc/nginx/templates/
     depends_on:
       backend:
         condition: "service_started"

--- a/docs/source/operations-guide/dev.md
+++ b/docs/source/operations-guide/dev.md
@@ -149,13 +149,3 @@ To fix linting issues automatically:
 ```console
 user@host:~/lumigator/lumigator/frontend$ npm run lint:fix
 ```
-
-### Environment Variables
-
-To configure environment variables, create an `.env` file in the root of the `frontend` directory with the following structure:
-
-```bash
-VUE_APP_BASE_URL=http://localhost:8000/api/v1/  # Backend API URL
-```
-
-You can add other environment-specific variables as needed.

--- a/lumigator/frontend/Dockerfile
+++ b/lumigator/frontend/Dockerfile
@@ -6,7 +6,6 @@ FROM node:${NODE_VERSION}-alpine AS base
 COPY ../../ /mzai
 
 WORKDIR /mzai/
-ARG VUE_APP_BASE_URL
 
 # Install dependencies
 RUN npm --prefix /mzai/lumigator/frontend install

--- a/lumigator/frontend/src/services/http/index.js
+++ b/lumigator/frontend/src/services/http/index.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const http = axios.create({
-  baseURL: import.meta.env.VUE_APP_BASE_URL, // API baseURL as env variable
+  baseURL: '/api/v1/', // Set to relative path to the backend
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
# What's changing

This changes the front end from having a hard coded path to the backend to accessing the backend on a path relative to the backend

Before

```
baseURL: 'http://my-backend-domain:8000/api/v1'
```

After

```
baseURL: '/api/v1'
```

This worked before, since with docker compose, the front end build occurs just before runtime, and `VUE_APP_BASE_URL` gets passed in. This doesn't work in environments where the front end is built prior and shipped in a docker container (like kubernetes) **This change prevents us from having to do a custom front end build for each environment**

This will need to be used in conjunction with https://github.com/mozilla-ai/lumigator/pull/610 

Cases covered
- [x] local dev mode uses [vite proxy](https://github.com/mozilla-ai/lumigator/blob/5bd9e85c25139134221229b30dab03549864eb4d/lumigator/frontend/vite.config.js#L29)
- [x] Docker compose uses [nginx proxy pass](https://github.com/mozilla-ai/lumigator/pull/610)
- [x] Kube will use nginx proxy pass as well (forthcoming helm chart)

Refs #...
Closes #...

# How to test it

Steps to test the changes:

Run `make start-lumigator-build` locally

- [x] Try uploading a dataset
- [x] Try running an experiment

# Additional notes for reviewers

N/A

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
