### PR TITLE
Backend: Dataset errors

### DIFF
--- a/lumigator/backend/backend/api/routes/datasets.py
+++ b/lumigator/backend/backend/api/routes/datasets.py
@@ -31,7 +31,7 @@ def dataset_exception_mappings() -> dict[type[ServiceError], HTTPStatus]:
         DatasetUpstreamError: status.HTTP_500_INTERNAL_SERVER_ERROR,
         DatasetSizeError: status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
         DatasetInvalidError: status.HTTP_422_UNPROCESSABLE_ENTITY,
-        DatasetNotAvailableError: status.HTTP_204_NO_CONTENT,
+        DatasetNotAvailableError: status.HTTP_422_UNPROCESSABLE_ENTITY,
     }
 
 

--- a/lumigator/backend/backend/api/routes/datasets.py
+++ b/lumigator/backend/backend/api/routes/datasets.py
@@ -14,6 +14,7 @@ from backend.services.exceptions.base_exceptions import ServiceError
 from backend.services.exceptions.dataset_exceptions import (
     DatasetInvalidError,
     DatasetMissingFieldsError,
+    DatasetNotAvailableError,
     DatasetNotFoundError,
     DatasetSizeError,
     DatasetUpstreamError,
@@ -30,6 +31,7 @@ def dataset_exception_mappings() -> dict[type[ServiceError], HTTPStatus]:
         DatasetUpstreamError: status.HTTP_500_INTERNAL_SERVER_ERROR,
         DatasetSizeError: status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
         DatasetInvalidError: status.HTTP_422_UNPROCESSABLE_ENTITY,
+        DatasetNotAvailableError: status.HTTP_204_NO_CONTENT,
     }
 
 

--- a/lumigator/backend/backend/services/exceptions/base_exceptions.py
+++ b/lumigator/backend/backend/services/exceptions/base_exceptions.py
@@ -64,3 +64,23 @@ class UpstreamError(ServiceError):
         msg = _append_message(f"Upstream error with {service_name}", message)
         super().__init__(msg, exc)
         self.service_name = service_name
+
+
+class NotAvailableError(ServiceError):
+    """Base exception for errors caused by a resource not being available."""
+
+    def __init__(
+        self,
+        resource: str,
+        message: str,
+        exc: Exception | None = None,
+    ):
+        """Creates a NotAvailableError.
+
+        :param resource: the resource type that was not available
+        :param message: error message
+        :param exc: optional exception
+        """
+        msg = f"{resource} not available"
+        super().__init__(_append_message(msg, message), exc)
+        self.resource = resource

--- a/lumigator/backend/backend/services/exceptions/dataset_exceptions.py
+++ b/lumigator/backend/backend/services/exceptions/dataset_exceptions.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
 from backend.services.exceptions.base_exceptions import (
+    NotAvailableError,
     NotFoundError,
     UpstreamError,
     ValidationError,
@@ -81,3 +82,26 @@ class DatasetUpstreamError(UpstreamError):
         :param exc: optional exception
         """
         super().__init__(service_name, message, exc)
+
+
+class DatasetNotAvailableError(NotAvailableError):
+    """Raised when a dataset is not available.
+
+    This error differs from DatasetNotFoundError, the expectation here is that the dataset
+    should have been available based on identifying information for another resource.
+
+    Example: When a job runs to generate a dataset, the job ID may later be used to retrieve
+    the dataset.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        exc: Exception | None = None,
+    ):
+        """Creates a DatasetNotAvailableError.
+
+        :param message: error message
+        :param exc: optional exception
+        """
+        super().__init__("Dataset", message, exc)

--- a/lumigator/backend/backend/tests/conftest.py
+++ b/lumigator/backend/backend/tests/conftest.py
@@ -15,7 +15,6 @@ from fastapi import FastAPI, UploadFile
 from fastapi.testclient import TestClient
 from fsspec.implementations.memory import MemoryFileSystem
 from loguru import logger
