### PR TITLE
[BUG] Falconsai model fails due to missing parameter max_position_embeddings in HF config

### DIFF
--- a/lumigator/jobs/inference/model_clients.py
+++ b/lumigator/jobs/inference/model_clients.py
@@ -139,7 +139,7 @@ class HuggingFaceModelClient(BaseModelClient):
             logger.warning(
                 f"Tokenizer model_max_length ({self._pipeline.tokenizer.model_max_length})"
                 f" is bigger than the model's max_position_embeddings ({max_pos_emb})"
-                "Setting the tokenizer model_max_length to the model's max_position_embeddings."
+                " Setting the tokenizer model_max_length to the model's max_position_embeddings."
             )
             self._pipeline.tokenizer.model_max_length = max_pos_emb
 


### PR DESCRIPTION
To replicate the error
1. Spin up lumigator from main
2. Upload dataset 
3. Create an experiment, select Falconsai/textsummarization model from the UI 

Ray Inference Job fails with error:
```
AttributeError: 'T5Config' object has no attribute 'max_position_embeddings'
```
Because the model_config does not contain max_position_embeddings: https://huggingface.co/Falconsai/text_summarization/blob/main/config.json


Edge case from #1015  

Run an experiment with this branch. It should run without errors

# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
