### PR TITLE
Fix link checker

### DIFF
--- a/.github/workflows/build_and_publish_docs.yaml
+++ b/.github/workflows/build_and_publish_docs.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
         - main
-        - brake/docs
   pull_request:
     branches:
       - "**"
@@ -56,8 +55,13 @@ jobs:
       uses: lycheeverse/lychee-action@v2
       with:
         # Documentation: https://github.com/lycheeverse/lychee?tab=readme-ov-file#commandline-parameters
-        # Excluding the docs folder because these links will be checked by the sphinx linkcheck builder later
-        args: --base . --verbose --no-progress './**/*.md'  './**/*.html' './**/*.rst' --exclude 'mailto:|localhost' --exclude-path 'docs/source'
+        # Excluding the docs folder because the links in there are dynamic and are checked after
+        # they're compiled into html
+        args: |
+          --base . --verbose --no-progress
+          './**/*.md' './docs/build/**/*.html' './**/*.rst'
+          --exclude 'mailto:|localhost'
+          --exclude-path 'docs/source'
 
     - name: Set up pages
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/build_and_publish_docs.yaml
+++ b/.github/workflows/build_and_publish_docs.yaml
@@ -62,6 +62,7 @@ jobs:
           './**/*.md' './docs/build/**/*.html' './**/*.rst'
           --exclude 'mailto:|localhost'
           --exclude-path 'docs/source'
+          --exclude-path '.venv'
 
     - name: Set up pages
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/build_and_publish_docs.yaml
+++ b/.github/workflows/build_and_publish_docs.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
         - main
+        - brake/docs
   pull_request:
     branches:
       - "**"
@@ -23,30 +24,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Check links
-      id: lychee
-      uses: lycheeverse/lychee-action@v2
-      with:
-        # Documentation: https://github.com/lycheeverse/lychee?tab=readme-ov-file#commandline-parameters
-        # Excluding the docs folder because these links will be checked by the sphinx linkcheck builder later
-        args: --base . --verbose --no-progress './**/*.md'  './**/*.rst' --exclude 'mailto:|localhost' --exclude-path 'docs'
-
-    - name: Check for modified paths
-      uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          docs_changes:
-            - 'docs/**'
-
     - name: Set up Python 3.11
-      if: steps.filter.outputs.docs_changes == 'true'
       uses: actions/setup-python@v5
       with:
         python-version: "3.11"
 
     - name: Set up environment
-      if: steps.filter.outputs.docs_changes == 'true'
       id: setup
       run: |
         curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -55,7 +38,6 @@ jobs:
       continue-on-error: false
 
     - name: Install docs dependencies
-      if: steps.filter.outputs.docs_changes == 'true'
       id: install_build_dependencies
       run: |
         . .venv/bin/activate
@@ -63,24 +45,32 @@ jobs:
       continue-on-error: false
 
     - name: Build documentation
-      if: steps.filter.outputs.docs_changes == 'true'
       run: |
         . .venv/bin/activate
         cd docs
         sphinx-build source build/html
 
+    # Always check the docs
+    - name: Check links
+      id: lychee
+      uses: lycheeverse/lychee-action@v2
+      with:
+        # Documentation: https://github.com/lycheeverse/lychee?tab=readme-ov-file#commandline-parameters
+        # Excluding the docs folder because these links will be checked by the sphinx linkcheck builder later
+        args: --base . --verbose --no-progress './**/*.md'  './**/*.html' './**/*.rst' --exclude 'mailto:|localhost' --exclude-path 'docs/source'
+
     - name: Set up pages
-      if: steps.filter.outputs.docs_changes == 'true'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: actions/configure-pages@v4
 
     - name: Upload artifact
-      if: steps.filter.outputs.docs_changes == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: actions/upload-pages-artifact@v3
       with:
         path: docs/build/html/
 
     - name: Deploy
-      if: steps.filter.outputs.docs_changes == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: actions/deploy-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/source/conceptual-guides/endpoints.md
+++ b/docs/source/conceptual-guides/endpoints.md
@@ -14,7 +14,7 @@ The components inside the backend, shown in the image below, are the different a
 the backend itself relies on:
 
 * The **API** makes backend functionalities available to the UI through different **routes** (see: {{ '[schema code](https://github.com/mozilla-ai/lumigator/blob/{}/lumigator/backend/backend/api/routes)'.format(commit_id) }} ).
-{{ '[**Schemas**](https://github.com/moa;asldfjaszilla-ai/lumigator/blob/{}/lumigator/schemas)'.format(commit_id) }}
+{{ '[**Schemas**](https://github.com/mozilla-ai/lumigator/blob/{}/lumigator/schemas)'.format(commit_id) }}
   are used in the API which allows one to exactly know which kind of data has to be passed to it.
 
 * **Services** implement the actual functionalities and are called by the different methods exposed

--- a/docs/source/conceptual-guides/endpoints.md
+++ b/docs/source/conceptual-guides/endpoints.md
@@ -14,7 +14,7 @@ The components inside the backend, shown in the image below, are the different a
 the backend itself relies on:
 
 * The **API** makes backend functionalities available to the UI through different **routes** (see: {{ '[schema code](https://github.com/mozilla-ai/lumigator/blob/{}/lumigator/backend/backend/api/routes)'.format(commit_id) }} ).
-{{ '[**Schemas**](https://github.com/mozilla-ai/lumigator/blob/{}/lumigator/schemas)'.format(commit_id) }}
+{{ '[**Schemas**](https://github.com/moa;asldfjaszilla-ai/lumigator/blob/{}/lumigator/schemas)'.format(commit_id) }}
   are used in the API which allows one to exactly know which kind of data has to be passed to it.
 
 * **Services** implement the actual functionalities and are called by the different methods exposed

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,6 @@ extensions = [
     "myst_parser",
     "sphinx_design",
     "sphinx_copybutton",
-    "sphinx.builders.linkcheck",
 ]
 
 # napoleon settings

--- a/docs/source/get-started/installation.md
+++ b/docs/source/get-started/installation.md
@@ -44,8 +44,7 @@ environment variables: `OPENAI_API_KEY` or `MISTRAL_API_KEY`. Refer to the
 Despite the fact this is a local setup, it lends itself to more distributed scenarios. For instance,
 one could provide different `AWS_*` environment variables to the backend container to connect to any
 provider's S3-compatible service, instead of minio. Similarly, one could provide a different
-`RAY_HEAD_NODE_HOST` to move compute to a remote ray cluster, and so on. See {{ '[here](https://github.com/mozilla-ai/lumigator/blob/{}/docker-compose.external.yaml)'.format(commit_id) }} for an example of how to do
-this.
+`RAY_HEAD_NODE_HOST` to move compute to a remote ray cluster, and so on. See {{ '[here](https://github.com/mozilla-ai/lumigator/blob/{}/docker-compose.yaml)'.format(commit_id) }} to see where the `RAY_HEAD_NODE_HOST` is defined
 
 To deploy Lumigator locally:
 


### PR DESCRIPTION
# What's changing

We need to check the links every build, not only when the docs change. This is because maybe the docs didn't change but the link it points to did! In order to catch that, we need to check the links every time. In order to check the links, we need to check the compiled sphinx docs, because the sphinx docs MD files use dynamic links that insert the GIT commit that ties it to the right file version. So we need to run the link checker on the compiled html.