### PR TITLE
Check Minio health more often

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,9 +10,9 @@ services:
       - 9001:9001
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
+      interval: 5s
       timeout: 20s
-      retries: 3
+      retries: 18
     environment:
       - MINIO_ROOT_USER=minioadmin
       - MINIO_ROOT_PASSWORD=minioadmin


### PR DESCRIPTION
# What's changing

Would it be ok if we check the health more often? My minio stack is normally up after ~7 seconds so this change would save me about 20 seconds every time I run local-up. I kept the same total duration by bumping up the retries.

> If this PR is related to an issue or closes one, please link it here.

# How to test it

Steps to test the changes:

1.`make local-up`

# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [ x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x ] Checked if a (backend) DB migration step was required and included it if required
