### PR TITLE
doc: missing nvidia-container-toolkit instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ To start Lumigator locally, follow these steps:
     cd lumigator
     ```
 
-1. If your system has an NVidia GPU, open a terminal and run:
+1. If your system has an NVIDIA GPU, you have an additional pre-requirement: [install the NVIDIA Container Toolkit following their instructions](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html). After that, open a terminal and run:
     ```bash
     export RAY_WORKERS_GPU=1
     export RAY_WORKERS_GPU_FRACTION=1.0
+    export GPU_COUNT=1
     ```
     **Important: Continue the next steps in this same terminal.***
 


### PR DESCRIPTION
# What's changing

Missing instructions to install nvidia-container-toolkit.

Related to #658

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [N/A] Added some tests for any new functionality
- [X] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [N/A] Checked if a (backend) DB migration step was required and included it if required
