### PR TITLE
Added API keys / tokens troubleshooting section + fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ services networked together to make up all the components of the Lumigator appli
 > uses SQLite for this purpose.
 
 > [!NOTE]
-> If you'd like to evaluate against LLM APIs like OpenAI and Mistral, you'll need to have your
-> environment variable [set locally](https://github.com/mozilla-ai/lumigator/blob/main/.env.template) for Lumigator pick it up at runtime, or, alternately, inject
-> into the running `backend` docker container.
+If you want to evaluate against LLM APIs like OpenAI and Mistral, you need to set the appropriate
+environment variables: `OPENAI_API_KEY` or `MISTRAL_API_KEY`. Refer to the
+[troubleshooting section](https://mozilla-ai.github.io/lumigator/get-started/troubleshooting.html#tokens-api-keys-not-set)
+in our documentation for more details.
 
 To start Lumigator locally, follow these steps:
 
@@ -83,20 +84,15 @@ To start Lumigator locally, follow these steps:
     export RAY_WORKERS_GPU_FRACTION=1.0
     export GPU_COUNT=1
     ```
-    **Important: Continue the next steps in this same terminal.***
+    **Important: Continue the next steps in this same terminal.**
 
 
 1. If you intend to use Mistral API or OpenAI API, use that same terminal and run:
     ```bash
     export MISTRAL_API_KEY=your_mistral_api_key
     export OPENAI_API_KEY=your_openai_api_key
-    rm .env
     ```
-    **Important: Continue the next steps in this same terminal.***
-
-    Note: Deleting the existing `.env` is a precaution to ensure you have the most up to date environemnt variables required at any point. Notice while we are in early stages of development, these may change.
-
-    The start script on the next step will recreate the necessary `.env` for you.
+    **Important: Continue the next steps in this same terminal.**
 
 1. From that same terminal, start Lumigator with:
 
@@ -104,11 +100,13 @@ To start Lumigator locally, follow these steps:
     make start-lumigator
     ```
 
-    This will create an appropriate `.env` and use Docker Compose to launch all necessary containers for you.
-
+The last command uses Docker Compose to launch all necessary containers for you.
 To verify that Lumigator is running, open a web browser and navigate to
-[`http://localhost`](http://localhost). You should see Lumigator's UI.
+[`http://localhost`](http://localhost): you should see Lumigator's UI.
 
+Now that Lumigator is running, you can start using it. The platform provides a REST API that allows
+you to interact with the system. Run the [example notebook](/notebooks/walkthrough.ipynb) for a
+quick walkthrough.
 
 Despite the fact this is a local setup, it lends itself to more distributed scenarios. For instance,
 one could provide different `AWS_*` environment variables to the backend container to connect to any
@@ -117,9 +115,8 @@ provider’s S3-compatible service, instead of minio. Similarly, one could provi
 [operational guides](https://mozilla-ai.github.io/lumigator/operations-guide/kubernetes.html) in the
 documentation for more deployment options.
 
-Now that Lumigator is running, you can start using it. The platform provides a REST API that allows
-you to interact with the system. Run the [example notebook](/notebooks/walkthrough.ipynb) for a
-quick walkthrough.
+If you want to permanently set any of the environment variables above, you can  add them to your rc file (e.g. `~/.bashrc`, `~/.zshrc`) or directly to the
+`.env` file that is automatically created after the first execution of lumigator.
 
 ### Lumigator UI
 Alternatively, you can also use the UI to interact with Lumigator. Once a Lumigator session is up and running, the UI can be accessed by visiting [`http://localhost`](http://localhost). On the **Datasets** tab, first upload a csv data with columns `examples` and (optionally) `ground_truth`. Next, the dataset can be used to run an evaluation using the **Experiments** tab.

--- a/docs/source/get-started/installation.md
+++ b/docs/source/get-started/installation.md
@@ -30,8 +30,8 @@ uses SQLite for this purpose.
 
 ```{note}
 If you want to evaluate against LLM APIs like OpenAI and Mistral, you need to set the appropriate
-environment variables: `OPENAI_API_KEY` or `MISTRAL_API_KEY`. Refer to the `.env.template` file in
-the repository for more details.
+environment variables: `OPENAI_API_KEY` or `MISTRAL_API_KEY`. Refer to the
+[troubleshooting section](troubleshooting.md) for more details.
 ```
 
 Despite the fact this is a local setup, it lends itself to more distributed scenarios. For instance,

--- a/docs/source/get-started/suggested-models.md
+++ b/docs/source/get-started/suggested-models.md
@@ -145,7 +145,7 @@ There are no summarization-specific parameters for these models.
 
 The [Open Mistral 7B](https://mistral.ai/news/announcing-mistral-7b/) model is a causal language
 model developed by [Mistral AI](https://mistral.ai/). It is the smaller version of the
-Mistal AI family of models.
+Mistral AI family of models.
 
 There are no summarization-specific parameters for this model.
 

--- a/docs/source/get-started/troubleshooting.md
+++ b/docs/source/get-started/troubleshooting.md
@@ -60,7 +60,7 @@ To fix any of these, you should:
 
 1. Get the respective key/token (instructions for
 [Mistral API](https://docs.mistral.ai/getting-started/quickstart/),
-OpenAI API (https://platform.openai.com/docs/quickstart),
+OpenAI API (see `https://platform.openai.com/docs/quickstart`),
 [HF gated models](https://huggingface.co/docs/hub/models-gated) and
 [tokens](https://huggingface.co/docs/hub/en/security-tokens#how-to-manage-user-access-tokens)
 )

--- a/docs/source/get-started/troubleshooting.md
+++ b/docs/source/get-started/troubleshooting.md
@@ -60,7 +60,7 @@ To fix any of these, you should:
 
 1. Get the respective key/token (instructions for
 [Mistral API](https://docs.mistral.ai/getting-started/quickstart/),
-[OpenAI API](https://platform.openai.com/docs/quickstart),
+OpenAI API (https://platform.openai.com/docs/quickstart),
 [HF gated models](https://huggingface.co/docs/hub/models-gated) and
 [tokens](https://huggingface.co/docs/hub/en/security-tokens#how-to-manage-user-access-tokens)
 )

--- a/docs/source/get-started/troubleshooting.md
+++ b/docs/source/get-started/troubleshooting.md
@@ -17,3 +17,53 @@ increasing the value specified under `Disk usage limit`
 
 - you can remove the Docker images left dangling by our build process by running the
 `docker image prune` command on the command line.
+
+
+## Tokens / API keys not set
+
+Some models or APIs require a key or a token to work. This may result in different
+kind of errors while trying to run jobs that make use of them. For instance, this
+happens when you try to run inference using Mistral and `MISTRAL_API_KEY` is not set:
+
+```
+  File "/tmp/ray/session_2025-01-23_02-13-26_636661_1/runtime_resources/working_dir_files/_ray_pkg_58d1ff7936232bdd/model_clients.py", line 130, in __init__
+    self._client = MistralClient(api_key=os.environ["MISTRAL_API_KEY"])
+                                         ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
+  File "<frozen os>", line 679, in __getitem__
+KeyError: 'MISTRAL_API_KEY'
+```
+
+This happens instead when you try to run inference with OpenAI models and you have
+not set `OPENAI_API_KEY`:
+
+```
+  File "/tmp/ray/session_2025-01-23_02-18-27_051519_1/runtime_resources/pip/617697551215d8488f42ccab087d2364573ba842/virtualenv/lib/python3.11/site-packages/openai/_client.py", line 105, in __init__
+    raise OpenAIError(
+openai.OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
+```
+
+The following, instead, happens when you try to access a model from a gated repository
+on HuggingFace without authorizing it or without sharing a `HF_TOKEN`:
+
+```
+  File "/tmp/ray/session_2025-01-23_02-18-27_051519_1/runtime_resources/pip/b9beac6aa077c93a8e0edf25e6f0e4c96432df34/virtualenv/lib/python3.11/site-packages/transformers/utils/hub.py", line 420, in cached_file
+    raise EnvironmentError(
+OSError: You are trying to access a gated repo.
+Make sure to have access to it at https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3.
+401 Client Error. (Request ID: Root=1-6792187d-76df0eae4be65d2a47c68d48;8789d12e-a496-4af8-99ce-3b29bbdf5032)
+
+Cannot access gated repo for url https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3/resolve/main/config.json.
+Access to model mistralai/Mistral-7B-Instruct-v0.3 is restricted. You must have access to it and be authenticated to access it. Please log in.
+```
+
+To fix any of these, you should:
+
+1. Get the respective key/token (instructions for
+[Mistral API](https://docs.mistral.ai/getting-started/quickstart/),
+[OpenAI API](https://platform.openai.com/docs/quickstart),
+[HF gated models](https://huggingface.co/docs/hub/models-gated) and
+[tokens](https://huggingface.co/docs/hub/en/security-tokens#how-to-manage-user-access-tokens)
+)
+
+2. Save it in your environment, either by adding it into your `~/.bashrc`, `~/.zshrc` file
+or by adding it to the `.env` file inside lumigator's main directory

--- a/docs/source/operations-guide/dev.md
+++ b/docs/source/operations-guide/dev.md
@@ -31,8 +31,10 @@ persisted between runs.
 To use the API-based vendor ground truth generation and evaluation, you'll need to pass the
 following environment variables for credentials, into the docker container:
 
-- `MISTRAL_API_KEY`: You Mistal API key.
-- `OPENAI_API_KEY`: Your OpenAI API key.
+- `MISTRAL_API_KEY`: your Mistral API key.
+- `OPENAI_API_KEY`: your OpenAI API key.
+
+Refer to the [troubleshooting section](troubleshooting.md) for more details.
 
 ## Testing the backend services
 

--- a/docs/source/user-guides/inference.md
+++ b/docs/source/user-guides/inference.md
@@ -5,9 +5,9 @@ a model downloaded from the Hugging Face Hub. The model will generate summaries 
 text data.
 
 ```{note}
-You can also use the OpenAI GPT family of models or the Mistal API to run an inference job. To do
+You can also use the OpenAI GPT family of models or the Mistral API to run an inference job. To do
 so, you need to set the appropriate environment variables: `OPENAI_API_KEY` or `MISTRAL_API_KEY`.
-Refer to the `.env.template` file in the repository for more details.
+Refer to the [troubleshooting section](troubleshooting.md) for more details.
 ```
 
 ## What You'll Need

--- a/lumigator/python/mzai/backend/README.md
+++ b/lumigator/python/mzai/backend/README.md
@@ -20,7 +20,15 @@ source .venv/bin/activate
 
 ## Make usage
 
-The available Makefile will copy a `.env` file from the existing `.env.template` file. There are some targets to start the docker composition (`local-up`, `start-lumigator`, `start-lumigator-build`), to stop it (`local-down`) and to run tests (`test-backend`, `test-sdk`, `test-all`).
+The available Makefile contains targets to:
+
+- start the system using docker compose (e.g. `local-up`, `start-lumigator`, `start-lumigator-build`)
+- stop the system (e.g. `local-down`, `stop-lumigator`)
+- run tests (e.g `test-backend`, `test-sdk`, `test-all`)
+
+When the system is started for the first time, a `.env` file is created from the existing `.env.template`. This file contains different parameters passed to the
+system as environment variables and you can customize it to suit your specific
+use case.
 
 ## Test instructions
 


### PR DESCRIPTION
# What's changing

- there's a new section in troubleshooting re: missing API keys / tokens. It reports some of the errors one might get and how to fix this by setting up the respective env vars either in rc files or in the `.env` file
- references to API keys in readmes and documentation have been updated
- minor fixes

> If this PR is related to an issue or closes one, please link it here.

Closes https://github.com/mozilla-ai/lumigator/issues/579

