### PR TITLE
inference: Support invoking DeepSeek API (#869)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -108,6 +108,7 @@ services:
       - LOCAL_FSSPEC_S3_SECRET=${AWS_SECRET_ACCESS_KEY} # Should match AWS_SECRET_ACCESS_KEY
       - MISTRAL_API_KEY
       - OPENAI_API_KEY
+      - DEEPSEEK_API_KEY
       - HF_TOKEN
       - HF_HOME
       - AWS_ACCESS_KEY_ID

--- a/lumigator/backend/backend/services/jobs.py
+++ b/lumigator/backend/backend/services/jobs.py
@@ -355,6 +355,8 @@ class JobService:
             model_url = settings.OAI_API_URL
         elif request.job_config.model.startswith("mistral://"):
             model_url = settings.MISTRAL_API_URL
+        elif request.job_config.model.startswith("ds://"):
+            model_url = settings.DEEPSEEK_API_URL
         else:
             model_url = request.job_config.model_url
 
@@ -404,6 +406,19 @@ class JobService:
                     top_p=request.job_config.top_p,
                 )
             case "mistral://open-mistral-7b":
+                job_config.inference_server = InferenceServerConfig(
+                    base_url=self._set_model_type(request),
+                    engine=request.job_config.model,
+                    system_prompt=request.job_config.system_prompt or settings.DEFAULT_SUMMARIZER_PROMPT,
+                    max_retries=3,
+                )
+                job_config.params = SamplingParameters(
+                    max_tokens=request.job_config.max_tokens,
+                    frequency_penalty=request.job_config.frequency_penalty,
+                    temperature=request.job_config.temperature,
+                    top_p=request.job_config.top_p,
+                )
+            case "ds://deepseek-chat" | "ds://deepseek-reasoner":
                 job_config.inference_server = InferenceServerConfig(
                     base_url=self._set_model_type(request),
                     engine=request.job_config.model,

--- a/lumigator/backend/backend/settings.py
+++ b/lumigator/backend/backend/settings.py
@@ -57,6 +57,7 @@ class BackendSettings(BaseSettings):
     # Served models
     OAI_API_URL: str = "https://api.openai.com/v1"
     MISTRAL_API_URL: str = "https://api.mistral.ai/v1"
+    DEEPSEEK_API_URL: str = "https://api.deepseek.com/v1"
     DEFAULT_SUMMARIZER_PROMPT: str = "You are a helpful assistant, expert in text summarization. For every prompt you receive, provide a summary of its contents in at most two sentences."  # noqa: E501
 
     # Eval job details

--- a/lumigator/backend/backend/tests/unit/services/test_job_service.py
+++ b/lumigator/backend/backend/tests/unit/services/test_job_service.py
@@ -74,6 +74,8 @@ def test_set_explicit_inference_job_params(job_record, job_service):
         ("oai://gpt-4-turbo", None, settings.OAI_API_URL),
         # mistral model (from API)
         ("mistral://open-mistral-7b", None, settings.MISTRAL_API_URL),
+        # deepseek model (from API)
+        ("ds://deepseek-chat", None, settings.DEEPSEEK_API_URL),
     ],
 )
 def test_set_model(job_service, model, input_model_url, returned_model_url):

--- a/lumigator/jobs/inference/inference.py
+++ b/lumigator/jobs/inference/inference.py
@@ -11,6 +11,7 @@ from inference_config import InferenceJobConfig
 from loguru import logger
 from model_clients import (
     BaseModelClient,
+    DeepSeekModelClient,
     HuggingFaceModelClient,
     MistralModelClient,
     OpenAIModelClient,
@@ -99,6 +100,11 @@ def run_inference(config: InferenceJobConfig) -> Path:
             # run the mistral client
             logger.info(f"Using Mistral client. Endpoint: {base_url}")
             model_client = MistralModelClient(base_url, config)
+        elif "deepseek" in base_url:
+            # run the openai client using the DeepSeek URL (api.deepseek.com/v1)
+            # see: https://api-docs.deepseek.com/
+            logger.info(f"Using the DeepSeek client. Endpoint: {base_url}")
+            model_client = DeepSeekModelClient(base_url, config)
         else:
             # run the openai client
             logger.info(f"Using OAI client. Endpoint: {base_url}")


### PR DESCRIPTION
# What's changing

Add support for invoking the DeepSeek API, using the OpenAI Python client.

See here: https://api-docs.deepseek.com/

Closes #869

# How to test it

Steps to test the changes:

1. Grab your DeepSeek API key and export it:
    ```bash
    export DEEPSEEK_API_KEY=<your-key>
    ```
1. Deploy Lumigator with `make local-up`.
1. Upload a dataset using:
    ```bash
    #!/bin/bash
    if [ "$#" -gt 0 ]; then
        DATA_CSV_PATH="$1"
    else
        DATA_CSV_PATH="<data-path>"
    fi
    
    if [[ -z "${BACKEND_URL}" ]]; then
      BACKEND_URL=http://localhost:8000
    fi
    
    echo Connecting to $BACKEND_URL...
    
    curl -s $BACKEND_URL/api/v1/datasets/ \
      -H 'Accept: application/json' \
      -H 'Content-Type: multipart/form-data' \
      -F 'dataset=@'"$DATA_CSV_PATH"';type=text/csv' \
      -F 'format=job' | jq
    ```
1. Run an inference job:
    ```bash
    if [[ -z "${BACKEND_URL}" ]]; then
      BACKEND_URL=http://localhost:8000
    fi
    
    DATASET_ID=$(curl -s $BACKEND_URL/api/v1/datasets/ | jq -r '.items |sort_by(.created_at) | reverse | .[0].id')
    
    INFER_NAME="deeepseek_infer"
    INFER_DATASET=$DATASET_ID
    INFER_MAX_SAMPLES="1"
    INFER_MODEL="ds://deepseek-chat"
    INFER_MODEL_URL="https://api.deepseek.com/v1"
    INFER_SYSTEM_PROMPT="You are a helpful assistant, expert in text summarization. For every prompt you receive, provide a summary of its contents in at most two sentences."
    
    JSON_STRING=$(jq -n \
      --arg name "$INFER_NAME" \
      --arg model "$INFER_MODEL" \
      --arg model_url "$INFER_MODEL_URL" \
      --arg dataset_id "$INFER_DATASET" \
      --arg max_samples "$INFER_MAX_SAMPLES" \
      --arg system_prompt "$INFER_SYSTEM_PROMPT" \
      '{name: $name, dataset: $dataset_id, max_samples: $max_samples, job_config: {job_type: "inference", model: $model, model_url: $model_url, task: "summarization", system_prompt: $system_prompt}}')
    
    echo Connecting to $BACKEND_URL...
    
    curl -s $BACKEND_URL/api/v1/jobs/inference/ \
      -H 'Accept: application/json' \
      -H 'Content-Type: application/json' \
      -d "$JSON_STRING" | jq
    ```

# Additional notes for reviewers

Due to current server resource constraints, DeepSeek has suspended the API services for those who have not already added money to their account. It might be difficult to test this PR.

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
