### PR TITLE
Settings: Support generation/usage of encryption key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,15 +16,15 @@ KEEP_CONTAINERS_UP ?= "FALSE"
 
 # Configuration to identify the input and output config files
 # NOTE: Changing CONFIG_BUILD_DIR will require review of .gitignore
-CONFIG_BUILD_DIR="$(shell pwd)/build"
+CONFIG_BUILD_DIR=$(shell pwd)/build
 # Path to default config prefixed with dot to hide from user
-CONFIG_DEFAULT_FILE:="$(shell pwd)/.default.conf"
+CONFIG_DEFAULT_FILE:=$(shell pwd)/.default.conf
 # Directory for user specific configuration and keys
-CONFIG_USER_DIR:="${HOME}/.lumigator"
+CONFIG_USER_DIR:=${HOME}/.lumigator
 # Path to user editable config file (will be generated if missing)
-CONFIG_OVERRIDE_FILE:="$(CONFIG_USER_DIR)/user.conf"
+CONFIG_OVERRIDE_FILE:=$(CONFIG_USER_DIR)/user.conf
 # Location of the key to use for encryption.
-CONFIG_USER_KEY_FILE:="$(CONFIG_USER_DIR)/lumigator.key"
+CONFIG_USER_KEY_FILE:=$(CONFIG_USER_DIR)/lumigator.key
 # Env var name to hold encryption key
 CONFIG_USER_KEY_ENV_VAR=LUMIGATOR_SECRET_KEY
 

--- a/Makefile
+++ b/Makefile
@@ -263,4 +263,4 @@ config-generate-env: config-clean config-generate-key
 
 # config-generate-key: ensures that a (new or existing) user owned secret key exists to be passed to lumigator and used for encryption.
 config-generate-key:
-	@scripts/config_generate_key.sh $(CONFIG_USER_DIR) $(CONFIG_USER_KEY_FILE) $(CONFIG_USER_KEY_ENV_VAR);
+	@scripts/config_generate_key.sh $(CONFIG_USER_DIR) $(CONFIG_USER_KEY_FILE)

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,8 @@ test-backend-unit:
 	SQLALCHEMY_DATABASE_URL=sqlite:////tmp/local.db \
 	MLFLOW_TRACKING_URI=http://localhost:8001 \
 	PYTHONPATH=../jobs:$$PYTHONPATH \
-	uv run $(DEBUGPY_ARGS) -m pytest -s -o python_files="backend/tests/unit/*/test_*.py backend/tests/unit/test_*.py"
+	LUMIGATOR_SECRET_KEY=abcdefghijklmnopqrstuvwxyz123456 \
+	uv run $(DEBUGPY_ARGS) -m pytest -s -o python_files="backend/tests/unit/*/test_*.py backend/tests/unit/test_*.py" # pragma: allowlist secret
 
 test-backend-integration:
 	cd lumigator/backend/; \
@@ -221,7 +222,8 @@ test-backend-integration:
 	EVALUATOR_PIP_REQS=../jobs/evaluator/requirements.txt \
 	EVALUATOR_WORK_DIR=../jobs/evaluator \
 	PYTHONPATH=../jobs:$$PYTHONPATH \
-	uv run $(DEBUGPY_ARGS) -m pytest -s -o python_files="backend/tests/integration/*/test_*.py"
+	LUMIGATOR_SECRET_KEY=abcdefghijklmnopqrstuvwxyz123456 \
+	uv run $(DEBUGPY_ARGS) -m pytest -s -o python_files="backend/tests/integration/*/test_*.py" # pragma: allowlist secret
 
 test-backend-integration-containers:
 ifeq ($(CONTAINERS_RUNNING),)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -149,6 +149,7 @@ services:
     ports:
       - 8000:8000
     environment:
+      - LUMIGATOR_SECRET_KEY # Symmetric key used for encryption/decryption of stored secret data
       - DEPLOYMENT_TYPE
       # The local file needs to be available through a mount,
       # if persistence is needed