-
 from lumigator_schemas.experiments import ExperimentResponse
 from lumigator_schemas.jobs import (
     JobConfig,
@@ -97,7 +96,9 @@ def wait_for_experiment(client, experiment_id: UUID) -> bool:
     for _ in range(1, MAX_POLLS):
         get_experiment_response = client.get(f"/experiments/new/{experiment_id}")
         assert get_experiment_response.status_code == 200
-        get_experiment_response_model = ExperimentResponse.model_validate(get_experiment_response.json())
+        get_experiment_response_model = ExperimentResponse.model_validate(
+            get_experiment_response.json()
+        )
         if get_experiment_response_model.status == JobStatus.SUCCEEDED.value:
             succeeded = True
             timed_out = False

--- a/lumigator/backend/backend/tests/integration/api/routes/test_api_workflows.py
+++ b/lumigator/backend/backend/tests/integration/api/routes/test_api_workflows.py
@@ -95,6 +95,9 @@ def test_upload_data_launch_job(
     output_infer_job_response = local_client.get(
         f"/jobs/{create_inference_job_response_model.id}/dataset"
     )
+    assert output_infer_job_response is not None
+    assert output_infer_job_response.status_code == 200
+
     output_infer_job_response_model = DatasetResponse.model_validate(
         output_infer_job_response.json()
     )

--- a/lumigator/backend/backend/tests/unit/services/test_job_service.py
+++ b/lumigator/backend/backend/tests/unit/services/test_job_service.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from lumigator_schemas.jobs import (
     JobInferenceCreate,
@@ -14,8 +16,14 @@ def test_set_null_inference_job_params(job_record, job_service):
         model="hf://facebook/bart-large-cnn",
         dataset="cced289c-f869-4af1-9195-1d58e32d1cc1",
     )
-    params = job_service._get_job_params("INFERENCE", job_record, request)
-    assert params["max_samples"] == -1
+
+    # Patch the response we'd get from the dataset service since we don't actually have a dataset
+    with patch(
+        "backend.services.datasets.DatasetService.get_dataset_s3_path",
+        return_value="s3://bucket/path/to/dataset",
+    ):
+        params = job_service._get_job_params("INFERENCE", job_record, request)
+        assert params["max_samples"] == -1
 
 
 def test_set_explicit_inference_job_params(job_record, job_service):
@@ -26,8 +34,14 @@ def test_set_explicit_inference_job_params(job_record, job_service):
         model="hf://facebook/bart-large-cnn",
         dataset="cced289c-f869-4af1-9195-1d58e32d1cc1",
     )
-    params = job_service._get_job_params("INFERENCE", job_record, request)
-    assert params["max_samples"] == 10
+
+    # Patch the response we'd get from the dataset service since we don't actually have a dataset
+    with patch(
+        "backend.services.datasets.DatasetService.get_dataset_s3_path",
+        return_value="s3://bucket/path/to/dataset",
+    ):
+        params = job_service._get_job_params("INFERENCE", job_record, request)
+        assert params["max_samples"] == 10
 
 
 @pytest.mark.parametrize(

--- a/lumigator/backend/uv.lock
+++ b/lumigator/backend/uv.lock
@@ -189,7 +189,6 @@ dev = [
     { name = "moto", extra = ["s3"] },
     { name = "pytest" },
     { name = "requests-mock" },
-    { name = "testcontainers" },
 ]
 
 [package.metadata]
@@ -221,7 +220,6 @@ dev = [
     { name = "moto", extras = ["s3"], specifier = ">=5.0,<6" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "requests-mock", specifier = ">=1.12.1" },
-    { name = "testcontainers", specifier = ">=4.8.2" },
 ]
 
 [[package]]
@@ -522,20 +520,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632 },
-]
-
-[[package]]
-name = "docker"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "requests" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774 },
 ]
 
 [[package]]
