### PR TITLE
Add warning about local-template env mismatch to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,11 @@ DEV_DOCKER_COMPOSE_FILE:= .devcontainer/docker-compose.override.yaml
 
 check-dot-env:
 	@if [ ! -f .env ]; then cp .env.template .env; echo ".env created from .env.template"; fi
+	 @if [ -f .env ] && [ -f .env.template ] && ! cmp -s .env .env.template; then \
+      echo -e "\033[1;31m=====================================================================\033[0m"; \
+      echo -e "\033[1;31mWARNING: .env file differs from .env.template. Please review to stay in sync.\033[0m"; \
+      echo -e "\033[1;31m=====================================================================\033[0m"; \
+  fi
 
 # Launches Lumigator in 'development' mode (all services running locally, code mounted in)
 local-up: check-dot-env


### PR DESCRIPTION
# What's changing

When anything in the .env variables changes, it doesn't reflect on the user's local .env because that file is private and not in version control, and we don't override it since we'd like to respect the user's preferences.

We'd like to make sure that the user gets the latest from .env.template upon loading lumigator locally the first time with a check between the user's local .env file and the template in make local-up

* Updated section...
* Added new code to makefile `local-up` taking advantage of current makefile check 


<img width="917" alt="Screenshot 2025-01-23 at 11 00 14 AM" src="https://github.com/user-attachments/assets/1a874244-691e-4811-98e0-33a0fb6462cb" />


[Closes #723](https://github.com/mozilla-ai/lumigator/issues/723)

# How to test it

run `make local-up` and you should see the warning

# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [X] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
