### PR TITLE
Fix docker clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,10 +104,10 @@ clean-docker-buildcache:
 	docker builder prune --all -f
 
 clean-docker-containers:
-	docker rm -vf $$(docker container ls -aq)
+	docker container ls -aq | xargs -n1 docker rm -vf
 
 clean-docker-images:
-	docker rmi -f $$(docker image ls -aq)
+	docker image ls -aq | xargs -n1 docker rmi -f
 
 clean-docker-all: clean-docker-containers clean-docker-buildcache clean-docker-images
 

--- a/Makefile
+++ b/Makefile
@@ -104,10 +104,10 @@ clean-docker-buildcache:
 	docker builder prune --all -f
 
 clean-docker-containers:
-	docker container ls -aq | xargs -n1 docker rm -vf
+	docker container prune
 
 clean-docker-images:
-	docker image ls -aq | xargs -n1 docker rmi -f
+	docker image prune -a
 
 clean-docker-all: clean-docker-containers clean-docker-buildcache clean-docker-images
 

--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,10 @@ clean-docker-buildcache:
 clean-docker-containers:
 	docker container prune
 
+# remove all dangling images + all mzdotai/* ones
 clean-docker-images:
-	docker image prune -a
+	docker images "mzdotai/*" -q | xargs -n1 docker rmi -f; \
+	docker image prune
 
 clean-docker-all: clean-docker-containers clean-docker-buildcache clean-docker-images
 

--- a/docs/source/get-started/quickstart.md
+++ b/docs/source/get-started/quickstart.md
@@ -271,6 +271,12 @@ different aspects:
 - [BERTScore](https://openreview.net/pdf?id=SkeHuCVFDr) - Generates embeddings of ground truth input
   and model output and compares their cosine similarity
 
+## Terminate Session
+In order to shut down Lumigator, you can stop the containers that were [started](../get-started/installation.md) using Docker Compose. This can be done by simply running the following command:
+```console
+user@host:~/lumigator$ make stop-lumigator
+```
+
 ## Next Steps
 
 Congratulations! You have successfully uploaded a dataset, created an evaluation job, and retrieved


### PR DESCRIPTION
# What's changing

`make clean-docker-all` breaks when no containers are running because the first command `clean-docker-containers` returns an error if the list of containers is empty.

This PR fixes that by using `xargs` to pass the list (when not empty) to `docker rm` and `docker rmi`.

Closes https://github.com/mozilla-ai/lumigator/issues/660

# How to test it

run `make clean-all` or `make clean-docker-all`. This should remove all containers + images if present, without breaking if there is none

# Additional notes for reviewers

I am not sure why we'd need both `make clean-all` and `make clean-docker-all`. The semantics I had in mind was "clean-all should call clean-docker-all plus something else" but that does not happen (actually this is a subset of `clean-docker-all`). WDYT? Should we remove `clean-all` or is there a good reason to keep it (perhaps with a different name)?

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
