### PR TITLE
Makefile: match `local-up` profiles and compose files, in `local-down`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ local-up: check-dot-env
 	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) COMPUTE_TYPE=$(COMPUTE_TYPE) docker compose --profile local $(GPU_COMPOSE) -f $(LOCAL_DOCKERCOMPOSE_FILE) -f ${DEV_DOCKER_COMPOSE_FILE} up --watch --build
 
 local-down:
-	docker compose --profile local -f $(LOCAL_DOCKERCOMPOSE_FILE) down
+	docker compose --profile local $(GPU_COMPOSE) -f $(LOCAL_DOCKERCOMPOSE_FILE) -f ${DEV_DOCKER_COMPOSE_FILE} down
 
 local-logs:
 	docker compose -f $(LOCAL_DOCKERCOMPOSE_FILE) logs


### PR DESCRIPTION
# What's changing

Ensures that we do the same thing when we `make local-down` we did to `local-up`, this PR means that MLFlow is removed now when you `local-down`.

The current [local-up docker cmd](https://github.com/mozilla-ai/lumigator/pull/813/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R111):

```bash
docker compose --profile local $(GPU_COMPOSE) -f $(LOCAL_DOCKERCOMPOSE_FILE) -f ${DEV_DOCKER_COMPOSE_FILE} up --watch --build
```

# How to test it

Steps to test the changes:

1. `make local-up`
2. `make local-down`
3. Everything should be removed from the containers in Docker

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
