### PR TITLE
Fix name of Ray cluster env var

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -74,9 +74,10 @@ services:
       - "10001:10001"
     # https://docs.ray.io/en/releases-2.30.0/cluster/cli.html#ray-start for more info about the command
     # Apparently dead head nodes can be selected unless
-    # RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES_ENV_VAR is set
+    # RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES is set
     # Dead head nodes appear because of the GCS data being
     # persisted in Redis
+    # https://github.com/ray-project/ray/issues/32167
     entrypoint:
       - /bin/bash
       - -c
@@ -87,7 +88,7 @@ services:
           # a shared dir, permissions need to be setup
           # ... || true allows this to fail (-e is set)
           sudo chmod -R 777 /tmp/ray_pip_cache/ || true
-          RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES_ENV_VAR=1 RAY_REDIS_ADDRESS=redis:6379 ray start --head --dashboard-port=8265 --port=6379 --dashboard-host=0.0.0.0 --ray-client-server-port 10001
+          RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES=1 RAY_REDIS_ADDRESS=redis:6379 ray start --head --dashboard-port=8265 --port=6379 --dashboard-host=0.0.0.0 --ray-client-server-port 10001
           mkdir -p /tmp/ray/session_latest/runtime_resources/pip
           rmdir /tmp/ray/session_latest/runtime_resources/pip/ && ln -s /tmp/ray_pip_cache /tmp/ray/session_latest/runtime_resources/pip
           sleep infinity


### PR DESCRIPTION
Quickfix for https://github.com/ray-project/ray/issues/32167
The name of the env var is not correctly set in the Ray container entrypoint.