### PR TITLE
API/UI: Make model data more flexible for future use

### DIFF
--- a/lumigator/frontend/src/components/molecules/LModelCards.vue
+++ b/lumigator/frontend/src/components/molecules/LModelCards.vue
@@ -98,11 +98,15 @@ defineExpose({
 })
 
 const modelsRequiringAPIKey = computed(() => {
-  return models.value.filter((x) => x.requires_api_key)
+  return models.value.filter((x) => x?.metadata?.requirements !== undefined &&
+    Array.isArray(x.metadata.requirements) &&
+    x.metadata.requirements.includes("api_key"))
 })
 
 const modelsRequiringNoAPIKey = computed(() => {
-  return models.value.filter((x) => !x.requires_api_key)
+  return models.value.filter((x) => x?.metadata?.requirements === undefined ||
+    !Array.isArray(x.metadata.requirements) ||
+    !x.metadata.requirements.includes("api_key"))
 })
 
 function toggleModel(model) {

--- a/lumigator/frontend/src/components/molecules/LModelCards.vue
+++ b/lumigator/frontend/src/components/molecules/LModelCards.vue
@@ -99,14 +99,14 @@ defineExpose({
 
 const modelsByRequirement = (requirementKey, isRequired) => {
   return models.value.filter((x) => {
-    const isKeyPresent = x?.metadata?.requirements?.includes(requirementKey);
+    const isKeyPresent = x?.requirements?.includes(requirementKey);
     return isRequired ? isKeyPresent : !isKeyPresent;
   });
 }
 
-const modelsRequiringAPIKey = computed(() => modelsByRequirement("api_key"), true);
+const modelsRequiringAPIKey = computed(() => modelsByRequirement("api_key", true));
 
-const modelsRequiringNoAPIKey = computed(() => modelsByRequirement("api_key"), false);
+const modelsRequiringNoAPIKey = computed(() => modelsByRequirement("api_key", false));
 
 function toggleModel(model) {
   const index = selectedModels.value.findIndex(

--- a/lumigator/frontend/src/components/molecules/LModelCards.vue
+++ b/lumigator/frontend/src/components/molecules/LModelCards.vue
@@ -98,15 +98,11 @@ defineExpose({
 })
 
 const modelsRequiringAPIKey = computed(() => {
-  return models.value.filter((x) => x?.metadata?.requirements !== undefined &&
-    Array.isArray(x.metadata.requirements) &&
-    x.metadata.requirements.includes("api_key"))
+ return models.value.filter((x) => x?.metadata?.requirements?.includes("api_key"));
 })
 
 const modelsRequiringNoAPIKey = computed(() => {
-  return models.value.filter((x) => x?.metadata?.requirements === undefined ||
-    !Array.isArray(x.metadata.requirements) ||
-    !x.metadata.requirements.includes("api_key"))
+  return !modelsRequiringAPIKey.value;
 })
 
 function toggleModel(model) {

--- a/lumigator/frontend/src/components/molecules/LModelCards.vue
+++ b/lumigator/frontend/src/components/molecules/LModelCards.vue
@@ -97,13 +97,16 @@ defineExpose({
   selectedModels
 })
 
-const modelsRequiringAPIKey = computed(() => {
- return models.value.filter((x) => x?.metadata?.requirements?.includes("api_key"));
-})
+const modelsByRequirement = (requirementKey, isRequired) => {
+  return models.value.filter((x) => {
+    const isKeyPresent = x?.metadata?.requirements?.includes(requirementKey);
+    return isRequired ? isKeyPresent : !isKeyPresent;
+  });
+}
 
-const modelsRequiringNoAPIKey = computed(() => {
-  return !modelsRequiringAPIKey.value;
-})
+const modelsRequiringAPIKey = computed(() => modelsByRequirement("api_key"), true);
+
+const modelsRequiringNoAPIKey = computed(() => modelsByRequirement("api_key"), false);
 
 function toggleModel(model) {
   const index = selectedModels.value.findIndex(

--- a/lumigator/python/mzai/backend/backend/models.yaml
+++ b/lumigator/python/mzai/backend/backend/models.yaml
@@ -2,7 +2,6 @@
   uri: hf://facebook/bart-large-cnn
   website_url: https://huggingface.co/facebook/bart-large-cnn
   description: BART is a large-sized model fine-tuned on the CNN Daily Mail dataset.
-  requires_api_key: false
   info:
     parameter_count: 406M
     tensor_type: F32
@@ -20,7 +19,6 @@
   uri: hf://Falconsai/text_summarization
   website_url: https://huggingface.co/Falconsai/text_summarization
   description: A fine-tuned variant of the T5 transformer model, designed for the task of text summarization.
-  requires_api_key: false
   info:
     parameter_count: 60.5M
     tensor_type: F32
@@ -38,7 +36,6 @@
   uri: hf://mistralai/Mistral-7B-Instruct-v0.3
   website_url: https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3
   description: Mistral-7B-Instruct-v0.3 is an instruct fine-tuned version of the Mistral-7B-v0.3.
-  requires_api_key: false
   info:
     parameter_count: 7.25B
     tensor_type: BF16
@@ -50,7 +47,9 @@
   uri: oai://gpt-4o-mini
   website_url: https://platform.openai.com/docs/models#gpt-4o-mini
   description: OpenAI's GPT-4o-mini model.
-  requires_api_key: true
+  metadata:
+    requirements:
+      - api_key
   tasks:
     - summarization:
 
@@ -58,7 +57,9 @@
   uri: oai://gpt-4o
   website_url: https://platform.openai.com/docs/models#gpt-4o
   description: OpenAI's GPT-4o model.
-  requires_api_key: true
+  metadata:
+    requirements:
+      - api_key
   tasks:
     - summarization:
 
@@ -66,7 +67,9 @@
   uri: mistral://open-mistral-7b
   website_url: https://mistral.ai/technology/#models
   description: Mistral's 7B model.
-  requires_api_key: true
+  metadata:
+    requirements:
+      - api_key
   tasks:
     - summarization:
 
@@ -78,6 +81,8 @@
     parameter_count: 7.24B
     tensor_type: BF16
     model_size: 14.5GB
-  requires_api_key: false
+  metadata:
+    requirements:
+      - llamafile
   tasks:
     - summarization:

--- a/lumigator/python/mzai/backend/backend/models.yaml
+++ b/lumigator/python/mzai/backend/backend/models.yaml
@@ -47,9 +47,8 @@
   uri: oai://gpt-4o-mini
   website_url: https://platform.openai.com/docs/models#gpt-4o-mini
   description: OpenAI's GPT-4o-mini model.
-  metadata:
-    requirements:
-      - api_key
+  requirements:
+    - api_key
   tasks:
     - summarization:
 
@@ -57,9 +56,8 @@
   uri: oai://gpt-4o
   website_url: https://platform.openai.com/docs/models#gpt-4o
   description: OpenAI's GPT-4o model.
-  metadata:
-    requirements:
-      - api_key
+  requirements:
+    - api_key
   tasks:
     - summarization:
 
@@ -67,9 +65,8 @@
   uri: mistral://open-mistral-7b
   website_url: https://mistral.ai/technology/#models
   description: Mistral's 7B model.
-  metadata:
-    requirements:
-      - api_key
+  requirements:
+    - api_key
   tasks:
     - summarization:
 
@@ -81,8 +78,7 @@
     parameter_count: 7.24B
     tensor_type: BF16
     model_size: 14.5GB
-  metadata:
-    requirements:
-      - llamafile
+  requirements:
+    - llamafile
   tasks:
     - summarization:

--- a/lumigator/python/mzai/backend/backend/tests/data/models.json
+++ b/lumigator/python/mzai/backend/backend/tests/data/models.json
@@ -5,7 +5,7 @@
         "name": "facebook/bart-large-cnn",
         "uri": "hf://facebook/bart-large-cnn",
         "description": "BART is a large-sized model fine-tuned on the CNN Daily Mail dataset.",
-        "metadata": {},
+        "requirements": [],
         "info": {
           "parameter_count": "406M",
           "tensor_type": "F32",
@@ -28,7 +28,7 @@
         "name": "Falconsai/text_summarization",
         "uri": "hf://Falconsai/text_summarization",
         "description": "A fine-tuned variant of the T5 transformer model, designed for the task of text summarization.",
-        "metadata": {},
+        "requirements": [],
         "info": {
           "parameter_count": "60.5M",
           "tensor_type": "F32",
@@ -51,7 +51,7 @@
         "name": "mistralai/Mistral-7B-Instruct-v0.3",
         "uri": "hf://mistralai/Mistral-7B-Instruct-v0.3",
         "description": "Mistral-7B-Instruct-v0.3 is an instruct fine-tuned version of the Mistral-7B-v0.3.",
-        "metadata": {},
+        "requirements": [],
         "info": {
           "parameter_count": "7.25B",
           "tensor_type": "BF16",
@@ -67,9 +67,7 @@
         "name": "gpt-4o-mini",
         "uri": "oai://gpt-4o-mini",
         "description": "OpenAI's GPT-4o-mini model.",
-        "metadata": {
-          "requirements": [ "api_key" ]
-        },
+        "requirements": [ "api_key" ],
         "info": null,
         "tasks": [
           {
@@ -81,9 +79,7 @@
         "name": "gpt-4o",
         "uri": "oai://gpt-4o",
         "description": "OpenAI's GPT-4o model.",
-        "metadata": {
-          "requirements": [ "api_key" ]
-        },
+        "requirements": [ "api_key" ],
         "info": null,
         "tasks": [
           {
@@ -95,9 +91,7 @@
         "name": "open-mistral-7b",
         "uri": "mistral://open-mistral-7b",
         "description": "Mistral's 7B model.",
-        "metadata": {
-          "requirements": [ "api_key" ]
-        },
+        "requirements": [ "api_key" ],
         "info": null,
         "tasks": [
           {
@@ -109,9 +103,7 @@
         "name": "mistralai/Mistral-7B-Instruct-v0.2",
         "uri": "llamafile://mistralai/Mistral-7B-Instruct-v0.2",
         "description": "A llamafile package of Mistral's 7B Instruct model.",
-        "metadata": {
-          "requirements": [ "llamafile" ]
-        },
+        "requirements": [ "llamafile" ],
         "info": {
           "parameter_count": "7.24B",
           "tensor_type": "BF16",

--- a/lumigator/python/mzai/backend/backend/tests/data/models.json
+++ b/lumigator/python/mzai/backend/backend/tests/data/models.json
@@ -5,7 +5,7 @@
         "name": "facebook/bart-large-cnn",
         "uri": "hf://facebook/bart-large-cnn",
         "description": "BART is a large-sized model fine-tuned on the CNN Daily Mail dataset.",
-        "requires_api_key": false,
+        "metadata": {},
         "info": {
           "parameter_count": "406M",
           "tensor_type": "F32",
@@ -28,7 +28,7 @@
         "name": "Falconsai/text_summarization",
         "uri": "hf://Falconsai/text_summarization",
         "description": "A fine-tuned variant of the T5 transformer model, designed for the task of text summarization.",
-        "requires_api_key": false,
+        "metadata": {},
         "info": {
           "parameter_count": "60.5M",
           "tensor_type": "F32",
@@ -51,7 +51,7 @@
         "name": "mistralai/Mistral-7B-Instruct-v0.3",
         "uri": "hf://mistralai/Mistral-7B-Instruct-v0.3",
         "description": "Mistral-7B-Instruct-v0.3 is an instruct fine-tuned version of the Mistral-7B-v0.3.",
-        "requires_api_key": false,
+        "metadata": {},
         "info": {
           "parameter_count": "7.25B",
           "tensor_type": "BF16",
@@ -67,7 +67,9 @@
         "name": "gpt-4o-mini",
         "uri": "oai://gpt-4o-mini",
         "description": "OpenAI's GPT-4o-mini model.",
-        "requires_api_key": true,
+        "metadata": {
+          "requirements": [ "api_key" ]
+        },
         "info": null,
         "tasks": [
           {
@@ -79,7 +81,9 @@
         "name": "gpt-4o",
         "uri": "oai://gpt-4o",
         "description": "OpenAI's GPT-4o model.",
-        "requires_api_key": true,
+        "metadata": {
+          "requirements": [ "api_key" ]
+        },
         "info": null,
         "tasks": [
           {
@@ -91,7 +95,9 @@
         "name": "open-mistral-7b",
         "uri": "mistral://open-mistral-7b",
         "description": "Mistral's 7B model.",
-        "requires_api_key": true,
+        "metadata": {
+          "requirements": [ "api_key" ]
+        },
         "info": null,
         "tasks": [
           {
@@ -103,7 +109,9 @@
         "name": "mistralai/Mistral-7B-Instruct-v0.2",
         "uri": "llamafile://mistralai/Mistral-7B-Instruct-v0.2",
         "description": "A llamafile package of Mistral's 7B Instruct model.",
-        "requires_api_key": false,
+        "metadata": {
+          "requirements": [ "llamafile" ]
+        },
         "info": {
           "parameter_count": "7.24B",
           "tensor_type": "BF16",

--- a/lumigator/python/mzai/schemas/lumigator_schemas/models.py
+++ b/lumigator/python/mzai/schemas/lumigator_schemas/models.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel
+from typing import Any
+
+from pydantic import BaseModel, Field
 
 
 class ModelInfo(BaseModel):
@@ -12,6 +14,6 @@ class ModelsResponse(BaseModel):
     uri: str
     website_url: str
     description: str
-    requires_api_key: bool = False
+    metadata: dict[str, Any] = Field(default_factory=dict)
     info: ModelInfo | None = None
     tasks: list[dict[str, dict | None]]

--- a/lumigator/python/mzai/schemas/lumigator_schemas/models.py
+++ b/lumigator/python/mzai/schemas/lumigator_schemas/models.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from pydantic import BaseModel, Field
 
 
@@ -14,6 +12,6 @@ class ModelsResponse(BaseModel):
     uri: str
     website_url: str
     description: str
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    requirements: list[str] = Field(default_factory=list)
     info: ModelInfo | None = None
     tasks: list[dict[str, dict | None]]

--- a/lumigator/python/mzai/schemas/lumigator_schemas/models.py
+++ b/lumigator/python/mzai/schemas/lumigator_schemas/models.py
@@ -1,4 +1,19 @@
+from enum import Enum
+
 from pydantic import BaseModel, Field
+
+
+class ModelRequirement(str, Enum):
+    """Represents a type of requirement for a model"""
+
+    API_KEY = "api_key"  # pragma: allowlist secret
+    """Indicates that this model requires a configured API key for the related service.
+
+        e.g. OPENAI_API_KEY, or MISTRAL_API_KEY.
+        """
+
+    LLAMAFILE = "llamafile"
+    """Indicates that this model requires Llamafile to be running."""
 
 
 class ModelInfo(BaseModel):
@@ -12,6 +27,6 @@ class ModelsResponse(BaseModel):
     uri: str
     website_url: str
     description: str
-    requirements: list[str] = Field(default_factory=list)
+    requirements: list[ModelRequirement] = Field(default_factory=list)
     info: ModelInfo | None = None
     tasks: list[dict[str, dict | None]]

--- a/lumigator/python/mzai/sdk/tests/data/models.json
+++ b/lumigator/python/mzai/sdk/tests/data/models.json
@@ -6,7 +6,7 @@
         "uri": "hf://facebook/bart-large-cnn",
         "website_url": "https://huggingface.co/facebook/bart-large-cnn",
         "description": "BART is a large-sized model fine-tuned on the CNN Daily Mail dataset.",
-        "metadata": {},
+        "requirements": [],
         "info": {
           "parameter_count": "406M",
           "tensor_type": "F32",
@@ -30,7 +30,7 @@
         "uri": "hf://Falconsai/text_summarization",
         "website_url": "https://huggingface.co/Falconsai/text_summarization",
         "description": "A fine-tuned variant of the T5 transformer model, designed for the task of text summarization.",
-        "metadata": {},
+        "requirements": [],
         "info": {
           "parameter_count": "60.5M",
           "tensor_type": "F32",
@@ -54,7 +54,7 @@
         "uri": "hf://mistralai/Mistral-7B-Instruct-v0.3",
         "website_url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
         "description": "Mistral-7B-Instruct-v0.3 is an instruct fine-tuned version of the Mistral-7B-v0.3.",
-        "metadata": {},
+        "requirements": [],
         "info": {
           "parameter_count": "7.25B",
           "tensor_type": "BF16",
@@ -71,9 +71,7 @@
         "uri": "oai://gpt-4o-mini",
         "website_url": "https://platform.openai.com/docs/models#gpt-4o-mini",
         "description": "OpenAI's GPT-4o-mini model.",
-        "metadata": {
-          "requirements": [ "api_key" ]
-        },
+        "requirements": [ "api_key" ],
         "info": null,
         "tasks": [
           {
@@ -86,9 +84,7 @@
         "uri": "oai://gpt-4o",
         "website_url": "https://platform.openai.com/docs/models#gpt-4o",
         "description": "OpenAI's GPT-4o model.",
-        "metadata": {
-          "requirements": [ "api_key" ]
-        },
+        "requirements": [ "api_key" ],
         "info": null,
         "tasks": [
           {
@@ -101,9 +97,7 @@
         "uri": "mistral://open-mistral-7b",
         "website_url": " https://mistral.ai/technology/#models",
         "description": "Mistral's 7B model.",
-        "metadata": {
-          "requirements": [ "api_key" ]
-        },
+        "requirements": [ "api_key" ],
         "info": null,
         "tasks": [
           {
@@ -116,9 +110,7 @@
         "uri": "llamafile://mistralai/Mistral-7B-Instruct-v0.2",
         "website_url": " https://mistral.ai/technology/#models",
         "description": "A llamafile package of Mistral's 7B Instruct model.",
-        "metadata": {
-          "requirements": [ "llamafile" ]
-        },
+        "requirements": [ "llamafile" ],
         "info": {
           "parameter_count": "7.24B",
           "tensor_type": "BF16",

--- a/lumigator/python/mzai/sdk/tests/data/models.json
+++ b/lumigator/python/mzai/sdk/tests/data/models.json
@@ -6,7 +6,7 @@
         "uri": "hf://facebook/bart-large-cnn",
         "website_url": "https://huggingface.co/facebook/bart-large-cnn",
         "description": "BART is a large-sized model fine-tuned on the CNN Daily Mail dataset.",
-        "requires_api_key": false,
+        "metadata": {},
         "info": {
           "parameter_count": "406M",
           "tensor_type": "F32",
@@ -30,7 +30,7 @@
         "uri": "hf://Falconsai/text_summarization",
         "website_url": "https://huggingface.co/Falconsai/text_summarization",
         "description": "A fine-tuned variant of the T5 transformer model, designed for the task of text summarization.",
-        "requires_api_key": false,
+        "metadata": {},
         "info": {
           "parameter_count": "60.5M",
           "tensor_type": "F32",
@@ -54,7 +54,7 @@
         "uri": "hf://mistralai/Mistral-7B-Instruct-v0.3",
         "website_url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
         "description": "Mistral-7B-Instruct-v0.3 is an instruct fine-tuned version of the Mistral-7B-v0.3.",
-        "requires_api_key": false,
+        "metadata": {},
         "info": {
           "parameter_count": "7.25B",
           "tensor_type": "BF16",
@@ -71,7 +71,9 @@
         "uri": "oai://gpt-4o-mini",
         "website_url": "https://platform.openai.com/docs/models#gpt-4o-mini",
         "description": "OpenAI's GPT-4o-mini model.",
-        "requires_api_key": true,
+        "metadata": {
+          "requirements": [ "api_key" ]
+        },
         "info": null,
         "tasks": [
           {
@@ -84,7 +86,9 @@
         "uri": "oai://gpt-4o",
         "website_url": "https://platform.openai.com/docs/models#gpt-4o",
         "description": "OpenAI's GPT-4o model.",
-        "requires_api_key": true,
+        "metadata": {
+          "requirements": [ "api_key" ]
+        },
         "info": null,
         "tasks": [
           {
@@ -97,7 +101,9 @@
         "uri": "mistral://open-mistral-7b",
         "website_url": " https://mistral.ai/technology/#models",
         "description": "Mistral's 7B model.",
-        "requires_api_key": true,
+        "metadata": {
+          "requirements": [ "api_key" ]
+        },
         "info": null,
         "tasks": [
           {
@@ -110,7 +116,9 @@
         "uri": "llamafile://mistralai/Mistral-7B-Instruct-v0.2",
         "website_url": " https://mistral.ai/technology/#models",
         "description": "A llamafile package of Mistral's 7B Instruct model.",
-        "requires_api_key": false,
+        "metadata": {
+          "requirements": [ "llamafile" ]
+        },
         "info": {
           "parameter_count": "7.24B",
           "tensor_type": "BF16",


### PR DESCRIPTION
# What's changing

https://github.com/mozilla-ai/lumigator/pull/689 updated the API to flag when a model required an API key.
https://github.com/mozilla-ai/lumigator/pull/691 added support for this in the UI so models could be displayed in different lists.

This PR refactors these changes to allow for more flexibility as we want to categorize models differently.

Instead of a `bool` flag returned in the API for `requires_api_key` we  can return `requirements` which contains a list (think set) of the requirements for this model. e.g. `api_key`, `llamafile`.

# How to test it

Steps to test the changes:

1. `make local-up`
2. Try to create an experiment in the UI and ensure no changes to the UI
3. Try to use the [API docs](http://localhost:8000/docs#/models/get_suggested_models_api_v1_models__task_name__get) to get models for `summarization`

# Additional notes for reviewers

In this screen shot you can see the different requirements being returned, the idea here is that as we want to further sub-divide the way we show models to users, it will be easier.

![image](https://github.com/user-attachments/assets/244775e0-29e2-491a-b5dd-97a60a8fa078)

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
