### PR TITLE
Factor out job and experiment status check loops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ test-backend-unit:
 	RAY_DASHBOARD_PORT=8265 \
 	SQLALCHEMY_DATABASE_URL=sqlite:////tmp/local.db \
 	PYTHONPATH=../jobs:$$PYTHONPATH \
-	uv run pytest -o python_files="backend/tests/unit/*/test_*.py"
+	uv run pytest -s -o python_files="backend/tests/unit/*/test_*.py backend/tests/unit/test_*.py"
 
 test-backend-integration:
 	cd lumigator/python/mzai/backend/; \

--- a/lumigator/python/mzai/backend/backend/tests/conftest.py
+++ b/lumigator/python/mzai/backend/backend/tests/conftest.py
@@ -1,9 +1,11 @@
 import csv
 import io
 import os
+import time
 import uuid
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+from uuid import UUID
 
 import boto3
 import fsspec
@@ -13,7 +15,12 @@ from fastapi import FastAPI, UploadFile
 from fastapi.testclient import TestClient
 from fsspec.implementations.memory import MemoryFileSystem
 from loguru import logger
-from lumigator_schemas.jobs import JobConfig, JobType
+from lumigator_schemas.jobs import (
+    JobConfig,
+    JobResponse,
+    JobStatus,
+    JobType,
+)
 from mypy_boto3_s3 import S3Client
 from s3fs import S3FileSystem
 from sqlalchemy import Engine, create_engine
@@ -34,6 +41,14 @@ TEST_CAUSAL_MODEL = "hf://hf-internal-testing/tiny-random-LlamaForCausalLM"
 TEST_SUMMARY_MODEL = "hf://hf-internal-testing/tiny-random-T5ForConditionalGeneration"
 TEST_INFER_MODEL = "hf://hf-internal-testing/tiny-random-t5"
 
+# Maximum amount of polls done to check if a job has finished
+# (status FAILED or SUCCEEDED) in fucntion tests.
+# An Exception will be raised if the number of polls is exceeded.
+MAX_POLLS = 18
+
+# Time between job status polls.
+POLL_WAIT_TIME = 10
+
 
 @pytest.fixture
 def common_resources_dir() -> Path:
@@ -51,6 +66,48 @@ def format_dataset(data: list[list[str]]) -> str:
     csv.writer(buffer).writerows(data)
     buffer.seek(0)
     return buffer.read()
+
+
+def wait_for_job(client, job_id: UUID) -> bool:
+    succeeded = False
+    timed_out = True
+    for _ in range(1, MAX_POLLS):
+        get_job_response = client.get(f"/jobs/{job_id}")
+        assert get_job_response.status_code == 200
+        get_job_response_model = JobResponse.model_validate(get_job_response.json())
+        if get_job_response_model.status == JobStatus.SUCCEEDED.value:
+            succeeded = True
+            timed_out = False
+            break
+        if get_job_response_model.status == JobStatus.FAILED.value:
+            succeeded = False
+            timed_out = False
+            break
+        time.sleep(POLL_WAIT_TIME)
+    if timed_out:
+        raise Exception("Job poll timed out")
+    return succeeded
+
+
+def wait_for_experiment(client, experiment_id: UUID) -> bool:
+    succeeded = False
+    timed_out = True
+    for _ in range(1, MAX_POLLS):
+        get_experiment_response = client.get(f"/experiments_new/{experiment_id}")
+        assert get_experiment_response.status_code == 200
+        get_experiment_response_model = JobResponse.model_validate(get_experiment_response.json())
+        if get_experiment_response_model.status == JobStatus.SUCCEEDED.value:
+            succeeded = True
+            timed_out = False
+            break
+        if get_experiment_response_model.status == JobStatus.FAILED.value:
+            succeeded = False
+            timed_out = False
+            break
+        time.sleep(POLL_WAIT_TIME)
+    if timed_out:
+        raise Exception("Experiment poll timed out")
+    return succeeded
 
 
 @pytest.fixture


### PR DESCRIPTION
# What's changing

Job/experiments checks are now factored in a function, that returns `True` if the job or the experiment succeeded. If the polls time out, an Exception is raised (other recommendations about how to signals timeouts are welcome).

Also, the number of polls has been reduced to 18 for a total poll time of 180 seconds (3 minutes).

Closes #643 

# How to test it

Run the backend integration tests with `make test-backend-integration`.

# Additional notes for reviewers

N/A

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [x] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
