### PR TITLE
Add support for HF text-generation pipelines

### DIFF
--- a/lumigator/backend/backend/api/routes/jobs.py
+++ b/lumigator/backend/backend/api/routes/jobs.py
@@ -31,6 +31,7 @@ from backend.services.exceptions.job_exceptions import (
     JobNotFoundError,
     JobTypeUnsupportedError,
     JobUpstreamError,
+    JobValidationError,
 )
 from backend.settings import settings
 
@@ -42,6 +43,7 @@ def job_exception_mappings() -> dict[type[ServiceError], HTTPStatus]:
         JobNotFoundError: status.HTTP_404_NOT_FOUND,
         JobTypeUnsupportedError: status.HTTP_501_NOT_IMPLEMENTED,
         JobUpstreamError: status.HTTP_500_INTERNAL_SERVER_ERROR,
+        JobValidationError: status.HTTP_400_BAD_REQUEST,
     }
 
 
@@ -55,9 +57,7 @@ def create_inference_job(
 ) -> JobResponse:
     job_response = service.create_job(job_create_request)
 
-    service.add_background_task(
-        background_tasks, service.handle_inference_job, job_response.id, job_create_request
-    )
+    service.add_background_task(background_tasks, service.handle_inference_job, job_response.id, job_create_request)
 
     url = request.url_for(get_job.__name__, job_id=job_response.id)
     response.headers[HttpHeaders.LOCATION] = f"{url}"
@@ -243,9 +243,7 @@ def _get_all_ray_jobs() -> list[RayJobDetails]:
     """Returns metadata that exists in the Ray cluster for all jobs."""
     resp = requests.get(settings.RAY_JOBS_URL, timeout=5)  # 5 seconds
     if resp.status_code != HTTPStatus.OK:
-        loguru.logger.error(
-            f"Unexpected status code getting all jobs: {resp.status_code}, error: {resp.text or ''}"
-        )
+        loguru.logger.error(f"Unexpected status code getting all jobs: {resp.status_code}, error: {resp.text or ''}")
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             detail="Unexpected error getting job logs",
@@ -257,9 +255,7 @@ def _get_all_ray_jobs() -> list[RayJobDetails]:
     except json.JSONDecodeError as e:
         loguru.logger.error(f"JSON decode error: {e}")
         loguru.logger.error(f"Response text: {resp.text}")
-        raise HTTPException(
-            status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Invalid JSON response"
-        ) from e
+        raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Invalid JSON response") from e
 
 
 def _get_ray_job(job_id: UUID) -> RayJobDetails:
@@ -267,17 +263,14 @@ def _get_ray_job(job_id: UUID) -> RayJobDetails:
     resp = requests.get(urljoin(settings.RAY_JOBS_URL, f"{job_id}"), timeout=5)  # 5 seconds
 
     if resp.status_code == HTTPStatus.NOT_FOUND:
-        loguru.logger.error(
-            f"Upstream job metadata not found ({resp.status_code}), error:  {resp.text or ''}"
-        )
+        loguru.logger.error(f"Upstream job metadata not found ({resp.status_code}), error:  {resp.text or ''}")
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND,
             detail=f"Job metadata for ID: {job_id} not found",
         )
     elif resp.status_code != HTTPStatus.OK:
         loguru.logger.error(
-            "Unexpected status code getting job metadata text: "
-            f"{resp.status_code}, error: {resp.text or ''}"
+            f"Unexpected status code getting job metadata text: {resp.status_code}, error: {resp.text or ''}"
         )
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
@@ -290,6 +283,4 @@ def _get_ray_job(job_id: UUID) -> RayJobDetails:
     except json.JSONDecodeError as e:
         loguru.logger.error(f"JSON decode error: {e}")
         loguru.logger.error(f"Response text: {resp.text or ''}")
-        raise HTTPException(
-            status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Invalid JSON response"
-        ) from e
+        raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Invalid JSON response") from e

--- a/lumigator/backend/backend/api/routes/jobs.py
+++ b/lumigator/backend/backend/api/routes/jobs.py
@@ -26,7 +26,6 @@ from starlette.responses import Response
 
 from backend.api.deps import DatasetServiceDep, JobServiceDep
 from backend.api.http_headers import HttpHeaders
