### PR TITLE
Modified lumigator nginx size limit to 50mb

### DIFF
--- a/lumigator/frontend/nginx/default.conf.template
+++ b/lumigator/frontend/nginx/default.conf.template
@@ -2,6 +2,7 @@ server {
     listen       80;
     listen  [::]:80;
     server_name  localhost;
+    client_max_body_size 50M;
 
     location /api {
         proxy_pass http://$LUMIGATOR_API_HOST:$LUMIGATOR_API_PORT; # This will use the API_SERVER environment variable


### PR DESCRIPTION
Ensure our Nginx matches the max_dataset_size we have currently in the backend



> If this PR is related to an issue or closes one, please link it here.

Refs #1049 
Closes #1049 

# How to test it

Steps to test the changes:

1. Upload a dataset that's bigger than 2 MB but smaller than 50MB


# Additional notes for reviewers
Getting exactly 50MB will probably fail , around 48MB will work

- [ X] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ X] Checked if a (backend) DB migration step was required and included it if required
