### PR TITLE
A few changes to enable model preloading

### DIFF
--- a/.default.conf
+++ b/.default.conf
@@ -19,7 +19,7 @@ NVIDIA_VISIBLE_DEVICES=all
 GPU_COUNT=0
 # Cache for HuggingFace models and artifacts
 HF_HOME=${HOME}/.cache/huggingface
-MODELS_CACHED="facebook/bart-large-cnn,FacebookAI/roberta-large" #ensure values are comma separated
+MODELS_CACHED="facebook/bart-large-cnn,roberta-large" #ensure values are comma separated
 # Access token to use when attempting to access gated models in HuggingFace
 HF_TOKEN=
 # Access token to use when attempting to interact with Mistral's API

--- a/cache/Dockerfile.model-inference
+++ b/cache/Dockerfile.model-inference
@@ -1,13 +1,8 @@
 FROM python:3.11-slim
 
-RUN pip install --no-cache-dir transformers huggingface_hub
-
-# Ensure the cache directory exists (snapshot_download will create its own subfolders)
-RUN mkdir -p /home/ray/.cache/huggingface/hub
+RUN pip install --no-cache-dir transformers huggingface_hub loguru
 
 COPY cache/download_models.py /tmp/download_models.py
 
-RUN python /tmp/download_models.py
-
 # Exit immediately (this container’s only job is to populate the cache)
-CMD ["/bin/true"]
+CMD ["python", "/tmp/download_models.py"]

--- a/cache/download_models.py
+++ b/cache/download_models.py
@@ -1,12 +1,18 @@
 import os
 
 from huggingface_hub import snapshot_download
+from loguru import logger
+
+logger.info("*** Inference models caching ***")
 
 # Get the MODELS_CACHED environment variable (defaults to bart if not provided)
 models_env = os.environ.get("MODELS_CACHED", "facebook/bart-large-cnn")
+logger.info(f"Caching the following models: {models_env}")
+logger.info("(this might take a while...)")
+
 # Split by comma and strip whitespace
 models = [model.strip() for model in models_env.split(",")]
 
-for model in models:
+for i, model in enumerate(models):
     model_path = snapshot_download(model, cache_dir="/home/ray/.cache/huggingface/hub")
-    print(f"Model {model} downloaded")
+    logger.info(f"Model {i + 1}/{len(models)} downloaded: {model}")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,9 +7,8 @@ services:
       context: .
       dockerfile: cache/Dockerfile.model-inference
     platform: linux/${ARCH}
-    command: /bin/true
     volumes:
-      - ${HOME}/.cache/huggingface:/home/ray/.cache/huggingface
+      - ${HF_HOME}:/home/ray/.cache/huggingface
     environment:
       - MODELS_CACHED
     profiles:


### PR DESCRIPTION
# What's changing

- updated model name to `roberta-large` in config (the FacebookAI one is the same but bertscore reads the one with no company name from cache)
- fixed Dockerfile and docker-compose to run downloads in container and not at image-creation time
- updated download_models.py to provide meaningful updates to the users
