### PR TITLE
Use Job name instead of a reference to the address in memory.

### DIFF
--- a/lumigator/python/mzai/backend/backend/services/jobs.py
+++ b/lumigator/python/mzai/backend/backend/services/jobs.py
@@ -270,7 +270,7 @@ class JobService:
 
     def get_job(self, job_id: UUID) -> JobResponse:
         record = self._get_job_record(job_id)
-        loguru.logger.info(f"Obtaining info for job {job_id}: {record}")
+        loguru.logger.info(f"Obtaining info for job {job_id}: {record.name}")
 
         if record.status == JobStatus.FAILED or record.status == JobStatus.SUCCEEDED:
             return JobResponse.model_validate(record)


### PR DESCRIPTION
# What's changing

Use the record's name, because otherwise it logs the class name and memory address.

Before change:
```
.....- Obtaining info for job ca7c4a26-2c45-4e8e-9ce6-ae1abc9b2a49: <backend.records.jobs.JobRecord object at 0xffff713e8a90>
```

After Change
```
....- Obtaining info for job ca7c4a26-2c45-4e8e-9ce6-ae1abc9b2a49: nathans_job
```

# How to test it

Steps to test the changes:

1. `make local-up`
2. upload dataset
3. trigger a job, and look at the backend logs.

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
