### PR TITLE
UI: Fix - Change the way we decide if a property is present from entrypoint config

### DIFF
--- a/lumigator/frontend/src/helpers/index.js
+++ b/lumigator/frontend/src/helpers/index.js
@@ -39,9 +39,9 @@ export function retrieveEntrypoint(job) {
     // See: lumigator/python/mzai/backend/backend/config_templates.py
 
     // Normalize the max_samples
-    if (jsonObject?.job?.max_samples) {
+    if (jsonObject?.job?.max_samples !== undefined) {
       jsonObject.max_samples = jsonObject.job.max_samples;
-    } else if (jsonObject?.evaluation?.max_samples) {
+    } else if (jsonObject?.evaluation?.max_samples !== undefined) {
       jsonObject.max_samples = jsonObject.evaluation.max_samples;
     } else {
       throw new Error("Unable to parse max_samples from entrypoint config: " + configString);
@@ -49,13 +49,13 @@ export function retrieveEntrypoint(job) {
 
     // Normalize the model path
     let modelPath = '';
-    if (jsonObject?.model?.path) {
+    if (jsonObject?.model?.path !== undefined) {
       modelPath = jsonObject.model.path;
-    } else if (jsonObject?.model?.inference?.engine) {
+    } else if (jsonObject?.model?.inference?.engine !== undefined) {
       modelPath = jsonObject.model.inference.engine;
-    } else if (jsonObject?.hf_pipeline?.model_uri) {
+    } else if (jsonObject?.hf_pipeline?.model_uri !== undefined) {
       modelPath = jsonObject.hf_pipeline.model_uri;
-    } else if (jsonObject?.inference_server?.engine) {
+    } else if (jsonObject?.inference_server?.engine !== undefined) {
       modelPath = jsonObject.inference_server.engine;
     } else {
       throw new Error("Unable to parse model path from entrypoint config: " + configString);


### PR DESCRIPTION
# What's changing

Fix issue where no samples are submitted and default is used, which was causing an error in parsing in the UI when retrieving the experiment details.

# How to test it

Steps to test the changes:

1. `make local-up`
2. Upload a dataset
3. Create an experiment (but **don't** set any max samples)
4. Click the created experiment in the UI and see the details panel load correctly


# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
