### PR TITLE
doc: fix webui link

### DIFF
--- a/docs/source/user-guides/local-models.md
+++ b/docs/source/user-guides/local-models.md
@@ -84,7 +84,7 @@ You have a choice of choosing one among the below-mentioned local LLM tools. We 
 You can then download the results following the steps described [below](#download-inference-results)
 
 ## Ollama
-[Ollama](https://github.com/ollama/ollama) provides a simplified way to download, manage, and interact with various open-source LLMs either from the command line or with [web UI](https://docs.openwebui.com/).
+[Ollama](https://github.com/ollama/ollama) provides a simplified way to download, manage, and interact with various open-source LLMs either from the command line or with [web UI](https://github.com/open-webui/open-webui/).
 
 ### Procedure
 
@@ -176,7 +176,7 @@ user@host:~/$ export HUGGING_FACE_HUB_TOKEN=<your_huggingface_token>
 
    INFERENCE_NAME="vLLM HuggingFaceTB/SmolLM2-360M-Instruct"
    INFERENCE_DESC="Test inference with vLLM's HuggingFaceTB/SmolLM2-360M-Instruct"
-   INFERENCE_MODEL="HuggingFaceTB/SmolLM2-360M-Instruct" # Format expected vllm://<model_name>, the model_name must be same as one when running the docker container
+   INFERENCE_MODEL="HuggingFaceTB/SmolLM2-360M-Instruct" # Format expected vllm://<model_name>, the model_name must be same as one when running the docker container #pragma: allowlist secret
    INFERENCE_PROVIDER="hosted_vllm" # Provider as documented in LiteLLM https://docs.litellm.ai/docs/providers/vllm
    INFERENCE_BASE_URL="http://localhost:8090/v1" # vLLM setup to run on port 8090
 


### PR DESCRIPTION
# What's changing

[In our docs](https://github.com/mozilla-ai/lumigator/blob/main/docs/source/user-guides/local-models.md?plain=1#L87) we link to https://openwebui.com/, which is sometimes down and makes our doc build fail and look sad.
We can just as easily link to https://github.com/open-webui/open-webui , which is more often up and provides equally helpful information.

# How to test it
Test the link :) See the rendering of the markdown page.


# I already...

- [ X] Tested the changes in a working environment to ensure they work as expected
- [ NA] Added some tests for any new functionality
- [ X] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ X] Checked if a (backend) DB migration step was required and included it if required
