### PR TITLE
Update max line length from 100 chars to 120 as a treat in 2025

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -34,7 +34,7 @@ exclude = [
   "bazel-*",
 ]
 
-line-length = 100
+line-length = 120
 
 [lint]
 select = [


### PR DESCRIPTION
# What's changing

Updates the max line length from `100` characters to `120`.

# Additional notes for reviewers

79 characters mentioned in [pep-0008](https://peps.python.org/pep-0008/#maximum-line-length) was already too small. 

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
