### PR TITLE
fix: fix polling for workflow/experiment status

### DIFF
--- a/lumigator/frontend/src/components/datasets/LDatasetEmpty.vue
+++ b/lumigator/frontend/src/components/datasets/LDatasetEmpty.vue
@@ -1,15 +1,19 @@
 <template>
   <div class="l-dataset-empty">
-    <h2 class="l-dataset-empty__instructions">Use a dataset as the basis for your evaluation. It includes data for the model you'd like to
-      evaluate and possibly a ground truth "answer".</h2>
-      <p class="l-dataset-empty__instructions-text">
+    <h2 class="l-dataset-empty__instructions">
+      Use a dataset as the basis for your evaluation. It includes data for the model you'd like to
+      evaluate and possibly a ground truth "answer".
+    </h2>
+    <p class="l-dataset-empty__instructions-text">
       <span>
         If you don't have your dataset yet, you can use our
         <a
-        href="https://github.com/mozilla-ai/lumigator/tree/main/lumigator/sample_data"
-        target="_blank"
-        style="background-color: transparent"
-        > <span class="underline">sample datasets</span> <span class="pi pi-arrow-up-right"></span></a>
+          href="https://github.com/mozilla-ai/lumigator/tree/main/lumigator/sample_data"
+          target="_blank"
+          style="background-color: transparent"
+        >
+          <span class="underline">sample datasets</span> <span class="pi pi-arrow-up-right"></span
+        ></a>
       </span>
     </p>
     <Button

--- a/lumigator/frontend/src/components/experiments/LExperimentTable.vue
+++ b/lumigator/frontend/src/components/experiments/LExperimentTable.vue
@@ -140,13 +140,14 @@ function onWorkflowSelected(workflow: Workflow, experiment: ExperimentNew) {
   // because job might be still running
   // const inferenceJob = workflow.jobs.find((job: JobResult) => job.metrics?.length > 0)
   if (workflow.jobs) {
-    // experimentStore.fetchJobDetails(workflow.jobs[0].id)
+    experimentStore.fetchWorkflowDetails(workflow.id)
     selectedWorkflow.value = workflow
   }
   // select the experiment that job belongs to
   emit('l-experiment-selected', experiment)
 }
 
