### PR TITLE
fix: empty ground-truth column should mean no ground-truth

### DIFF
--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -80,8 +80,8 @@ def dataset_has_gt(filename: str) -> bool:
     if GT_FIELD not in dataset.column_names:
         return False
 
-    # We'll accept that there's at least one value in the ground_truth column
-    return any(dataset[GT_FIELD])
+    # True only if every value in dataset[GT_FIELD] is not None or empty.
+    return all(value for value in dataset[GT_FIELD])
 
 
 class DatasetService:

--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -75,6 +75,9 @@ def validate_experiment_dataset(filename: str):
 
 
 def dataset_has_gt(filename: str) -> bool:
+    """Returns true if the dataset located at the supplied path (filename) has a ground truth
+    column with all of its rows correctly populated, otherwise false.
+    """
     dataset = load_dataset("csv", data_files=filename, split="train")
 
     if GT_FIELD not in dataset.column_names:

--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -81,7 +81,7 @@ def dataset_has_gt(filename: str) -> bool:
         return False
 
     # True only if every value in dataset[GT_FIELD] is not None or empty.
-    return all(value for value in dataset[GT_FIELD])
+    return all(value is not None and value.strip() != "" for value in dataset[GT_FIELD])
 
 
 class DatasetService:

--- a/lumigator/python/mzai/backend/backend/services/datasets.py
+++ b/lumigator/python/mzai/backend/backend/services/datasets.py
@@ -75,12 +75,13 @@ def validate_experiment_dataset(filename: str):
 
 
 def dataset_has_gt(filename: str) -> bool:
-    with Path(filename).open() as f:
-        reader = csv.DictReader(f)
-        fields = set(reader.fieldnames or [])
-        has_gt = GT_FIELD in fields
+    dataset = load_dataset("csv", data_files=filename, split="train")
 
-    return has_gt
+    if GT_FIELD not in dataset.column_names:
+        return False
+
+    # We'll accept that there's at least one value in the ground_truth column
+    return any(dataset[GT_FIELD])
 
 
 class DatasetService:
@@ -105,7 +106,7 @@ class DatasetService:
         return self.dataset_repo.get_by_job_id(job_id)
 
     def _get_s3_path(self, dataset_key: str) -> str:
