### PR TITLE
UI: Enable dataset download icon and download CSV by default

### DIFF
--- a/lumigator/frontend/src/components/organisms/LDatasetDetails.vue
+++ b/lumigator/frontend/src/components/organisms/LDatasetDetails.vue
@@ -16,7 +16,7 @@
           severity="secondary"
           variant="text"
           rounded
-          @click="emit('l-download-dataset', selectedDataset)"
+          @click="emit('l-download-dataset')"
         />
         <Button
           severity="secondary"
@@ -95,6 +95,7 @@ const isCopied = ref(false);
 
 const emit = defineEmits([
   'l-delete-dataset',
+  'l-download-dataset',
   'l-details-closed',
   'l-experiment'
 ])

--- a/lumigator/frontend/src/components/organisms/LDatasetDetails.vue
+++ b/lumigator/frontend/src/components/organisms/LDatasetDetails.vue
@@ -16,6 +16,7 @@
           severity="secondary"
           variant="text"
           rounded
+          @click="emit('l-download-dataset', selectedDataset)"
         />
         <Button
           severity="secondary"

--- a/lumigator/frontend/src/components/pages/LDatasets.vue
+++ b/lumigator/frontend/src/components/pages/LDatasets.vue
@@ -43,7 +43,7 @@
         @l-experiment="onExperimentDataset($event)"
         @l-details-closed="onClearSelection()"
         @l-delete-dataset="deleteConfirmation($event)"
-        @l-download-dataset="downloadDataset($event)"
+        @l-download-dataset="onDownloadDataset()"
       />
     </Teleport>
   </div>
@@ -110,9 +110,8 @@ function deleteConfirmation(dataset) {
   });
 }
 
-async function downloadDataset(dataset) {
-  const blob = await datasetsService.downloadDataset(dataset.id);
-  downloadContent(blob, dataset.filename)
+function onDownloadDataset() {
+  datasetStore.loadDatasetFile();
 }
 
 const onDatasetAdded = () => { datasetInput.value.input.click() }

--- a/lumigator/frontend/src/components/pages/LDatasets.vue
+++ b/lumigator/frontend/src/components/pages/LDatasets.vue
@@ -43,6 +43,7 @@
         @l-experiment="onExperimentDataset($event)"
         @l-details-closed="onClearSelection()"
         @l-delete-dataset="deleteConfirmation($event)"
+        @l-download-dataset="downloadDataset($event)"
       />
     </Teleport>
   </div>
@@ -61,6 +62,8 @@ import LDatasetEmpty from '@/components/molecules/LDatasetEmpty.vue';
 import LDatasetDetails from '@/components/organisms/LDatasetDetails.vue';
 import { useConfirm } from "primevue/useconfirm";
 import { useToast } from "primevue/usetoast";
+import datasetsService from "@/services/datasets/datasetsService.js";
+import {downloadContent} from "@/helpers/index.js";
 
 const datasetStore = useDatasetStore();
 const { datasets, selectedDataset } = storeToRefs(datasetStore);
@@ -107,6 +110,10 @@ function deleteConfirmation(dataset) {
   });
 }
 
+async function downloadDataset(dataset) {
+  const blob = await datasetsService.downloadDataset(dataset.id);
+  downloadContent(blob, dataset.filename)
+}
 
 const onDatasetAdded = () => { datasetInput.value.input.click() }
 

--- a/lumigator/frontend/src/services/datasets/api.js
+++ b/lumigator/frontend/src/services/datasets/api.js
@@ -1,2 +1,3 @@
 export const PATH_DATASETS_ROOT = () => `datasets/`
 export const PATH_SINGLE_DATASET = (id) => `datasets/${id}`
+export const PATH_SINGLE_DATASET_DOWNLOAD = (id) => `datasets/${id}/download`

--- a/lumigator/frontend/src/services/datasets/datasetsService.js
+++ b/lumigator/frontend/src/services/datasets/datasetsService.js
@@ -1,5 +1,5 @@
 import http from '@/services/http';
-import { PATH_DATASETS_ROOT, PATH_SINGLE_DATASET } from './api';
+import {PATH_DATASETS_ROOT, PATH_SINGLE_DATASET, PATH_SINGLE_DATASET_DOWNLOAD} from './api';
 
 async function fetchDatasets() {
   try {
@@ -48,9 +48,38 @@ async function deleteDataset(id) {
   }
 }
 
+async function downloadDataset(id) {
+  try {
+    const url = `${PATH_SINGLE_DATASET_DOWNLOAD(id)}?extension=csv`;
+    const response = await http.get(url);
+    if (response.status !== 200) {
+      console.error("Error getting dataset download URLs: ", response.status);
+      return;
+    }
+
+    const { download_urls } = response.data;
+    if (!download_urls) {
+      console.error("No download URLs found in the response: ", response.data);
+      return;
+    } else if (download_urls.length > 1) {
+      console.error("Expected a single dataset CSV URL: ", download_urls);
+      return;
+    }
+
+    const fileResponse = await http.get(download_urls[0], {
+      responseType: 'blob', // Important: Receive the file as a binary blob
+    });
+    return fileResponse.data;
+
+  } catch (error) {
+    console.error("Error downloading dataset: ", error.message || error);
+  }
+}
+
 export default {
   fetchDatasets,
   fetchDatasetInfo,
   postDataset,
-  deleteDataset
+  deleteDataset,
+  downloadDataset
 }

--- a/lumigator/frontend/src/stores/datasets/store.js
+++ b/lumigator/frontend/src/stores/datasets/store.js
@@ -1,6 +1,7 @@
 import { ref } from 'vue';
 import { defineStore } from 'pinia'
 import datasetsService from "@/services/datasets/datasetsService";
+import {downloadContent} from "@/helpers/index.js";
 
 export const useDatasetStore = defineStore('dataset', () => {
   const datasets = ref([]);
@@ -41,6 +42,11 @@ export const useDatasetStore = defineStore('dataset', () => {
     await loadDatasets();
   }
 
+  async function loadDatasetFile() {
+    const blob = await datasetsService.downloadDataset(selectedDataset.value.id);
+    downloadContent(blob, selectedDataset.value.filename)
+  }
+
   return {
     datasets,
     loadDatasets,
@@ -48,6 +54,7 @@ export const useDatasetStore = defineStore('dataset', () => {
     loadDatasetInfo,
     resetSelection,
     uploadDataset,
-    deleteDataset
+    deleteDataset,
+    loadDatasetFile
   }
 })


### PR DESCRIPTION
# What's changing

Enables the dataset download button and downloads the CSV version of the dataset by default.

# How to test it

Steps to test the changes:

1. `make local-up`
2. Upload a dataset
3. Open the dataset details pane and click the download icon (top right)

![image](https://github.com/user-attachments/assets/dd40170e-5f02-4216-9783-eec904fce684)


# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
