### PR TITLE
Fix architecture bug

### DIFF
--- a/.github/workflows/lumigator_pipeline.yaml
+++ b/.github/workflows/lumigator_pipeline.yaml
@@ -197,6 +197,14 @@ jobs:
       - name: Truncate commit SHA
         run: echo "GITHUB_SHA_SHORT=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
 
+      - name: Set up QEMU
+        if: steps.filter.outputs.rebuild_fe == 'true' || contains(github.ref, 'refs/tags/')
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker buildx
+        if: steps.filter.outputs.rebuild_fe == 'true' || contains(github.ref, 'refs/tags/')
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to DockerHub
         uses: docker/login-action@v3
         if: steps.filter.outputs.rebuild_fe == 'true' || contains(github.ref, 'refs/tags/')

--- a/.github/workflows/lumigator_pipeline.yaml
+++ b/.github/workflows/lumigator_pipeline.yaml
@@ -217,6 +217,7 @@ jobs:
         if: steps.filter.outputs.rebuild_fe == 'true' || contains(github.ref, 'refs/tags/')
         with:
           file: "lumigator/frontend/Dockerfile"
+          platforms: linux/amd64,linux/arm64
           push: true
           target: "server"
           build-args: |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,7 +85,6 @@ services:
       context: .
       dockerfile: "Dockerfile"
       target: "main_image"
-    platform: linux/amd64
     depends_on:
       localstack:
         condition: "service_started"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,6 @@ services:
     # image and set LOCALSTACK_AUTH_TOKEN in your env
     # image: localstack/localstack-pro:3.4.0
     image: localstack/localstack:3.4.0
-    platform: linux/amd64
     ports:
       - 4566:4566
     environment:
@@ -24,7 +23,6 @@ services:
 
   localstack-create-bucket:
     image: localstack/localstack:3.4.0
-    platform: linux/amd64
     depends_on:
       localstack:
         condition: service_healthy
@@ -130,7 +128,7 @@ services:
       - "localhost:host-gateway"
 
   frontend:
-    image: mzdotai/lumigator-frontend:latest
+    image: mzdotai/lumigator-frontend:frontend_cdeec75
     build:
       context: .
       dockerfile: "./lumigator/frontend/Dockerfile"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -128,7 +128,7 @@ services:
       - "localhost:host-gateway"
 
   frontend:
-    image: mzdotai/lumigator-frontend:frontend_cdeec75
+    image: mzdotai/lumigator-frontend:latest
     build:
       context: .
       dockerfile: "./lumigator/frontend/Dockerfile"


### PR DESCRIPTION
# What's changing

This PR fixes the error that we saw several times when executing `make start-lumigator`: `frontend The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested`

Refs #577 
Closes #577 

# How to test it

Change the frontend image tag in your docker-compose to: frontend_cdeec75. I created that tag with the new process (you can also grab the one generated by the latest checks of this PR), and execute `make start-lumigator`.

# I already...

- [X] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
