### PR TITLE
LiteLLM should use the provider key

### DIFF
--- a/lumigator/jobs/inference/model_clients.py
+++ b/lumigator/jobs/inference/model_clients.py
@@ -54,8 +54,10 @@ class LiteLLMModelClient(BaseModelClient):
         self,
         prompt: str,
     ) -> str:
+        litellm_model = f"{self.config.inference_server.provider}/{self.config.inference_server.model}"
+        logger.info(f"Sending request to {litellm_model}")
         response = completion(
-            model=self.config.inference_server.model,
+            model=litellm_model,
             messages=[
                 {"role": "system", "content": self.system},
                 {"role": "user", "content": prompt},


### PR DESCRIPTION
# What's changing

@aittalam mentioned some docs updates needed for LiteLLM and while answering that question I realized there is a bug in the code where we're not using the provider key in LiteLLM. this doesn't cause any issues when the provider is OpenAI compatible but does raise issues if using the deepseek api, mistral, etc.

> If this PR is related to an issue or closes one, please link it here.

Refs #956 

# How to test it


# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