--- a/docs/source/operations-guide/configuration.md
+++ b/docs/source/operations-guide/configuration.md
@@ -60,11 +60,13 @@ ${HOME}/.lumigator/lumigator.key`
 
 During deployment, when the `build/.env` file is generated, this key will be merged into the `.env` with the key name `LUMIGATOR_SECRET_KEY`.
 
-```{note}
 Due to the sensitive nature of the key, you cannot override the value for LUMIGATOR_SECRET_KEY that appears
 in the .env using user.conf.
 
-It will always be read from ${HOME}/.lumigator/lumigator.key, and must be present.
+It will be read from ${HOME}/.lumigator/lumigator.key, and must be present.
+
+```{note}
+Please ensure you have not exported LUMIGATOR_SECRET_KEY as this will conflict with the accurate value in the generated .env file.
 ```
 
 Once the key is generated, it should not be changed otherwise any data stored in Lumigator's databse will become unreadable.

--- a/docs/source/operations-guide/configuration.md
+++ b/docs/source/operations-guide/configuration.md
@@ -20,6 +20,7 @@ When you start Lumigator using commands like `make local-up` or `make start-lumi
 
 1. Any temporary config files used for deployment are removed
 1. Default and user settings (if present) are combined (with user settings preferred - see below for information on using your own settings)
+1. These settings are also combined with the user stored `LUMIGATOR_SECRET_KEY` - see below for more information on the secret key
 1. The generated config file (`.env`) is placed under the `build` directory in the repository root
 1. Docker Compose is supplied with the environment file path to the generated `.env` file
 
@@ -33,7 +34,7 @@ The `build` directory and the user defined config file are both marked in `.giti
 
 ## How should I set my own settings?
 
-User specific configuration can be stored in a file named `user.conf`, this file is configured in `.gitignore` and will never be commited to version control.
+User specific configuration can be stored in a file named `user.conf` in under `${HOME}/.lumigator`, this file is configured in `.gitignore` for safety, but should never appear in your repo directory.
 
 `user.conf` must be created manually when required, **only** add key/values for the settings you explicitly wish to change from the defaults.
 
