### PR TITLE
Fixed HF_HOME for HF cache into ray

### DIFF
--- a/.default.conf
+++ b/.default.conf
@@ -17,8 +17,8 @@ RAY_WORKER_GPUS=0
 RAY_WORKER_GPUS_FRACTION=0
 NVIDIA_VISIBLE_DEVICES=all
 GPU_COUNT=0
-# Cache for HuggingFace models and artifacts ($ escapes resolution during deployment)
-HF_HOME=$${HOME}/.cache/huggingface
+# Cache for HuggingFace models and artifacts
+HF_HOME=${HOME}/.cache/huggingface
 # Access token to use when attempting to access gated models in HuggingFace
 HF_TOKEN=
 # Access token to use when attempting to interact with Mistral's API

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -94,7 +94,7 @@ services:
           sleep infinity
     shm_size: 2g
     volumes:
-      - ${HOME}/.cache/huggingface:/home/ray/.cache/huggingface
+      - ${HF_HOME}:/home/ray/.cache/huggingface
       - ray-pip-cache:/tmp/ray_pip_cache
     deploy:
       resources:
@@ -110,7 +110,6 @@ services:
       - OPENAI_API_KEY
       - DEEPSEEK_API_KEY
       - HF_TOKEN
-      - HF_HOME
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - AWS_DEFAULT_REGION


### PR DESCRIPTION
# What's changing

Fixed the use of HF_HOME in configs to properly cache HF models from ray container into HF_HOME directory:

- [`HF_HOME`](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/environment_variables#hfhome) is the env variable that HF looks into to know where e.g. to store its cache
- we'd like to mount host `HF_HOME` to ray's
- we define `HF_HOME` in `.default.conf` just for the sake of knowing where the host HF cache is (likely the default, but users can change it here if they have chosen another place for it)
- we mount `HF_HOME` to `/home/ray/.cache/huggingface` inside the ray container, so all models downloaded in there will be cached locally
- we don't make `HF_HOME` env var available in the container, as using the system default is fine there.

> If this PR is related to an issue or closes one, please link it here.

Closes https://github.com/mozilla-ai/lumigator/issues/876

# How to test it

Steps to test the changes:

1. clear your `~/.cache/huggingface` directory
2. run a full workflow - the first time, it will take some extra time to download all the required models (e.g. bart for inference/annotation and roberta-large for evaluation)
3. run it again, it should take less time
4. make local-down, then local-up again
5. run the workflow again, it should still use cached models (so smaller time because there's no download involved)


# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [x] Added some tests for any new functionality (no new functionality)
- [x] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`) (no need to update docs)
- [x] Checked if a (backend) DB migration step was required and included it if required (no need for db migration)
