### PR TITLE
[BUG] Sampling parameters were only being applied to LiteLLM, not HFPipeline

### DIFF
--- a/lumigator/backend/backend/services/jobs.py
+++ b/lumigator/backend/backend/services/jobs.py
@@ -169,12 +169,12 @@ class JobDefinitionInference(JobDefinition):
                 system_prompt=request.job_config.system_prompt or settings.DEFAULT_SUMMARIZER_PROMPT,
                 max_retries=3,
             )
-            job_config.params = SamplingParameters(
-                max_tokens=request.job_config.max_tokens,
-                frequency_penalty=request.job_config.frequency_penalty,
-                temperature=request.job_config.temperature,
-                top_p=request.job_config.top_p,
-            )
+        job_config.params = SamplingParameters(
+            max_tokens=request.job_config.max_tokens,
+            frequency_penalty=request.job_config.frequency_penalty,
+            temperature=request.job_config.temperature,
+            top_p=request.job_config.top_p,
+        )
         return job_config
 
     def store_as_dataset(self) -> bool:


### PR DESCRIPTION
I made https://github.com/mozilla-ai/lumigator/pull/972 a little big, so I'm going to split this into some smaller more manageable chunks.

# What's changing

Our SamplingParameters should apply whether using the HF Pipeline or the LiteLLM pipeline for the inference job

> If this PR is related to an issue or closes one, please link it here.

Refs #970 
# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
