### PR TITLE
clear selected job upon dismissing details

### DIFF
--- a/lumigator/frontend/src/components/pages/LExperiments.vue
+++ b/lumigator/frontend/src/components/pages/LExperiments.vue
@@ -153,6 +153,7 @@ onMounted(async () => {
 watch(showSlidingPanel, (newValue) => {
   if (!newValue) {
     selectedExperiment.value = null;
+    selectedJob.value = null;
   }
 });
 </script>


### PR DESCRIPTION
Small change to clear the state of the "details" component after use.