### PR TITLE
Fixing multiplatform build

### DIFF
--- a/.github/workflows/lumigator_pipeline.yaml
+++ b/.github/workflows/lumigator_pipeline.yaml
@@ -309,8 +309,7 @@ jobs:
               - '.github/**'
               - 'lumigator/**'
 
-      - name: Install skopeo
-        run: sudo apt-get -y install skopeo
+
 
       - name: Truncate commit SHA
         if: steps.filter.outputs.push_fe == 'true' || contains(github.ref, 'refs/tags/')
@@ -334,6 +333,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Install skopeo
+        run: sudo apt-get -y install skopeo
+
+      - name: Copy multi-platform image to DockerHub
+        run: |
+          skopeo copy --all docker://ghcr.io/${{ github.repository }}:frontend_${{ env.GITHUB_SHA_SHORT }} docker://mzdotai/lumigator-frontend:mario_test
 
       - name: Tag and push Docker image (tagged releases)
         if: contains(github.ref, 'refs/tags/') 

--- a/.github/workflows/lumigator_pipeline.yaml
+++ b/.github/workflows/lumigator_pipeline.yaml
@@ -309,6 +309,9 @@ jobs:
               - '.github/**'
               - 'lumigator/**'
 
+      - name: Install skopeo
+        run: sudo apt-get -y install skopeo
+
       - name: Truncate commit SHA
         if: steps.filter.outputs.push_fe == 'true' || contains(github.ref, 'refs/tags/')
         run: echo "GITHUB_SHA_SHORT=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV

--- a/.github/workflows/lumigator_pipeline.yaml
+++ b/.github/workflows/lumigator_pipeline.yaml
@@ -262,10 +262,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download Docker images
-        if: steps.filter.outputs.push_be == 'true' || contains(github.ref, 'refs/tags/')
-        run: docker pull ghcr.io/${{ github.repository }}:backend_dev_${{ env.GITHUB_SHA_SHORT }}
-
       - name: Login to DockerHub
         if: steps.filter.outputs.push_be == 'true' || contains(github.ref, 'refs/tags/')
         uses: docker/login-action@v3
@@ -275,21 +271,15 @@ jobs:
 
       - name: Tag and push Docker image (tagged releases)
         if: contains(github.ref, 'refs/tags/') 
-        run: |
-          docker tag ghcr.io/${{ github.repository }}:backend_dev_${{ env.GITHUB_SHA_SHORT }} mzdotai/lumigator:${{ github.ref_name }}
-          docker push mzdotai/lumigator:${{ github.ref_name }}
+        run: skopeo copy --all docker://ghcr.io/${{ github.repository }}:backend_dev_${{ env.GITHUB_SHA_SHORT }} docker://mzdotai/lumigator:${{ github.ref_name }}
 
       - name: Tag and push Docker image (normal build)
         if: steps.filter.outputs.push_be == 'true' && !contains(github.ref, 'refs/tags/')  
-        run: |
-          docker tag ghcr.io/${{ github.repository }}:backend_dev_${{ env.GITHUB_SHA_SHORT }} mzdotai/lumigator:backend_dev_${{ env.GITHUB_SHA_SHORT }}
-          docker push mzdotai/lumigator:backend_dev_${{ env.GITHUB_SHA_SHORT }}
+        run: skopeo copy --all docker://ghcr.io/${{ github.repository }}:backend_dev_${{ env.GITHUB_SHA_SHORT }} docker://mzdotai/lumigator:backend_dev_${{ env.GITHUB_SHA_SHORT }}
 
       - name: Tag and push Docker image (latest)
         if: steps.filter.outputs.push_be == 'true' && github.ref == 'refs/heads/main'
-        run: |
-          docker tag ghcr.io/${{ github.repository }}:backend_dev_${{ env.GITHUB_SHA_SHORT }} mzdotai/lumigator:latest
-          docker push mzdotai/lumigator:latest
+        run: skopeo copy --all docker://ghcr.io/${{ github.repository }}:backend_dev_${{ env.GITHUB_SHA_SHORT }} docker://mzdotai/lumigator:latest
 
   push-frontend-images:
     name: Push frontend Docker images
