### PR TITLE
[Hotfix] Chart name regression breaks frontend/backend communication

### DIFF
--- a/infra/helm/lumigator/charts/backend/Chart.yaml
+++ b/infra/helm/lumigator/charts/backend/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: lumigator-backend
+name: backend
 description: A Helm chart for Lumigator backend
 
 # A chart can be either an 'application' or a 'library' chart.

--- a/infra/helm/lumigator/charts/frontend/Chart.yaml
+++ b/infra/helm/lumigator/charts/frontend/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: lumigator-frontend
+name: frontend
 description: A Helm chart for Lumigator frontend
 
 # A chart can be either an 'application' or a 'library' chart.


### PR DESCRIPTION
# What's changing

It looks like a change in https://github.com/mozilla-ai/lumigator/pull/745 introduced a regression which breaks the front end nginx container being able to find the backend container (Chart name dictates the name of the backend service, which changed when the chart name changed)

# How to test it

Helm install

# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