-        return f"s3://{ Path(settings.S3_BUCKET) / dataset_key }"
+        return f"s3://{Path(settings.S3_BUCKET) / dataset_key}"
 
     def _get_s3_key(self, dataset_id: UUID, filename: str) -> str:
         """Generate the S3 key for the dataset contents.

--- a/lumigator/python/mzai/backend/backend/tests/conftest.py
+++ b/lumigator/python/mzai/backend/backend/tests/conftest.py
@@ -80,6 +80,16 @@ def valid_upload_file(valid_experiment_dataset) -> UploadFile:
 
 
 @pytest.fixture(scope="session")
+def valid_experiment_dataset_with_empty_gt() -> str:
+    """Minimal valid dataset without groundtruth."""
+    data = [
+        ["examples", "ground_truth"],
+        ["Hello World"],
+    ]
+    return format_dataset(data)
+
+
+@pytest.fixture(scope="session")
 def missing_examples_dataset() -> str:
     """Minimal invalid dataset without examples."""
     data = [

--- a/lumigator/python/mzai/backend/backend/tests/conftest.py
+++ b/lumigator/python/mzai/backend/backend/tests/conftest.py
@@ -3,7 +3,7 @@ import io
 import os
 import uuid
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import boto3
 import fsspec
@@ -35,8 +35,14 @@ TEST_SUMMARY_MODEL = "hf://hf-internal-testing/tiny-random-T5ForConditionalGener
 TEST_INFER_MODEL = "hf://hf-internal-testing/tiny-random-t5"
 
 
+@pytest.fixture
 def common_resources_dir() -> Path:
     return Path(__file__).parent.parent.parent.parent
+
+
+@pytest.fixture
+def common_resources_sample_data_dir(common_resources_dir) -> Path:
+    return common_resources_dir / "sample_data"
 
 
 def format_dataset(data: list[list[str]]) -> str:
@@ -110,22 +116,22 @@ def extra_column_dataset() -> str:
 
 
 @pytest.fixture(scope="function")
-def dialog_dataset():
-    filename = common_resources_dir() / "sample_data" / "dialogsum_exc.csv"
+def dialog_dataset(common_resources_dir):
+    filename = common_resources_dir / "sample_data" / "dialogsum_exc.csv"
     with Path(filename).open("rb") as f:
         yield f
 
 
 @pytest.fixture(scope="function")
-def dialog_empty_gt_dataset():
-    filename = common_resources_dir() / "sample_data" / "dialogsum_mini_empty_gt.csv"
+def dialog_empty_gt_dataset(common_resources_dir):
+    filename = common_resources_dir / "sample_data" / "dialogsum_mini_empty_gt.csv"
     with Path(filename).open("rb") as f:
         yield f
 
 
 @pytest.fixture(scope="function")
-def dialog_no_gt_dataset():
-    filename = common_resources_dir() / "sample_data" / "dialogsum_mini_no_gt.csv"
+def dialog_no_gt_dataset(common_resources_dir):
+    filename = common_resources_dir / "sample_data" / "dialogsum_mini_no_gt.csv"
     with Path(filename).open("rb") as f:
         yield f
 

--- a/lumigator/python/mzai/backend/backend/tests/unit/api/routes/test_datasets.py
+++ b/lumigator/python/mzai/backend/backend/tests/unit/api/routes/test_datasets.py
@@ -106,6 +106,7 @@ def test_experiment_ground_truth(
     app_client: TestClient,
     valid_experiment_dataset: str,
     valid_experiment_dataset_without_gt: str,
+    valid_experiment_dataset_with_empty_gt: str,
     dependency_overrides_fakes,
 ):
     ground_truth_response = app_client.post(
@@ -129,5 +130,17 @@ def test_experiment_ground_truth(
     created_dataset = DatasetResponse.model_validate(no_ground_truth_response.json())
     assert created_dataset.ground_truth is False
     location = no_ground_truth_response.headers.get(HttpHeaders.LOCATION)
+    assert location != ""
+    assert location == f"{app_client.base_url}datasets/{created_dataset.id}"
+
+    empty_ground_truth_response = app_client.post(
+        url="/datasets",
+        data={"format": DatasetFormat.JOB.value},
+        files={"dataset": ("dataset.csv", valid_experiment_dataset_with_empty_gt)},
+    )
+    assert empty_ground_truth_response.status_code == status.HTTP_201_CREATED
+    created_dataset = DatasetResponse.model_validate(empty_ground_truth_response.json())
+    assert created_dataset.ground_truth is False
+    location = empty_ground_truth_response.headers.get(HttpHeaders.LOCATION)
     assert location != ""
     assert location == f"{app_client.base_url}datasets/{created_dataset.id}"

--- a/lumigator/python/mzai/sample_data/dialogsum_mini_all_gt_is_whitespace.csv
+++ b/lumigator/python/mzai/sample_data/dialogsum_mini_all_gt_is_whitespace.csv
@@ -1,0 +1,19 @@
+examples,ground_truth
+"#Person1#: Hello, how are you doing today?
+#Person2#: I ' Ve been having trouble breathing lately.,     
+#Person1#: Have you had any type of cold lately?
+#Person2#: No, I haven ' t had a cold. I just have a heavy feeling in my chest when I try to breathe.
+#Person1#: Do you have any allergies that you know of?,
+#Person2#: No, I don ' t have any allergies that I know of.
+#Person1#: Does this happen all the time or mostly when you are active?
+#Person2#: It happens a lot when I work out.,    
+#Person1#: I am going to send you to a pulmonary specialist who can run tests on you for asthma.
+#Person2#: Thank you for your help, doctor.",       
+"#Person1#: Hey Jimmy. Let's go workout later today.
+#Person2#: Sure. What time do you want to go?
+#Person1#: How about at 3:30?
+#Person2#: That sounds good. Today we work on Legs and forearm.
+#Person1#: Hey. I just played basketball earlier, so my legs are a little sore. Let's work out on arms and stomach today.
+#Person2#: I'm on a weekly schedule. You're messing everything up.
+#Person1#: C'mon. We're only switching two days. You can do legs on Friday.
+#Person2#: Aright. I'll meet you at the gym at 3:30 then.",       

--- a/lumigator/python/mzai/sample_data/dialogsum_mini_some_missing_some_whitespace_gt.csv
+++ b/lumigator/python/mzai/sample_data/dialogsum_mini_some_missing_some_whitespace_gt.csv
@@ -1,0 +1,19 @@
+examples,ground_truth
+"#Person1#: Hello, how are you doing today?
+#Person2#: I ' Ve been having trouble breathing lately.,     
+#Person1#: Have you had any type of cold lately?
+#Person2#: No, I haven ' t had a cold. I just have a heavy feeling in my chest when I try to breathe.
+#Person1#: Do you have any allergies that you know of?,
+#Person2#: No, I don ' t have any allergies that I know of.
+#Person1#: Does this happen all the time or mostly when you are active?
+#Person2#: It happens a lot when I work out.,    
+#Person1#: I am going to send you to a pulmonary specialist who can run tests on you for asthma.
+#Person2#: Thank you for your help, doctor.",#Person2# has trouble breathing. The doctor asks #Person2# about it and will send #Person2# to a pulmonary specialist.
+"#Person1#: Hey Jimmy. Let's go workout later today.
+#Person2#: Sure. What time do you want to go?
+#Person1#: How about at 3:30?
+#Person2#: That sounds good. Today we work on Legs and forearm.
+#Person1#: Hey. I just played basketball earlier, so my legs are a little sore. Let's work out on arms and stomach today.
+#Person2#: I'm on a weekly schedule. You're messing everything up.
+#Person1#: C'mon. We're only switching two days. You can do legs on Friday.
+#Person2#: Aright. I'll meet you at the gym at 3:30 then.",       


### PR DESCRIPTION
# What's changing

Currently if we upload a csv with an existing ground_truth column that is empty, we consider it as having a ground-truth. Instead, we should be checking as well whether there are any values in it and return false if it's truly empty.

Closes #620 

# How to test it

Steps to test the changes:


1. git checkout this branch && git pull
1. make local-up
1. Browse to localhost (lumigator UI)
1. Upload [this CSV](https://github.com/user-attachments/files/18413388/dialogsum_mini_empty_gt.csv), which has an empty gt column (header is there, but no values)
1. See on the UI gt column set as **False**


# Additional notes for reviewers

Open to any **reasoned** choice between "ask for all rows to be annotated" and "1 sample is enough" to consider gt to be present. 

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [X] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [X] Checked if a (backend) DB migration step was required and included it if required
