### PR TITLE
Fix pydantic deprecated call (dict) -> model_dump

### DIFF
--- a/lumigator/backend/backend/api/routes/jobs.py
+++ b/lumigator/backend/backend/api/routes/jobs.py
@@ -75,7 +75,7 @@ def create_annotation_job(
     reference model should be used to generate annotations.
     See more: https://blog.mozilla.ai/lets-build-an-app-for-evaluating-llms/
     """
-    inference_job_create_config_dict = job_create_request.job_config.dict()
+    inference_job_create_config_dict = job_create_request.job_config.model_dump()
     inference_job_create_config_dict["model"] = "facebook/bart-large-cnn"
     inference_job_create_config_dict["provider"] = "hf"
     inference_job_create_config_dict["output_field"] = "ground_truth"


### PR DESCRIPTION
# What's changing

Update pydantic call to avoid deprecation warning


# Additional notes for reviewers


# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
