### PR TITLE
Show configuration in operational guide menu

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,6 +45,7 @@ Hugging Face and local stores or accessed through APIs. It consists of:
    :maxdepth: 2
    :caption: Operations Guide
 
+   operations-guide/configuration
    operations-guide/kubernetes
    operations-guide/alembic
    operations-guide/dev

--- a/docs/source/operations-guide/configuration.md
+++ b/docs/source/operations-guide/configuration.md
@@ -1,7 +1,8 @@
 # Configuring Lumigator
 
-> [!NOTE]
-> This guide only covers configuring Lumigator when deployed using Docker.
+```{note}
+This guide only covers configuring Lumigator when deployed using Docker.
+```
 
 Lumigator comes with sensible defaults that allow you to [start using it](../get-started/installation.md) without modification using [`Docker Compose`](https://docs.docker.com/compose/).
 
@@ -26,8 +27,9 @@ From there the `.env` file variables are used in Lumigator's application or supp
 
 When you stop Lumigator using commands like `make local-down` or `make stop-lumigator`, the temporary files stored under `build` are removed. While Lumigator is running they are present if you wish to examine their contents.
 
-> [!NOTE]
-> The `build` directory and the user defined config file are both marked in `.gitignore`
+```{note}
+The `build` directory and the user defined config file are both marked in `.gitignore`
+```
 
 ## How should I set my own settings?
 


### PR DESCRIPTION
# What's changing

Fix the way note is displayed in configuration page of docs, and update navigation to show the page.

> If this PR is related to an issue or closes one, please link it here.

Refs #812 

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
