### PR TITLE
Bugfix for old experiments endpoint

### DIFF
--- a/lumigator/backend/backend/api/routes/experiments.py
+++ b/lumigator/backend/backend/api/routes/experiments.py
@@ -1,7 +1,7 @@
 from http import HTTPStatus
 from uuid import UUID
 
-from fastapi import APIRouter, BackgroundTasks, status
+from fastapi import APIRouter, status
 from lumigator_schemas.experiments import (
     ExperimentCreate,
     ExperimentIdCreate,
@@ -30,10 +30,8 @@ def experiment_exception_mappings() -> dict[type[ServiceError], HTTPStatus]:
 
 
 @router.post("/", status_code=status.HTTP_201_CREATED)
-def create_experiment(
-    service: JobServiceDep, request: ExperimentCreate, background_tasks: BackgroundTasks
-) -> ExperimentResponse:
-    return service.create_job(JobEvalCreate.model_validate(request.model_dump()), background_tasks)
+def create_experiment(service: JobServiceDep, request: ExperimentCreate) -> ExperimentResponse:
+    return service.create_job(JobEvalCreate.model_validate(request.model_dump()))
 
 
 @router.get("/{experiment_id}")

--- a/lumigator/backend/backend/api/routes/experiments.py
+++ b/lumigator/backend/backend/api/routes/experiments.py
@@ -7,13 +7,14 @@ from lumigator_schemas.experiments import (
     ExperimentIdCreate,
     ExperimentIdResponse,
     ExperimentResponse,
-    ExperimentResultResponse,
     GetExperimentResponse,
 )
 from lumigator_schemas.extras import ListingResponse
 from lumigator_schemas.jobs import (
     JobEvalCreate,
+    JobResponse,
     JobResultDownloadResponse,
+    JobResultResponse,
 )
 
 from backend.api.deps import ExperimentServiceDep, JobServiceDep
@@ -30,12 +31,12 @@ def experiment_exception_mappings() -> dict[type[ServiceError], HTTPStatus]:
 
 
 @router.post("/", status_code=status.HTTP_201_CREATED)
-def create_experiment(service: JobServiceDep, request: ExperimentCreate) -> ExperimentResponse:
+def create_experiment(service: JobServiceDep, request: ExperimentCreate) -> JobResponse:
     return service.create_job(JobEvalCreate.model_validate(request.model_dump()))
 
 
 @router.get("/{experiment_id}")
-def get_experiment(service: JobServiceDep, experiment_id: UUID) -> ExperimentResponse:
+def get_experiment(service: JobServiceDep, experiment_id: UUID) -> JobResponse:
     return ExperimentResponse.model_validate(service.get_job(experiment_id).model_dump())
 
 
@@ -44,21 +45,17 @@ def list_experiments(
     service: JobServiceDep,
     skip: int = 0,
     limit: int = 100,
-) -> ListingResponse[ExperimentResponse]:
-    return ListingResponse[ExperimentResponse].model_validate(
-        service.list_jobs(skip, limit).model_dump()
-    )
+) -> ListingResponse[JobResponse]:
+    return ListingResponse[JobResponse].model_validate(service.list_jobs(skip, limit).model_dump())
 
 
 @router.get("/{experiment_id}/result")
 def get_experiment_result(
     service: JobServiceDep,
     experiment_id: UUID,
-) -> ExperimentResultResponse:
+) -> JobResultResponse:
     """Return experiment results metadata if available in the DB."""
-    return ExperimentResultResponse.model_validate(
-        service.get_job_result(experiment_id).model_dump()
-    )
+    return JobResultResponse.model_validate(service.get_job_result(experiment_id).model_dump())
 
 
 @router.get("/{experiment_id}/result/download")

--- a/lumigator/backend/backend/api/routes/experiments.py
+++ b/lumigator/backend/backend/api/routes/experiments.py
@@ -7,13 +7,13 @@ from lumigator_schemas.experiments import (
     ExperimentIdCreate,
     ExperimentIdResponse,
     ExperimentResponse,
-    ExperimentResultDownloadResponse,
     ExperimentResultResponse,
     GetExperimentResponse,
 )
 from lumigator_schemas.extras import ListingResponse
 from lumigator_schemas.jobs import (
     JobEvalCreate,
+    JobResultDownloadResponse,
 )
 
 from backend.api.deps import ExperimentServiceDep, JobServiceDep
@@ -65,9 +65,9 @@ def get_experiment_result(
 def get_experiment_result_download(
     service: JobServiceDep,
     experiment_id: UUID,
-) -> ExperimentResultDownloadResponse:
+) -> JobResultDownloadResponse:
     """Return experiment results file URL for downloading."""
-    return ExperimentResultDownloadResponse.model_validate(
+    return JobResultDownloadResponse.model_validate(
         service.get_job_result_download(experiment_id).model_dump()
     )
 


### PR DESCRIPTION
# What's changing

We have unit/integration testing around the new experiments (e.g. /experiments/new and /workflows) but apparently not for the old experiments endpoint 🙈 

Please feel free to approve and merge this without me, since this is needed to get the frontend working (the frontend is the only thing using the old experiments endpoint.