+// aggregates the experiment's status based on its workflows statuses
 function retrieveStatus(experimentId: string) {
   const experiment = experiments.value.find((exp) => exp.id === experimentId)
   if (!experiment) {

--- a/lumigator/frontend/src/sdk/workflowsService.ts
+++ b/lumigator/frontend/src/sdk/workflowsService.ts
@@ -24,8 +24,14 @@ export async function fetchWorkflowResults(workflow: Workflow): Promise<Workflow
   return response.data
 }
 
+export async function fetchWorkflowDetails(id: string): Promise<Workflow> {
+  const response = await lumigatorApiAxiosInstance.get(`workflows/${id}`)
+  return response.data
+}
+
 export const workflowsService = {
   createWorkflow,
   fetchLogs,
   fetchWorkflowResults,
+  fetchWorkflowDetails,
 }

--- a/lumigator/frontend/src/stores/experimentsStore.ts
+++ b/lumigator/frontend/src/stores/experimentsStore.ts
@@ -29,32 +29,74 @@ export const useExperimentStore = defineStore('experiments', () => {
   const completedStatus = [WorkflowStatus.SUCCEEDED, WorkflowStatus.FAILED]
 
   async function fetchAllExperiments() {
-    experiments.value = await experimentsService.fetchExperiments()
+    experiments.value = (await experimentsService.fetchExperiments()).map((experiment) => {
+      return {
+        ...experiment,
+        status: retrieveStatus(experiment),
+      }
+    })
+  }
+
+  // aggregates the experiment's status based on its workflows statuses
+  function retrieveStatus(experiment: ExperimentNew): WorkflowStatus {
+    const workflowStatuses = experiment.workflows.map((workflow) => workflow.status)
+    const uniqueStatuses = new Set(workflowStatuses)
+
+    if (uniqueStatuses.has(WorkflowStatus.RUNNING)) {
+      return WorkflowStatus.RUNNING
+    } else if (
+      uniqueStatuses.has(WorkflowStatus.FAILED) &&
+      uniqueStatuses.has(WorkflowStatus.SUCCEEDED)
+    ) {
+      return WorkflowStatus.INCOMPLETE
+    } else {
+      // if none of its workflows are running, or if some failed and others succeeded, then it probably means they all have the same status so just return it
+      return [...uniqueStatuses][0]
+    }
   }
 
   /**
    * The retrieved IDs will determine which experiment is still Running
    * @returns {string[]} IDs of stored experiments that have not completed
    */
-  function getIncompleteExperimentIds() {
-    return experiments.value
-      .filter((experiment) => !completedStatus.includes(experiment.status))
-      .map((experiment) => experiment.id)
+  function getIncompleteExperiments(): ExperimentNew[] {
+    return experiments.value.filter((experiment) => !completedStatus.includes(experiment.status))
   }
 
   /**
    *
    * @param {string} id - String (UUID) representing the experiment which should be updated with the latest status
    */
-  async function updateExperimentStatus(id: string) {
+  async function updateExperimentStatus(experiment: ExperimentNew): Promise<void> {
     try {
-      const status = await jobsService.fetchJobStatus(id)
-      const experiment = experiments.value.find((experiment) => experiment.id === id)
-      if (experiment) {
+      const incompleteWorkflows = experiment.workflows.filter(
+        (workflow) => !completedStatus.includes(workflow.status),
+      )
+
+      const incompleteWorkflowDetails = await Promise.all(
+        incompleteWorkflows.map((workflow) => workflowsService.fetchWorkflowDetails(workflow.id)),
+      )
+
+      incompleteWorkflowDetails.forEach((workflow) => {
+        const existingWorkflow = experiment.workflows.find((w) => w.id === workflow.id)
+        if (existingWorkflow) {
+          existingWorkflow.status = workflow.status
+        }
+      })
+
+      const status = incompleteWorkflowDetails.every((workflow) =>
+        completedStatus.includes(workflow.status),
+      )
+        ? WorkflowStatus.SUCCEEDED
+        : retrieveStatus(experiment)
+
+      // const e = experiments.value.find((exp) => exp.id === experiment.id)
+      // if (e) {
+        // e.status = status
         experiment.status = status
-      }
+      // }
     } catch (error) {
-      console.error(`Failed to update status for job ${id} ${error}`)
+      console.error(`Failed to update status for exp ${experiment} ${error}`)
     }
   }
 
@@ -62,7 +104,9 @@ export const useExperimentStore = defineStore('experiments', () => {
    * Updates the status for stored experiments that are not completed
    */
   async function updateStatusForIncompleteExperiments() {
-    await Promise.all(getIncompleteExperimentIds().map((id) => updateExperimentStatus(id)))
+    await Promise.all(
+      getIncompleteExperiments().map((experiment) => updateExperimentStatus(experiment)),
+    )
   }
 
   /**
@@ -135,10 +179,12 @@ export const useExperimentStore = defineStore('experiments', () => {
     const results = await workflowsService.fetchWorkflowResults(workflow)
     if (results) {
       selectedWorkflow.value = workflow
-      selectedWorkflowResults.value = transformJobResults(
-        results,
-      )
+      selectedWorkflowResults.value = transformJobResults(results)
     }
+  }
+
+  async function fetchWorkflowDetails(workflowId: string) {
+    return workflowsService.fetchWorkflowDetails(workflowId)
   }
 
   /**
@@ -280,5 +326,6 @@ export const useExperimentStore = defineStore('experiments', () => {
     fetchAllExperiments,
     updateStatusForIncompleteExperiments,
     fetchWorkflowResults,
+    fetchWorkflowDetails,
   }
 })

--- a/lumigator/frontend/src/stores/experimentsStore.ts
+++ b/lumigator/frontend/src/stores/experimentsStore.ts
@@ -92,8 +92,8 @@ export const useExperimentStore = defineStore('experiments', () => {
 
       // const e = experiments.value.find((exp) => exp.id === experiment.id)
       // if (e) {
-        // e.status = status
-        experiment.status = status
+      // e.status = status
+      experiment.status = status
       // }
     } catch (error) {
       console.error(`Failed to update status for exp ${experiment} ${error}`)

--- a/lumigator/frontend/src/stores/experimentsStore.ts
+++ b/lumigator/frontend/src/stores/experimentsStore.ts
@@ -11,7 +11,6 @@ import type { Model } from '@/types/Model'
 import { workflowsService } from '@/sdk/workflowsService'
 import type { ExperimentNew } from '@/types/ExperimentNew'
 import { WorkflowStatus, type Workflow, type WorkflowResults } from '@/types/Workflow'
-import { jobsService } from '@/sdk/jobsService'
 import axios from 'axios'
 
 export const useExperimentStore = defineStore('experiments', () => {


### PR DESCRIPTION
# What's changing

Closes https://github.com/mozilla-ai/lumigator/issues/875 , part of https://github.com/mozilla-ai/lumigator/issues/885

Fixes an issue with polling/updating the experiment and workflow level statuses on creating a new experiment

# How to test it

Steps to test the changes:

1. Create a new Experiment with workflows
2. The experiment status and workflow status should now update without having to refresh the page

# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
