### PR TITLE
Ray env var empty string fix

### DIFF
--- a/lumigator/python/mzai/backend/backend/settings.py
+++ b/lumigator/python/mzai/backend/backend/settings.py
@@ -117,12 +117,12 @@ class BackendSettings(BaseSettings):
     @computed_field
     @property
     def RAY_WORKER_GPUS(self) -> float:  # noqa: N802
-        return float(os.environ.get(self.RAY_WORKER_GPUS_ENV_VAR, 1.0))
+        return float(os.environ.get(self.RAY_WORKER_GPUS_ENV_VAR) or 1.0)
 
     @computed_field
     @property
     def RAY_WORKER_GPUS_FRACTION(self) -> float:  # noqa: N802
-        return float(os.environ.get(self.RAY_WORKER_GPUS_FRACTION_ENV_VAR, 1.0))
+        return float(os.environ.get(self.RAY_WORKER_GPUS_FRACTION_ENV_VAR) or 1.0)
 
     # URL for the Ray Dashboard
     @computed_field


### PR DESCRIPTION
# What's changing

We previously set RAY GPU env vars as `return float(os.environ.get(self.RAY_WORKER_GPUS_ENV_VAR, 1.0))`. If the app receives an empty string for one of these vars, it won't build, because the code attempts to render the string to a float instead of assigning it `1.0` since it's not null: 

```
 File "/mzai/lumigator/python/mzai/backend/backend/services/jobs.py", line 51, in JobService
2025-01-23T14:16:16.606623668Z     "ray_worker_gpus": settings.RAY_WORKER_GPUS,
2025-01-23T14:16:16.606624418Z                        ^^^^^^^^^^^^^^^^^^^^^^^^
2025-01-23T14:16:16.606625126Z   File "/mzai/lumigator/python/mzai/backend/backend/settings.py", line 120, in RAY_WORKER_GPUS
2025-01-23T14:16:16.606640710Z     return float(os.environ.get(self.RAY_WORKER_GPUS_ENV_VAR, 1.0))
2025-01-23T14:16:16.606642543Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-01-23T14:16:16.606643293Z ValueError: could not convert string to float: ''
```

<img width="838" alt="Screenshot 2025-01-23 at 9 31 21 AM" src="https://github.com/user-attachments/assets/81c754eb-99fe-4d85-82b7-77a83a105c1b" />



# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [X] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