@@ -44,6 +45,32 @@ Please review `.default.conf` for the format, setting names and default values (
 ## Can I configure everything?
 
 Not currently, there are a lot of settings available in `.default.conf` but for example you cannot yet change the URL that is exposed via FastAPI on our Backend component from http://localhost:8000.
+
+You cannot configure the user secret key under `LUMIGATOR_SECRET_KEY` as the value for this key **must** be read from the Lumigator dot fodler in the user's home directory.
+
+## What is the secret key?
+
+Lumigator requires a (symmetric) secret key which is used for encrypting and decrypting specific settings (secrets) stored via the API.
+
+The key will be created and stored automatically (if it is not present) on startup. The path Lumigator expects to find the key is:
+
+```bash
+${HOME}/.lumigator/lumigator.key`
+```
+
+During deployment, when the `build/.env` file is generated, this key will be merged into the `.env` with the key name `LUMIGATOR_SECRET_KEY`.
+
+```{note}
+Due to the sensitive nature of the key, you cannot override the value for LUMIGATOR_SECRET_KEY that appears
+in the .env using user.conf.
+
+It will always be read from ${HOME}/.lumigator/lumigator.key, and must be present.
+```
+
+Once the key is generated, it should not be changed otherwise any data stored in Lumigator's databse will become unreadable.
+
+Additionally it is the user's responsibility to ensure this key is kept safe. The only place it can exist
+within the Lumigator repo is in the `buid/.env` file that is automatically removed when you call `make local-down` or `make stop-lumigator`.
 
 ## Settings
 

--- a/lumigator/backend/backend/settings.py
+++ b/lumigator/backend/backend/settings.py
@@ -11,6 +11,7 @@ from sqlalchemy.engine import URL, make_url
 
 class BackendSettings(BaseSettings):
     # Backend
+    LUMIGATOR_SECRET_KEY: str  # Symmetric encryption key used for interacting with stored secrets
     DEPLOYMENT_TYPE: DeploymentType = DeploymentType.LOCAL
     MAX_DATASET_SIZE_HUMAN_READABLE: Final[str] = "50MB"
     MAX_DATASET_SIZE: ByteSize = MAX_DATASET_SIZE_HUMAN_READABLE

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e  # Exit on error
+
+# Prevent duplicate loading
+if [ -n "$COMMON_SH_LOADED" ]; then
+    return
+fi
+COMMON_SH_LOADED=1
+
+# ########################
+# Colorful terminal output
+# ########################
+echo_red() {
+    echo -e "\033[1;31m$1\033[0m"
+}
+
+echo_yellow() {
+    echo -e "\033[1;33m$1\033[0m"
+}
+
+echo_green() {
+    echo -e "\033[1;32m$1\033[0m"
+}
+
+echo_white() {
+    echo -e "\033[1;37m$1\033[0m"
+}

--- a/scripts/config_generate_env.sh
+++ b/scripts/config_generate_env.sh
@@ -71,7 +71,7 @@ generate_env() {
         USER_KEY_VALUE=$(tr -d '\n' < "$CONFIG_USER_KEY_FILE")  # Remove newlines
         echo "$CONFIG_USER_KEY_ENV_VAR=$USER_KEY_VALUE" > "$TEMP_USER_KEY_FILE"
     else
-        echo_red "Required user key file '$CONFIG_USER_KEY_FILE' not found. Exiting." >&2
+        echo_red "Error: Required user key file '$CONFIG_USER_KEY_FILE' not found. Exiting." >&2
         exit 1
     fi
 

--- a/scripts/config_generate_env.sh
+++ b/scripts/config_generate_env.sh
@@ -13,11 +13,17 @@ else
     exit 1
 fi
 
+# ###########################################################
+# Track creation of temporary files in the script for cleanup
+# ###########################################################
+TEMP_FILES=()
+
 # #########################
 # Merge configuration files
 # #########################
 merge_conf_files() {
     temp_file=$(mktemp)
+    TEMP_FILES+=("$temp_file")
     keys_order=()
 
     while IFS='=' read -r key value || [[ -n "$key" ]]; do
@@ -41,28 +47,46 @@ merge_conf_files() {
 # Main script logic for handling .env generation
 generate_env() {
     CONFIG_BUILD_DIR="$1"
-    CONFIG_DEFAULT_FILE="$2"
-    CONFIG_OVERRIDE_FILE="$3"
+    CONFIG_USER_KEY_FILE="$2"
+    CONFIG_USER_KEY_ENV_VAR="$3"
+    CONFIG_DEFAULT_FILE="$4"
+    CONFIG_OVERRIDE_FILE="5"
 
     echo_white "Generating the .env file..."
     mkdir -p "$CONFIG_BUILD_DIR"  # Ensure the build (output) directory exists
 
+    # Create a temp file to hold the env_var=value for the user's key.
+    TEMP_USER_KEY_FILE=$(mktemp)
+    TEMP_FILES+=("$TEMP_USER_KEY_FILE")
+
+    # Check for the key file's existence and populate the temp file with KEY=VALUE so we can merge it
+    if [ -f "$CONFIG_USER_KEY_FILE" ]; then
+        USER_KEY_VALUE=$(tr -d '\n' < "$CONFIG_USER_KEY_FILE")  # Remove newlines
+        echo "$CONFIG_USER_KEY_ENV_VAR=$USER_KEY_VALUE" > "$TEMP_USER_KEY_FILE"
+    else
+        echo_red "Required user key file '$CONFIG_USER_KEY_FILE' not found. Exiting." >&2
+        exit 1
+    fi
+
     if [ -f "$CONFIG_OVERRIDE_FILE" ]; then
         echo_green "Found user configuration: '$CONFIG_OVERRIDE_FILE', overrides will be applied"
-        merge_conf_files "$CONFIG_DEFAULT_FILE" "$CONFIG_OVERRIDE_FILE" > "$CONFIG_BUILD_DIR/.env"
+        merge_conf_files "$CONFIG_DEFAULT_FILE" "$CONFIG_OVERRIDE_FILE" "$TEMP_USER_KEY_FILE" > "$CONFIG_BUILD_DIR/.env"
     else
-        echo_yellow "No user configuration found, default will be used: '$CONFIG_DEFAULT_FILE'"
-        cp "$CONFIG_DEFAULT_FILE" "$CONFIG_BUILD_DIR/.env"
+        echo_yellow "No user configuration found, default will be used for merge: '$CONFIG_DEFAULT_FILE'"
+        merge_conf_files "$CONFIG_DEFAULT_FILE" "$TEMP_USER_KEY_FILE" > "$CONFIG_BUILD_DIR/.env"
     fi
 
     echo_green "Config file generated: '$CONFIG_BUILD_DIR/.env'"
 }
 
 # Ensure the script is being called with the correct number of arguments
-if [[ $# -lt 3 || $# -gt 4 ]]; then
-    echo "Usage: $0 <config_build_dir> <config_user_dir> <config_file_default> [config_file_override]"
+if [[ $# -lt 4 || $# -gt 5 ]]; then
+    echo "Usage: $0 <config_build_dir> <config_user_key_file> <config_user_key_env_var> <config_file_default> [config_file_override]"
     exit 1
 fi
 
+# Set up a global trap to clean up all temporary files when the script exits
+trap 'rm -rf -- "${TEMP_FILES[@]}"' EXIT
+
 # Call the function to generate the .env file
-generate_env "$1" "$2" "$3" "$4"
+generate_env "$1" "$2" "$3" "$4" "$5"

--- a/scripts/config_generate_env.sh
+++ b/scripts/config_generate_env.sh
@@ -40,8 +40,6 @@ merge_conf_files() {
     for key in "${keys_order[@]}"; do
         grep "^$key=" "$temp_file"
     done
-
-    rm "$temp_file"
 }
 
 # Main script logic for handling .env generation

--- a/scripts/config_generate_env.sh
+++ b/scripts/config_generate_env.sh
@@ -48,7 +48,7 @@ generate_env() {
     CONFIG_USER_KEY_FILE="$2"
     CONFIG_USER_KEY_ENV_VAR="$3"
     CONFIG_DEFAULT_FILE="$4"
-    CONFIG_OVERRIDE_FILE="5"
+    CONFIG_OVERRIDE_FILE="$5"
 
     echo_white "Generating the .env file..."
     mkdir -p "$CONFIG_BUILD_DIR"  # Ensure the build (output) directory exists

--- a/scripts/config_generate_key.sh
+++ b/scripts/config_generate_key.sh
@@ -17,7 +17,6 @@ fi
 generate_key() {
     APP_DIR="$1"
     KEY_FILE="$2"
-    APP_ENV_VAR_NAME="$3"
     EXPECTED_APP_DIR_PERMS=700  # Secure permissions for dir (owner-only access)
     EXPECTED_KEY_PERMS=600 # Secure permissions for file (owner-only access)
 
@@ -59,10 +58,10 @@ generate_key() {
 
 
 # Ensure the script is being called with the correct number of arguments
-if [[ $# -lt 3 || $# -gt 3 ]]; then
-    echo "Usage: $0 <config_user_dir> <config_user_key_file> <config_user_key_env_var>"
+if [[ $# -lt 2 || $# -gt 2 ]]; then
+    echo "Usage: $0 <config_user_dir> <config_user_key_file>"
     exit 1
 fi
 
 # Call the function to generate the key
-generate_key "$1" "$2" "$3"
+generate_key "$1" "$2"

--- a/scripts/config_generate_key.sh
+++ b/scripts/config_generate_key.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# #######################
+# Source common functions
+# #######################
+COMMON_FILE="$(dirname "$0")/common.sh"
+if [ -f "$COMMON_FILE" ]; then
+    source "$COMMON_FILE"
+else
+    echo "Error: common.sh not found!" >&2
+    exit 1
+fi
+
+# #########################
+# Ensure app encryption key
+# #########################
+generate_key() {
+    APP_DIR="$1"
+    KEY_FILE="$2"
+    APP_ENV_VAR_NAME="$3"
+    EXPECTED_APP_DIR_PERMS=700  # Secure permissions for dir (owner-only access)
+    EXPECTED_KEY_PERMS=600 # Secure permissions for file (owner-only access)
+
+    echo "Ensuring application encryption key (and directory) exists..."
+
+    # Ensure we have a directory and not a file at the expected path if it already exists
+    if [ -e "$APP_DIR" ] && [ ! -d "$APP_DIR" ]; then
+        echo_red "Error: $APP_DIR exists but is not a directory!" >&2
+        exit 1
+    fi
+
+    # Handle the case where we don't have a directory yet
+    mkdir -p "$APP_DIR"
+
+    # Check and update permissions if incorrect
+    CURRENT_PERMS=$(stat -c "%a" "$APP_DIR" 2>/dev/null || stat -f "%A" "$APP_DIR")
+    if [ "$CURRENT_PERMS" -ne "$EXPECTED_APP_DIR_PERMS" ]; then
+        echo_yellow "Setting permissions for $APP_DIR (current: $CURRENT_PERMS, expected: $EXPECTED_APP_DIR_PERMS)"
+        chmod "$EXPECTED_APP_DIR_PERMS" "$APP_DIR"
+    fi
+
+    # Check if key file exists with the right permissions, otherwise generate one for the user
+    if [ ! -f "$KEY_FILE" ]; then
+        echo_yellow "No key found. Generating a new AES-256 key..."
+        openssl rand -base64 32 > "$KEY_FILE"
+        chmod "$EXPECTED_KEY_PERMS" "$KEY_FILE"
+        echo_green "Key generated and stored in $KEY_FILE"
+    else
+        echo_yellow "Existing key found in $KEY_FILE"
+    fi
+
+    # Check and fix permissions if incorrect
+    CURRENT_KEY_PERMS=$(stat -c "%a" "$KEY_FILE" 2>/dev/null || stat -f "%A" "$KEY_FILE")
+    if [ "$CURRENT_KEY_PERMS" -ne "$EXPECTED_KEY_PERMS" ]; then
+        echo_yellow "Fixing permissions for $KEY_FILE (current: $CURRENT_KEY_PERMS, expected: $EXPECTED_KEY_PERMS)"
+        chmod "$EXPECTED_KEY_PERMS" "$KEY_FILE"
+    fi
+
+    # Output instructions to set the environment variable
+    echo_green "Run the following command to set the key in your environment:"
+    echo ""
+    echo_white "    export $APP_ENV_VAR_NAME=\$(tr -d '\\\\n' < \"$KEY_FILE\")"
+    echo ""
+}
+
+
+# Ensure the script is being called with the correct number of arguments
+if [[ $# -lt 3 || $# -gt 3 ]]; then
+    echo "Usage: $0 <config_user_dir> <config_user_key_file> <config_user_key_env_var>"
+    exit 1
+fi
+
+# Call the function to generate the key
+generate_key "$1" "$2" "$3"

--- a/scripts/config_generate_key.sh
+++ b/scripts/config_generate_key.sh
@@ -55,12 +55,6 @@ generate_key() {
         echo_yellow "Fixing permissions for $KEY_FILE (current: $CURRENT_KEY_PERMS, expected: $EXPECTED_KEY_PERMS)"
         chmod "$EXPECTED_KEY_PERMS" "$KEY_FILE"
     fi
-
-    # Output instructions to set the environment variable
-    echo_green "Run the following command to set the key in your environment:"
-    echo ""
-    echo_white "    export $APP_ENV_VAR_NAME=\$(tr -d '\\\\n' < \"$KEY_FILE\")"
-    echo ""
 }
 
 

--- a/scripts/setup_uv.sh
+++ b/scripts/setup_uv.sh
@@ -2,25 +2,16 @@
 
 set -e  # Exit on error
 
-# ###############
-# Colorful output
-# ###############
-
-red() {
-    echo -e "\033[1;31m$1\033[0m"
-}
-
-yellow() {
-    echo -e "\033[1;33m$1\033[0m"
-}
-
-green() {
-    echo -e "\033[1;32m$1\033[0m"
-}
-
-white() {
-    echo -e "\033[1;37m$1\033[0m"
-}
+# #######################
+# Source common functions
+# #######################
+COMMON_FILE="$(dirname "$0")/common.sh"
+if [ -f "$COMMON_FILE" ]; then
+    source "$COMMON_FILE"
+else
+    echo "Error: common.sh not found!" >&2
+    exit 1
+fi
 
 # ##########
 # Install UV
@@ -44,20 +35,17 @@ done
 
 # If not in PATH, add it temporarily and suggest making it permanent
 if [ "$PATH_PRESENT" -eq 0 ]; then
-    red "PATH does not contain '$LOCAL_BIN' (installation directory). Adding temporarily..."
+    echo_red "PATH does not contain '$LOCAL_BIN' (installation directory). Adding temporarily..."
     export PATH="$LOCAL_BIN:$PATH"
 fi
 
 # Install uv if not found
 UV_INSTALL_REQUIRED=0
 if ! command -v uv >/dev/null 2>&1; then
-    red "uv not found. Installing..."
+    echo_red "uv not found. Installing..."
     curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="$LOCAL_BIN" sh
     UV_INSTALL_REQUIRED=1
 fi
-
-# Now, run the setup for virtual environments
-export PATH="$LOCAL_BIN:$PATH"
 
 # ######################################
 # Configure Virtual Environments for UV
@@ -94,22 +82,22 @@ done
 uv sync && uv sync --dev
 
 if [ "$PATH_PRESENT" -eq 0 ]; then
-    yellow "The PATH was temporaily updated to include '$LOCAL_BIN'"
-    yellow "To make this change permanent, add the following line to your shell profile:"
+    echo_yellow "The PATH was temporaily updated to include '$LOCAL_BIN'"
+    echo_yellow "To make this change permanent, add the following line to your shell profile:"
     echo ""
-    white "    export PATH=\"$LOCAL_BIN:\$PATH\""
+    echo_white "    export PATH=\"$LOCAL_BIN:\$PATH\""
     echo ""
-    yellow "Depending on your installation directory, you may be able to use generic shell environment variables:"
+    echo_yellow "Depending on your installation directory, you may be able to use generic shell environment variables:"
     echo ""
-    white "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+    echo_white "    export PATH=\"\$HOME/.local/bin:\$PATH\""
     echo ""
 fi
 
 if [ "$UV_INSTALL_REQUIRED" -eq 1 ]; then
-    green "Package manager 'uv' has been installed at '$LOCAL_BIN'."
+    echo_green "Package manager 'uv' has been installed at '$LOCAL_BIN'."
 fi
 
-green "Virtual environments created at the following locations:"
+echo_green "Virtual environments created at the following locations:"
 for venv in "${venv_locations[@]}"; do
-    white "    $venv"
+    echo_white "    $venv"
 done


### PR DESCRIPTION
# What's changing

On starting Lumigator via `make local-up` or `make start-lumigator*` we now check for the existence of a key file in the Lumigator 'dot folder' in the user's home folder (`~/.lumigator/lumigator.key`). 

If the key isn't found we generate it and store it.

The key is used to create the temp `.env` file supplied to Docker Compose for deployment, which sets the `LUMIGATOR_SECRET_KEY` on the Backend container (and the backend app pulls it into it's settings).

Closes #948 

# How to test it

Steps to test the changes:

* Start Lumigator and check the terminal output:
```bash
make local-up
```
* Check the generated key value (to compare with the rest):
```bash
cat ~/.lumigator/lumigator.key
```
* Check the `build/.env` file: 
```bash
cat build/.env | grep LUMIGATOR_SECRET_KEY
```
* Check the docker compose output: 
```bash
docker-compose --log-level ERROR -f docker-compose.yaml -f .devcontainer/docker-compose.override.yaml --profile local --env-file build/.env config | yq '.services.backend.environment' | grep LUMIGATOR_SECRET_KEY
```
* Check the backend container's env var:
```bash
docker exec -it lumigator-backend-1 env | grep LUMIGATOR_SECRET_KEY
```
* Stop Lumigator and check the temp build file containing the key is gone (but not the user key):
```
make local-down
cat build/.env
cat ~/.lumigator/lumigator.key
```

# Additional notes for reviewers


# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [x] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