-from backend.services.exceptions.base_exceptions import ServiceError
 from backend.services.exceptions.job_exceptions import (
     JobNotFoundError,
     JobTypeUnsupportedError,
@@ -38,7 +37,11 @@ from backend.settings import settings
 router = APIRouter()
 
 
-def job_exception_mappings() -> dict[type[ServiceError], HTTPStatus]:
+def job_exception_mappings() -> (
+    dict[
+        type[JobNotFoundError] | type[JobTypeUnsupportedError] | type[JobUpstreamError] | type[JobValidationError], int
+    ]
+):
     return {
         JobNotFoundError: status.HTTP_404_NOT_FOUND,
         JobTypeUnsupportedError: status.HTTP_501_NOT_IMPLEMENTED,

--- a/lumigator/backend/backend/config_templates.py
+++ b/lumigator/backend/backend/config_templates.py
@@ -91,6 +91,7 @@ default_eval_template = """{{
 default_infer_template = """{{
     "name": "{job_name}/{job_id}",
     "dataset": {{ "path": "{dataset_path}" }},
+    "system_prompt": "{system_prompt}",
     "hf_pipeline": {{
         "model_uri": "{model_uri}",
         "task": "{task}",

--- a/lumigator/backend/backend/services/exceptions/job_exceptions.py
+++ b/lumigator/backend/backend/services/exceptions/job_exceptions.py
@@ -27,9 +27,7 @@ class JobNotFoundError(NotFoundError):
 class JobTypeUnsupportedError(ServiceError):
     """Raised when a job type is not yet supported."""
 
-    def __init__(
-        self, job_type: JobType | object, message: str | None = None, exc: Exception | None = None
-    ):
+    def __init__(self, job_type: JobType | object, message: str | None = None, exc: Exception | None = None):
         """Creates a JobTypeNotSupportedError
 
         :param job_type: the type of job that is not supported,

--- a/lumigator/backend/backend/services/exceptions/job_exceptions.py
+++ b/lumigator/backend/backend/services/exceptions/job_exceptions.py
@@ -6,6 +6,7 @@ from backend.services.exceptions.base_exceptions import (
     NotFoundError,
     ServiceError,
     UpstreamError,
+    ValidationError,
     _append_message,
 )
 
@@ -58,3 +59,15 @@ class JobUpstreamError(UpstreamError):
         :param exc: optional exception
         """
         super().__init__(service_name, message, exc)
+
+
+class JobValidationError(ValidationError):
+    """Raised when there are issues during Job validation."""
+
+    def __init__(self, message: str, exc: Exception | None = None):
+        """Creates a JobValidationError
+
+        :param message: an optional error message
+        :param exc: optional exception
+        """
+        super().__init__(message, exc)

--- a/lumigator/backend/backend/services/jobs.py
+++ b/lumigator/backend/backend/services/jobs.py
@@ -46,6 +46,7 @@ from backend.services.exceptions.job_exceptions import (
     JobNotFoundError,
     JobTypeUnsupportedError,
     JobUpstreamError,
+    JobValidationError,
 )
 from backend.settings import settings
 
@@ -431,6 +432,9 @@ class JobService:
             job_type = JobType.INFERENCE
             if not request.output_field:
                 request.output_field = "predictions"
+
+            if request.task == "text-generation" and not request.system_prompt:
+                raise JobValidationError("System prompt is required for text generation tasks.") from None
         else:
             raise JobTypeUnsupportedError(request) from None
 

--- a/lumigator/backend/backend/services/jobs.py
+++ b/lumigator/backend/backend/services/jobs.py
@@ -283,7 +283,7 @@ class JobService:
         elif resp.status_code != HTTPStatus.OK:
             raise JobUpstreamError(
                 "ray",
-                "Unexpected status code getting job logs:" f" {resp.status_code}, error: {resp.text or ''}",
+                f"Unexpected status code getting job logs: {resp.status_code}, error: {resp.text or ''}",
             ) from None
         try:
             metadata = json.loads(resp.text)

--- a/lumigator/backend/backend/tests/unit/services/test_job_service.py
+++ b/lumigator/backend/backend/tests/unit/services/test_job_service.py
@@ -5,6 +5,7 @@ from lumigator_schemas.jobs import (
     JobInferenceCreate,
 )
 
+from backend.services.exceptions.job_exceptions import JobValidationError
 from backend.services.jobs import JobService
 from backend.settings import settings
 
@@ -77,3 +78,15 @@ def test_set_model(job_service, model, input_model_url, returned_model_url):
     )
     model_url = job_service._set_model_type(request)
     assert model_url == returned_model_url
+
+
+def test_invalid_text_generation(job_service):
+    request = JobInferenceCreate(
+        name="test_text_generation_run",
+        description="Test run to verify that system prompt is set.",
+        model="hf://microsoft/Phi-3.5-mini-instruct",
+        dataset="d34dd34d-d34d-d34d-d34d-d34dd34dd34d",
+        task="text-generation",
+    )
+    with pytest.raises(JobValidationError):
+        job_service.create_job(request=request)

--- a/lumigator/jobs/inference/inference_config.py
+++ b/lumigator/jobs/inference/inference_config.py
@@ -165,6 +165,7 @@ class InferenceJobConfig(BaseInferenceJobConfig):
     name: str
     dataset: DatasetConfig
     job: JobConfig
+    system_prompt: str | None = Field(title="System Prompt", default=None, exclude=True)
     inference_server: InferenceServerConfig | None = None
     params: SamplingParameters | None = None
     hf_pipeline: HfPipelineConfig | None = None

--- a/lumigator/jobs/inference/model_clients.py
+++ b/lumigator/jobs/inference/model_clients.py
@@ -151,6 +151,9 @@ class MistralModelClient(APIModelClient):
 
 class HuggingFaceModelClient(BaseModelClient):
     def __init__(self, config: InferenceJobConfig):
+        logger.info(f"System prompt: {config.system_prompt}")
+        self._system = config.system_prompt
+        self._task = config.hf_pipeline.task
         self._pipeline = pipeline(**config.hf_pipeline.model_dump())
         self._set_tokenizer_max_length()
 
@@ -199,10 +202,24 @@ class HuggingFaceModelClient(BaseModelClient):
         )
 
     def predict(self, prompt):
-        prediction = self._pipeline(prompt)[0]
+        # When using a text-generation model, the pipeline returns a dictionary with a single key,
+        # 'generated_text'. The value of this key is a list of dictionaries, each containing the\
+        # role and content of a message. For example:
+        # [{'role': 'system', 'content': 'You are a helpful assistant.'},
+        #  {'role': 'user', 'content': 'What is the capital of France?'}, ...]
+        # We want to return the content of the last message in the list, which is the model's
+        # response to the prompt.
+        if self._task == "text-generation":
+            messages = [
+                {"role": "system", "content": self._system},
+                {"role": "user", "content": prompt},
+            ]
+            generation = self._pipeline(messages)[0]
+            return generation["generated_text"][-1]["content"]
 
-        # The result is a dictionary with a single key, which name depends on the task
-        # (e.g., 'summary_text' for summarization)
-        # Get the name of the key and return its value
-        result_key = list(prediction.keys())[0]
-        return prediction[result_key]
+        # If we're using a summarization model, the pipeline returns a dictionary with a single key.
+        # The name of the key depends on the task (e.g., 'summary_text' for summarization).
+        # Get the name of the key and return its value.
+        if self._task == "summarization":
+            generation = self._pipeline(prompt)[0]
+            return generation["summary_text"]

--- a/lumigator/jobs/inference/schemas.py
+++ b/lumigator/jobs/inference/schemas.py
@@ -52,6 +52,7 @@ class InferenceJobConfig(BaseModel):
     name: str
     dataset: DatasetConfig
     job: JobConfig
+    system_prompt: str | None = None
     inference_server: InferenceServerConfig | None = None
     params: SamplingParameters | None = None
     hf_pipeline: HfPipelineConfig | None = None

--- a/lumigator/schemas/lumigator_schemas/jobs.py
+++ b/lumigator/schemas/lumigator_schemas/jobs.py
@@ -104,7 +104,14 @@ class JobInferenceCreate(BaseModel):
     trust_remote_code: bool = False
     torch_dtype: str = "auto"
     model_url: str | None = None
-    system_prompt: str | None = None
+    system_prompt: str | None = Field(
+        title="System Prompt",
+        default=None,
+        examples=[
+            "You are an advanced AI trained to summarize documents accurately and concisely. "
+            "Your goal is to extract key information while maintaining clarity and coherence."
+        ],
+    )
     output_field: str | None = "predictions"
     max_tokens: int = 1024
     frequency_penalty: float = 0.0


### PR DESCRIPTION
# What's changing

Add support for models filtered by the "text-generation" tag on the HF Hub. This means adding support for causal models, such as Llama, Gemma, Qwen, etc.

Causal models can complete a wide variety of tasks; therefore, users should provide a proper system prompt to inform the models about the task at hand. The user-provided system prompt, along with the data, is then transformed into a model-specific prompt using the chat template defined in the tokenizer config (a Jinja2 string template). This step will fail for older models, which don't have a defined chat template.

Refs #122

# How to test it

Steps to test the changes:

1. Deploy Lumigator with `make local-up`
2. Upload a dataset through the OpenAPI UI.
3. Create an inference job with the following body:
    ```json
    {
      "name": "string",
      "model": "hf://microsoft/Phi-3.5-mini-instruct",
      "dataset": "<dataset-uuid>",
      "max_samples": 1,
      "system_prompt": "You are an advanced AI trained to summarize documents accurately and concisely. Your goal is to extract key information while maintaining clarity and coherence.",
      "task": "text-generation"
    }
    ```

# Additional notes for reviewers

Recent models include a `chat_template` attribute in their `tokenizer_config.json` file. This attribute is essentially a Jinja2 string, such as the one defined [here](https://huggingface.co/microsoft/Phi-3.5-mini-instruct/blob/main/tokenizer_config.json#L119) for `microsoft/Phi-3.5-mini-instruct`.

The pipeline takes the user's input and uses it to render the template into a valid prompt, which then serves as the model's input. The user input follows the same standardized format:

```python
messages = [
    {"role": "system", "content": "You are a helpful assistant."},
    {"role": "user", "content": "What is the meaning of life?"},
]
```

However, some older models, such as [`openai-community/gpt2`](https://huggingface.co/openai-community/gpt2) do not include a chat template. These models break this process.

We should investigate how we could let the user specify a valid chat template. Passing it through the API as another argument doesn't seem to be the best approach, as they would have to do a lot of manual work, escaping special characters to convert the Jinja2 template to a JSON serializable object. I created #809 to track this.

# I already...

- - [x] Tested the changes in a working environment to ensure they work as expected
- - [x] Added some tests for any new functionality
- - [x] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- - [x] Checked if a (backend) DB migration step was required and included it if required
