### PR TITLE
[BUG] UI: Experiment details doesn't show max samples correctly

### DIFF
--- a/lumigator/frontend/src/components/molecules/LExperimentDetails.vue
+++ b/lumigator/frontend/src/components/molecules/LExperimentDetails.vue
@@ -116,7 +116,7 @@
       >
         <div class="l-experiment-details__content-label">samples limit</div>
         <div class="l-experiment-details__content-field">
-          {{ selectedExperiment }}
+          {{ selectedExperiment.samples }}
         </div>
       </div>
       <div class="l-experiment-details__content-item">


### PR DESCRIPTION
# What's changing

This PR fixes a new bug where experiment details don't show max samples correctly and instead show the entire JSON object for the selected experiment.

# How to test it

Steps to test the changes:

1. `make local-up`
2. http://localhost
3. Upload a dataset with ground truth
4. Create an experiment with the dataset (enter max samples, or don't, or make two experiments with each)
5. Once created view the experiment details panel on the right hand side and samples limit should show correctly

![image](https://github.com/user-attachments/assets/96bca60a-a528-4118-9864-1edccaafe340)

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
