### PR TITLE
Fixing db persistency in the local dev scenario

### DIFF
--- a/.devcontainer/docker-compose.override.yaml
+++ b/.devcontainer/docker-compose.override.yaml
@@ -8,9 +8,13 @@ services:
       dockerfile: "Dockerfile"
       target: "dev_image"
     volumes:
-      -  database_volume:/mzai/backend/local.db
+      - type: bind
+        source: ~/.lumigator/db/
+        target: /lumigator_db/
     ports:
       - "5678:5678"
+    environment:
+      - SQLALCHEMY_DATABASE_URL=sqlite:////lumigator_db/local.db
     develop:
       watch:
         - path: lumigator/python/mzai/backend/


### PR DESCRIPTION
# What's changing

This PR binds the sqlite database in the backend container to a local file in `~/.lumigator/db`.
This allows the DB to persist from one session to another (i.e. even after `make local-down`+`make local-up`.

Closes #515 

# How to test it

Steps to test the changes:

1. run `make local-up`
2. add a dataset
3. run `make local-down`
4. run `make local-up`
5. get datasets list 

# Additional notes for reviewers

This is still a draft pr because:

- some integration tests run using this DB, which is not ideal. We should either prevent this or add in the docs that this might happen and how to avoid it
- while retrieving datasets works properly, jobs do not work as well because currently the list jobs method returns an intersection between jobs in the DB and jobs running on ray. Unless we persist ray data (which btw is possible), or start relying on the DB only to store/get job info, we won't be able to see jobs from a previous lumigator execution. 👉 NOTE that this is partially solved by https://github.com/mozilla-ai/lumigator/pull/744, we need to decide how to deal with logs in that case: see [this comment](https://github.com/mozilla-ai/lumigator/pull/744#pullrequestreview-2581646577))
- this is currently working in dev setup only. Do we want to have this as a stable feature in the `make start-lumigator` scenario? This still has to be discussed