@@ -309,8 +299,6 @@ jobs:
               - '.github/**'
               - 'lumigator/**'
 
-
-
       - name: Truncate commit SHA
         if: steps.filter.outputs.push_fe == 'true' || contains(github.ref, 'refs/tags/')
         run: echo "GITHUB_SHA_SHORT=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
@@ -323,10 +311,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download Docker images
-        if: steps.filter.outputs.push_fe == 'true' || contains(github.ref, 'refs/tags/')
-        run: docker pull ghcr.io/${{ github.repository }}:frontend_${{ env.GITHUB_SHA_SHORT }}
-
       - name: Login to DockerHub
         if: steps.filter.outputs.push_fe == 'true' || contains(github.ref, 'refs/tags/')
         uses: docker/login-action@v3
@@ -334,30 +318,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Install skopeo
-        run: sudo apt-get -y install skopeo
-
-      - name: Copy multi-platform image to DockerHub
-        run: |
-          skopeo copy --all docker://ghcr.io/${{ github.repository }}:frontend_${{ env.GITHUB_SHA_SHORT }} docker://mzdotai/lumigator-frontend:mario_test
-
       - name: Tag and push Docker image (tagged releases)
         if: contains(github.ref, 'refs/tags/') 
-        run: |
-          docker tag ghcr.io/${{ github.repository }}:frontend_${{ env.GITHUB_SHA_SHORT }} mzdotai/lumigator-frontend:${{ github.ref_name }}
-          docker push mzdotai/lumigator-frontend:${{ github.ref_name }}
+        run: skopeo copy --all docker://ghcr.io/${{ github.repository }}:frontend_${{ env.GITHUB_SHA_SHORT }} docker://mzdotai/lumigator-frontend:${{ github.ref_name }}
 
       - name: Tag and push Docker image (normal build)
         if: steps.filter.outputs.push_fe == 'true' && !contains(github.ref, 'refs/tags/')
-        run: |
-          docker tag ghcr.io/${{ github.repository }}:frontend_${{ env.GITHUB_SHA_SHORT }} mzdotai/lumigator-frontend:frontend_${{ env.GITHUB_SHA_SHORT }}
-          docker push mzdotai/lumigator-frontend:frontend_${{ env.GITHUB_SHA_SHORT }}
+        run: skopeo copy --all docker://ghcr.io/${{ github.repository }}:frontend_${{ env.GITHUB_SHA_SHORT }} docker://mzdotai/lumigator-frontend:frontend_${{ env.GITHUB_SHA_SHORT }}
 
       - name: Tag and push Docker image (latest)
         if: steps.filter.outputs.push_fe == 'true' && github.ref == 'refs/heads/main'
-        run: |
-          docker tag ghcr.io/${{ github.repository }}:frontend_${{ env.GITHUB_SHA_SHORT }} mzdotai/lumigator-frontend:latest
-          docker push mzdotai/lumigator-frontend:latest
+        run: skopeo copy --all docker://ghcr.io/${{ github.repository }}:frontend_${{ env.GITHUB_SHA_SHORT }} docker://mzdotai/lumigator-frontend:latest
 
   sdk-packaging:
     name: Package SDK


### PR DESCRIPTION
# What's changing

Due to the second pipeline iteration, I changed how we build and push the images to DockerHub. I introduced an intermediate registry in order to build the images at the same time we are executing the tests. After all tests have passed, the action downloads the image from the intermediate  registry, and pushes it to DockerHub. In that step, we lost the multi-platform image, because the runner is downloading the one accordingly to its architecture.

# How to test it

Run `make start-lumigator` changing backend image tag to: `backend_dev_95ebf41`. That's the tag of the last pipeline execution of this PR, you can check it.

# Additional notes for reviewers

N/A

# I already...

- [X] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
