### PR TITLE
Fixed a typo in quickstart.md file

### DIFF
--- a/docs/source/get-started/quickstart.md
+++ b/docs/source/get-started/quickstart.md
@@ -52,7 +52,7 @@ This will run all of the components needed for Lumigator.
 This creates multiple container services networked together to make up all the components of the Lumigator application:
 
 - `minio`: Local storage for datasets that mimics S3-API compatible functionality.
-- `backend`: Lumigator’s FastAPI REST API. Access the Swagger HTTP Docs at http://localhost:8O00/docs
+- `backend`: Lumigator’s FastAPI REST API. Access the Swagger HTTP Docs at http://localhost:8000/docs
 - `ray`: A Ray cluster for submitting several types of jobs. Access the Ray dashboard at http://localhost:8265
 - `mlflow`: Used to track experiments and metrics, accessible at  http://localhost:8001
 - `frontend`: Lumigator's Web UI, accessible at http://localhost:80


### PR DESCRIPTION
# What's changing

Provide a clear and concise description of the content changes you're proposing. List all the
changes you are making to the content.

* Fixed a typo in quickstart.md, the link of the Swaggert HTTP docs was "http://localhost:8O00/docs" instead of "http://localhost:8000/docs"

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
