### PR TITLE
build: always pull latest docker image before start-lumigator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,6 @@ local-logs:
 
 # Launches lumigator in 'user-local' mode (All services running locally, using latest docker container, no code mounted in)
 start-lumigator: check-dot-env
-	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) COMPUTE_TYPE=$(COMPUTE_TYPE) docker compose --profile local $(GPU_COMPOSE) -f $(LOCAL_DOCKERCOMPOSE_FILE) pull
 	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) COMPUTE_TYPE=$(COMPUTE_TYPE) docker compose --profile local $(GPU_COMPOSE) -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d
 
 # Launches lumigator with no code mounted in, and forces build of containers (used in CI for integration tests)

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ local-logs:
 
 # Launches lumigator in 'user-local' mode (All services running locally, using latest docker container, no code mounted in)
 start-lumigator: check-dot-env
+	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) COMPUTE_TYPE=$(COMPUTE_TYPE) docker compose --profile local $(GPU_COMPOSE) -f $(LOCAL_DOCKERCOMPOSE_FILE) pull
 	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) COMPUTE_TYPE=$(COMPUTE_TYPE) docker compose --profile local $(GPU_COMPOSE) -f $(LOCAL_DOCKERCOMPOSE_FILE) up -d
 
 # Launches lumigator with no code mounted in, and forces build of containers (used in CI for integration tests)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -99,6 +99,7 @@ services:
 
   backend:
     image: mzdotai/lumigator:v0.1.0-alpha
+    pull_policy: always
     build:
       context: .
       dockerfile: "Dockerfile"
@@ -149,6 +150,7 @@ services:
       - "localhost:host-gateway"
 
   frontend:
+    pull_policy: always
     image: mzdotai/lumigator-frontend:v0.1.0-alpha
     build:
       context: .


### PR DESCRIPTION
# What's changing

Ensure `make start-lumigator` command always pulls the latest docker image versions before starting, as a way to avoid the need for manually removing and rebuilding images

# How to test it

Steps to test the changes:

1. run `make start-lumigator`
2. potentially push a new version of the docker image
3. run `make start-lumigator` again and ensure that the latest version is running and that the new image has been pulled

Or just double check that docker attempts to pull the images before running
<img width="737" alt="image" src="https://github.com/user-attachments/assets/2dd39736-7963-4915-a5db-5c648f7b69db" />


# Additional notes for reviewers

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
