### PR TITLE
Changed containers in docker-compose to use latest tag

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -128,7 +128,7 @@ services:
   backend:
     labels:
       ai.mozilla.product_name: lumigator
-    image: mzdotai/lumigator:v0.1.1-alpha
+    image: mzdotai/lumigator:latest
     pull_policy: always
     build:
       context: .
@@ -188,7 +188,7 @@ services:
     labels:
       ai.mozilla.product_name: lumigator
     pull_policy: always
-    image: mzdotai/lumigator-frontend:v0.1.1-alpha
+    image: mzdotai/lumigator-frontend:latest
     build:
       context: .
       dockerfile: "./lumigator/frontend/Dockerfile"


### PR DESCRIPTION
We're changing how we run start-lumigator to ensure we always pick the latest version of the containers. As it happened twice, we've made important changes to the environment variables in our docker-compose for ray. The tag for the backend and frontend container have code that need the variables in an older version (the same git tag as the containers).

This prs ensures we always point to the latest images in the containers