@@ -913,7 +897,7 @@ wheels = [
 
 [[package]]
 name = "lumigator-schemas"
-version = "0.1.0-alpha"
+version = "0.1.0a0"
 source = { editable = "../schemas" }
 dependencies = [
     { name = "pydantic" },
@@ -1712,22 +1696,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pywin32"
-version = "308"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/e2/02652007469263fe1466e98439831d65d4ca80ea1a2df29abecedf7e47b7/pywin32-308-cp311-cp311-win32.whl", hash = "sha256:5d8c8015b24a7d6855b1550d8e660d8daa09983c80e5daf89a273e5c6fb5095a", size = 5928156 },
-    { url = "https://files.pythonhosted.org/packages/48/ef/f4fb45e2196bc7ffe09cad0542d9aff66b0e33f6c0954b43e49c33cad7bd/pywin32-308-cp311-cp311-win_amd64.whl", hash = "sha256:575621b90f0dc2695fec346b2d6302faebd4f0f45c05ea29404cefe35d89442b", size = 6559559 },
-    { url = "https://files.pythonhosted.org/packages/79/ef/68bb6aa865c5c9b11a35771329e95917b5559845bd75b65549407f9fc6b4/pywin32-308-cp311-cp311-win_arm64.whl", hash = "sha256:100a5442b7332070983c4cd03f2e906a5648a5104b8a7f50175f7906efd16bb6", size = 7972495 },
-    { url = "https://files.pythonhosted.org/packages/00/7c/d00d6bdd96de4344e06c4afbf218bc86b54436a94c01c71a8701f613aa56/pywin32-308-cp312-cp312-win32.whl", hash = "sha256:587f3e19696f4bf96fde9d8a57cec74a57021ad5f204c9e627e15c33ff568897", size = 5939729 },
-    { url = "https://files.pythonhosted.org/packages/21/27/0c8811fbc3ca188f93b5354e7c286eb91f80a53afa4e11007ef661afa746/pywin32-308-cp312-cp312-win_amd64.whl", hash = "sha256:00b3e11ef09ede56c6a43c71f2d31857cf7c54b0ab6e78ac659497abd2834f47", size = 6543015 },
-    { url = "https://files.pythonhosted.org/packages/9d/0f/d40f8373608caed2255781a3ad9a51d03a594a1248cd632d6a298daca693/pywin32-308-cp312-cp312-win_arm64.whl", hash = "sha256:9b4de86c8d909aed15b7011182c8cab38c8850de36e6afb1f0db22b8959e3091", size = 7976033 },
-    { url = "https://files.pythonhosted.org/packages/a9/a4/aa562d8935e3df5e49c161b427a3a2efad2ed4e9cf81c3de636f1fdddfd0/pywin32-308-cp313-cp313-win32.whl", hash = "sha256:1c44539a37a5b7b21d02ab34e6a4d314e0788f1690d65b48e9b0b89f31abbbed", size = 5938579 },
-    { url = "https://files.pythonhosted.org/packages/c7/50/b0efb8bb66210da67a53ab95fd7a98826a97ee21f1d22949863e6d588b22/pywin32-308-cp313-cp313-win_amd64.whl", hash = "sha256:fd380990e792eaf6827fcb7e187b2b4b1cede0585e3d0c9e84201ec27b9905e4", size = 6542056 },
-    { url = "https://files.pythonhosted.org/packages/26/df/2b63e3e4f2df0224f8aaf6d131f54fe4e8c96400eb9df563e2aae2e1a1f9/pywin32-308-cp313-cp313-win_arm64.whl", hash = "sha256:ef313c46d4c18dfb82a2431e3051ac8f112ccee1a34f29c263c583c568db63cd", size = 7974986 },
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2002,21 +1970,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3e/da/1fb4bdb72ae12b834becd7e1e7e47001d32f91ec0ce8d7bc1b618d9f0bd9/starlette-0.41.2.tar.gz", hash = "sha256:9834fd799d1a87fd346deb76158668cfa0b0d56f85caefe8268e2d97c3468b62", size = 2573867 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/43/f185bfd0ca1d213beb4293bed51d92254df23d8ceaf6c0e17146d508a776/starlette-0.41.2-py3-none-any.whl", hash = "sha256:fbc189474b4731cf30fcef52f18a8d070e3f3b46c6a04c97579e85e6ffca942d", size = 73259 },
-]
-
-[[package]]
-name = "testcontainers"
-version = "4.8.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "docker" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/72/c58d84f5704c6caadd9f803a3adad5ab54ac65328c02d13295f40860cf33/testcontainers-4.8.2.tar.gz", hash = "sha256:dd4a6a2ea09e3c3ecd39e180b6548105929d0bb78d665ce9919cb3f8c98f9853", size = 63590 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/77/5ac0dff2903a033d83d971fd85957356abdb66a327f3589df2b3d1a586b4/testcontainers-4.8.2-py3-none-any.whl", hash = "sha256:9e19af077cd96e1957c13ee466f1f32905bc6c5bc1bc98643eb18be1a989bfb0", size = 104326 },
 ]
 
 [[package]]


### PR DESCRIPTION
# What's changing

More dataset errors returned from the `dataset_service`.

* When the dataset is not found when getting the S3 path (`DatasetNotFoundError`)
* When the dataset identified to a job ID (run ID) is not available (`DatasetNotAvailableError`)

`DatasetNotAvailableError` is mapped to [HTTP status code `422`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422) 

> The HTTP 422 Unprocessable Content [client error response](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses) status code indicates that the server understood the content type of the request content, and the syntax of the request content was correct, but it was unable to process the contained instructions.

>Clients that receive a 422 response should expect that repeating the request without modification will fail with the same error.

Also, updated the `uv` lock file as it seems to be trying to get my attention on every PR and I've ignored it thus far.

# How to test it

Steps to test the changes:

1.
2.
3.

# Additional notes for reviewers

This PR will be updated from `main` and readied up once the integration test issues have been resolved.

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
