### PR TITLE
API/Storage: Recreate a CSV from the uploaded dataset (CSV) and allow filtering for downloads

### DIFF
--- a/lumigator/python/mzai/backend/backend/api/routes/datasets.py
+++ b/lumigator/python/mzai/backend/backend/api/routes/datasets.py
@@ -45,7 +45,7 @@ def upload_dataset(
     An uploaded dataset is parsed into HuggingFace format files and stored alongside a
     recreated version of the input dataset.
 
-    NOTE: The recreated version of the CSV file may not have identical delimeters as it will follow
+    NOTE: The recreated version of the CSV file may not have identical delimiters as it will follow
     the format that HuggingFace uses when it generates the CSV.
     """
     ds_response = service.upload_dataset(

--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -247,11 +247,7 @@ class DatasetService:
         When supplied, only URLs for files that match the specified extension are returned.
         """
         # Sanitize the input for a file extension.
-        if extension is not None:
-            extension = extension.strip().lower()
-            # If there's nothing left, set it as None.
-            if extension == "":
-                extension = None
+        extension = extension.strip().lower() if extension and extension.strip() else None
 
         record = self._get_dataset_record(dataset_id)
         dataset_key = self._get_s3_key(dataset_id, record.filename)

--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -180,7 +180,6 @@ class DatasetService:
 
             # convert the dataset to HF format and save it to S3
             self._save_dataset_to_s3(temp.name, record)
-
         finally:
             # Cleanup temp file
             Path(temp.name).unlink()

--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -247,6 +247,13 @@ class DatasetService:
 
         When supplied, only URLs for files that match the specified extension are returned.
         """
+        # Sanitize the input for a file extension.
+        if extension is not None:
+            extension = extension.strip().lower()
+            # If there's nothing left, set it as None.
+            if extension == "":
+                extension = None
+
         record = self._get_dataset_record(dataset_id)
         dataset_key = self._get_s3_key(dataset_id, record.filename)
 
@@ -264,7 +271,7 @@ class DatasetService:
             download_urls = []
             for s3_object in s3_response["Contents"]:
                 # Ignore files that don't end with the extension if it was specified
-                if extension and not s3_object["Key"].lower().endswith(extension.lower()):
+                if extension and not s3_object["Key"].lower().endswith(extension):
                     continue
 
                 download_url = self.s3_client.generate_presigned_url(

--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -116,7 +116,12 @@ class DatasetService:
         return f"{settings.S3_DATASETS_PREFIX}/{dataset_id}/{filename}"
 
     def _save_dataset_to_s3(self, temp_fname, record):
-        """Loads a dataset, converts it to HF dataset format, and saves it on S3."""
+        """Converts the specified file to a set of HuggingFace dataset formatted files,
+        along with a newly recreated CSV file. The files are stored in an S3 bucket.
+        """
+        # Temp file to be used to contain the recreated CSV file.
+        temp = NamedTemporaryFile(delete=False)
+
         try:
             # Load the CSV file as HF dataset
             dataset_hf = load_dataset("csv", data_files=temp_fname, split="train")
@@ -126,12 +131,19 @@ class DatasetService:
             dataset_path = self._get_s3_path(dataset_key)
             # Deprecated!!!
             dataset_hf.save_to_disk(dataset_path, fs=self.s3_filesystem)
+
+            # Use the converted HF format files to rebuild the CSV and store it as 'dataset.csv'.
+            dataset_hf.to_csv(temp.name, index=False)
+            self.s3_filesystem.put_file(temp.name, f"{dataset_path}/dataset.csv")
         except Exception as e:
             # if a record was already created, delete it from the DB
             if record:
                 self.dataset_repo.delete(record.id)
 
             self._raise_unhandled_exception(e)
+        finally:
+            # Clean up temp file
+            Path(temp.name).unlink()
 
     def upload_dataset(
         self,
@@ -228,8 +240,13 @@ class DatasetService:
         # Getting this far means we are OK to remove the record from the DB.
         self.dataset_repo.delete(record.id)
 
-    def get_dataset_download(self, dataset_id: UUID) -> DatasetDownloadResponse:
-        """Generate presigned download URLs for dataset files."""
+    def get_dataset_download(
+        self, dataset_id: UUID, extension: str | None = None
+    ) -> DatasetDownloadResponse:
+        """Generate pre-signed download URLs for dataset files.
+
+        When supplied, only URLs for files that match the specified extension are returned.
+        """
         record = self._get_dataset_record(dataset_id)
         dataset_key = self._get_s3_key(dataset_id, record.filename)
 
@@ -246,6 +263,10 @@ class DatasetService:
 
             download_urls = []
             for s3_object in s3_response["Contents"]:
+                # Ignore files that don't end with the extension if it was specified
+                if extension and not s3_object["Key"].lower().endswith(extension.lower()):
+                    continue
+
                 download_url = self.s3_client.generate_presigned_url(
                     "get_object",
                     Params={

--- a/lumigator/python/mzai/backend/backend/tests/conftest.py
+++ b/lumigator/python/mzai/backend/backend/tests/conftest.py
@@ -9,7 +9,7 @@ import boto3
 import fsspec
 import pytest
 import requests_mock
-from fastapi import FastAPI
+from fastapi import FastAPI, UploadFile
 from fastapi.testclient import TestClient
 from fsspec.implementations.memory import MemoryFileSystem
 from loguru import logger
@@ -65,6 +65,18 @@ def valid_experiment_dataset_without_gt() -> str:
         ["Hello World"],
     ]
     return format_dataset(data)
+
+
+@pytest.fixture
+def valid_upload_file(valid_experiment_dataset) -> UploadFile:
+    """Minimal valid upload file (with ground truth)."""
+    fake_filename = "dataset.csv"
+    fake_file = io.BytesIO(valid_experiment_dataset.encode("utf-8"))
+    fake_upload_file = UploadFile(
+        filename=fake_filename,
+        file=fake_file,
+    )
+    return fake_upload_file
 
 
 @pytest.fixture(scope="session")

--- a/lumigator/python/mzai/backend/backend/tests/fakes/fake_s3.py
+++ b/lumigator/python/mzai/backend/backend/tests/fakes/fake_s3.py
@@ -29,12 +29,16 @@ class FakeS3Client:
     def list_objects_v2(self, **kwargs):
         bucket = kwargs["Bucket"]
         prefix = kwargs["Prefix"]
+        key = f"s3://{bucket}/{prefix}"
+
         return {
             "IsTruncated": False,
             "Name": bucket,
             "KeyCount": len(self.storage),
             "Prefix": prefix,
-            "Contents": [self.__map_entry_to_content(key) for key in self.storage.keys()],
+            "Contents": [
+                self.__map_entry_to_content(k) for k in self.storage.keys() if k.startswith(key)
+            ],
         }
 
     def generate_presigned_url(self, method, **kwargs):

--- a/lumigator/python/mzai/backend/backend/tests/unit/api/routes/test_datasets.py
+++ b/lumigator/python/mzai/backend/backend/tests/unit/api/routes/test_datasets.py
@@ -10,7 +10,9 @@ from lumigator_schemas.datasets import DatasetDownloadResponse, DatasetFormat, D
 from backend.api.http_headers import HttpHeaders
 
 
-def test_upload_delete(app_client: TestClient, valid_experiment_dataset: str, dependency_overrides_fakes):
+def test_upload_delete(
+    app_client: TestClient, valid_experiment_dataset: str, dependency_overrides_fakes
+):
     upload_filename = "dataset.csv"
 
     # Create
@@ -53,7 +55,9 @@ def test_dataset_delete_error(app_client: TestClient, dependency_overrides_fakes
         assert data["detail"] == f"Unexpected error deleting dataset for ID: {dataset_id}"
 
 
-def test_presigned_download(app_client: TestClient, valid_experiment_dataset: str, dependency_overrides_fakes):
+def test_presigned_download(
+    app_client: TestClient, valid_experiment_dataset: str, dependency_overrides_fakes
+):
     upload_filename = "dataset.csv"
 
     # Create
@@ -88,10 +92,7 @@ def test_presigned_download(app_client: TestClient, valid_experiment_dataset: st
     ],
 )
 def test_experiment_format_validation(
-    app_client: TestClient,
-    dataset: str,
-    expected_status: int,
-    dependency_overrides_fakes
+    app_client: TestClient, dataset: str, expected_status: int, dependency_overrides_fakes
 ):
     response = app_client.post(
         url="/datasets",
@@ -105,7 +106,7 @@ def test_experiment_ground_truth(
     app_client: TestClient,
     valid_experiment_dataset: str,
     valid_experiment_dataset_without_gt: str,
-    dependency_overrides_fakes
+    dependency_overrides_fakes,
 ):
     ground_truth_response = app_client.post(
         url="/datasets",

--- a/lumigator/python/mzai/backend/backend/tests/unit/services/test_dataset_service.py
+++ b/lumigator/python/mzai/backend/backend/tests/unit/services/test_dataset_service.py
@@ -1,3 +1,9 @@
+from io import BytesIO
+from uuid import UUID
+
+import pytest
+from fastapi import UploadFile
+from lumigator_schemas.datasets import DatasetFormat
 from s3fs import S3FileSystem
 
 from backend.repositories.datasets import DatasetRepository
@@ -18,3 +24,44 @@ def test_delete_dataset_file_not_found(db_session, fake_s3_client, fake_s3fs):
     dataset_service.delete_dataset(dataset_record.id)
     dataset_record = dataset_service._get_dataset_record(dataset_record.id)
     assert dataset_record is None
+
+
+def test_upload_dataset(db_session, fake_s3_client, fake_s3fs, valid_upload_file):
+    dataset_service = DatasetService(DatasetRepository(db_session), fake_s3_client, fake_s3fs)
+    upload_response = dataset_service.upload_dataset(valid_upload_file, DatasetFormat.JOB)
+
+    assert upload_response.id is not None
+    assert isinstance(upload_response.id, UUID)
+
+
+@pytest.mark.parametrize(
+    "extension, total",
+    [
+        ("foo", 0),
+        ("csv", 1),
+        ("  csv ", 1),
+        ("CSV", 1),
+        ("cSv", 1),
+        ("json", 2),
+        ("", 4),
+        ("    ", 4),
+    ],
+)
+def test_dataset_download_with_extensions(
+    db_session, fake_s3_client, fake_s3fs, valid_upload_file, extension, total
+):
+    dataset_service = DatasetService(DatasetRepository(db_session), fake_s3_client, fake_s3fs)
+    upload_response = dataset_service.upload_dataset(valid_upload_file, DatasetFormat.JOB)
+
+    assert upload_response.id is not None
+    assert isinstance(upload_response.id, UUID)
+
+    download_response = dataset_service.get_dataset_download(upload_response.id, extension)
+    assert download_response.id is not None
+    assert isinstance(download_response.id, UUID)
+    # 4 files total (HF dataset: 1 x arrow file + 2 x json) + 1 CSV.
+    assert len(download_response.download_urls) == total
+    assert (
+        sum(1 for x in download_response.download_urls if x.endswith(extension.strip().lower()))
+        == total
+    )

--- a/lumigator/python/mzai/sdk/lumigator_sdk/lm_datasets.py
+++ b/lumigator/python/mzai/sdk/lumigator_sdk/lm_datasets.py
@@ -129,10 +129,7 @@ class Datasets:
             DatasetDownloadResponse: the download link for the requested
                 dataset.
         """
-        if extension is not None:
-            extension = extension.strip().lower()
-            if extension == "":
-                extension = None
+        extension = extension.strip().lower() if extension and extension.strip() else None
 
         endpoint = (
             f"{self.DATASETS_ROUTE}/{id}/download"

--- a/lumigator/python/mzai/sdk/lumigator_sdk/lm_datasets.py
+++ b/lumigator/python/mzai/sdk/lumigator_sdk/lm_datasets.py
@@ -105,7 +105,7 @@ class Datasets:
         """
         self.client.get_response(f"{self.DATASETS_ROUTE}/{id}", method=HTTPMethod.DELETE)
 
-    def get_dataset_link(self, id: UUID) -> DatasetDownloadResponse:
+    def get_dataset_link(self, id: UUID, extension: str | None = None) -> DatasetDownloadResponse:
         """Return the download link for a specific dataset.
 
         .. admonition:: Example
@@ -121,11 +121,23 @@ class Datasets:
             id (UUID): the ID of the dataset whose download link we want to
                 obtain.
 
+            extension (str): when specified, will be used to return only URLs for files which have
+                a matching file extension. Wildcards are not accepted. By default, all files are
+                returned. e.g. csv.
+
         Returns:
             DatasetDownloadResponse: the download link for the requested
                 dataset.
         """
-        endpoint = f"{self.DATASETS_ROUTE}/{id}/download"
+        if extension is not None:
+            extension = extension.strip().lower()
+            if extension == "":
+                extension = None
+
+        endpoint = (
+            f"{self.DATASETS_ROUTE}/{id}/download"
+            f"{f'?extension={extension}' if extension is not None else ''}"
+        )
         response = self.client.get_response(endpoint)
 
         return DatasetDownloadResponse(**(response.json()))

--- a/lumigator/python/mzai/sdk/tests/conftest.py
+++ b/lumigator/python/mzai/sdk/tests/conftest.py
@@ -19,6 +19,7 @@ def request_mock() -> requests_mock.Mocker:
     with requests_mock.Mocker() as cm:
         yield cm
 
+
 @pytest.fixture(scope="session")
 def mock_vendor_data() -> str:
     return '["openai", "mistral"]'
@@ -34,7 +35,7 @@ def lumi_client(request_mock, mock_vendor_data) -> LumigatorClient:
     request_mock.get(
         url=f"http://{LUMI_HOST}/api/v1/{Health.HEALTH_ROUTE}",
         status_code=HTTPStatus.OK,
-        json={'status': 'OK', 'dpeloymentType': 'local'},
+        json={"status": "OK", "deploymentType": "local"},
     )
     return LumigatorClient(LUMI_HOST)
 
@@ -180,4 +181,3 @@ def simple_eval_template():
             "storage_path": "{storage_path}"
         }}
     }}"""
-


### PR DESCRIPTION
# What's changing

This PR makes two changes:

1. On dataset upload we still parse the CSV to HuggingFace datasets as before, but now use the parsed files to recreate the CSV and uploads it in S3 alongside the previous HF ones (arrow and JSON).
2. The API now supports a query parameter for dataset download to filter for a specific extension (e.g. csv), the logic for this lives in the`DatasetService`.

The reason for this is that it's most likely that users (including the UI) simply want the CSV version of the dataset, either for display or to review, for example, when it is a dataset that was generated from an annotation job (where Lumigator adds ground truth for the user).

Support added to the SDK.

Closes: https://github.com/mozilla-ai/lumigator/issues/563

# How to test it

Steps to test the changes:

1. `make local-up`
3. In the UI, upload a dataset
4. Click the dataset to get the details panel, and copy the ID
5. In the [Swagger docs for dataset download](http://localhost:8000/docs#/datasets/get_dataset_download_api_v1_datasets__dataset_id__download_get) enter the ID and execute, you should see 4 results (2 JSON, 1 arrow and the new CSV)
6. In the `extension` text field, add `csv` and re-execute the API call, you should see only a single result in the returned URLs for the CSV file


# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [x] Added some tests for any new functionality
- [x] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
