### PR TITLE
HuggingFaceModelClient logic based on whether the model is seq2seq or Causal LM

### DIFF
--- a/lumigator/jobs/inference/model_clients.py
+++ b/lumigator/jobs/inference/model_clients.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from inference_config import InferenceJobConfig
 from litellm import completion
 from loguru import logger
-from transformers import AutoModelForSeq2SeqLM, AutoTokenizer, pipeline
+from transformers import AutoConfig, AutoModelForSeq2SeqLM, AutoTokenizer, pipeline
 
 
 def strip_path_prefix(path: str) -> str:
@@ -82,7 +82,11 @@ class HuggingFaceModelClient(BaseModelClient):
         self._system_prompt = config.system_prompt
         logger.info(f"System prompt: {config.system_prompt}")
         self._task = config.hf_pipeline.task
-        if self._task == "summarization":
+        # Load the model configuration to check the architecture type
+        self.hf_model_config = AutoConfig.from_pretrained(
+            config.hf_pipeline.model_name_or_path, trust_remote_code=config.hf_pipeline.trust_remote_code
+        )
+        if self._task == "summarization" and self.hf_model_config.is_encoder_decoder:
             # The summarization pipeline is only supported for Seq2Seq models
             # https://huggingface.co/docs/transformers/en/main_classes/pipelines#transformers.SummarizationPipeline
             model = AutoModelForSeq2SeqLM.from_pretrained(
@@ -107,11 +111,11 @@ class HuggingFaceModelClient(BaseModelClient):
                 device=config.hf_pipeline.device,
             )
             self._set_seq2seq_max_length()
-        elif self._task == "text-generation":
-            self._pipeline = pipeline(**config.hf_pipeline.model_dump())
         else:
-            raise ValueError(f"Unsupported task: {self._task}")
-        logger.info(f"HuggingFaceModelClient initialized with config: {config}")
+            # CausalLM models supported for summarization and translation tasks through system_prompt
+            # HF pipeline task overwritten to 'text-generation' since these causalLMs are not task-specific models
+            self._task = config.hf_pipeline.task = "text-generation"
+            self._pipeline = pipeline(**config.hf_pipeline.model_dump())
 
     def _set_seq2seq_max_length(self):
         """Make sure that the model can actually support the max_new_tokens configured.
@@ -146,6 +150,18 @@ class HuggingFaceModelClient(BaseModelClient):
             self._config.generation_config.max_new_tokens = max_pos_emb
 
     def predict(self, prompt):
+        # Case-1: Seq2seq model
+        # If we're using a summarization model, the pipeline returns a dictionary with a single key.
+        # The name of the key depends on the task (e.g., 'summary_text' for summarization).
+        # Get the name of the key and return its value.
+        if self._task == "summarization" and self.hf_model_config.is_encoder_decoder:
+            generation = self._pipeline(
+                prompt, max_new_tokens=self._config.generation_config.max_new_tokens, truncation=True
+            )[0]
+            return generation["summary_text"]
+
+        # Case-2: CausalLM model: can be used for text-generation or summarization
+        # or translation tasks with right system_prompt
         # When using a text-generation model, the pipeline returns a dictionary with a single key,
         # 'generated_text'. The value of this key is a list of dictionaries, each containing the\
         # role and content of a message. For example:
@@ -153,19 +169,9 @@ class HuggingFaceModelClient(BaseModelClient):
         #  {'role': 'user', 'content': 'What is the capital of France?'}, ...]
         # We want to return the content of the last message in the list, which is the model's
         # response to the prompt.
-        if self._task == "text-generation":
-            messages = [
-                {"role": "system", "content": self._system_prompt},
-                {"role": "user", "content": prompt},
-            ]
-            generation = self._pipeline(messages, max_new_tokens=self._config.generation_config.max_new_tokens)[0]
-            return generation["generated_text"][-1]["content"]
-
-        # If we're using a summarization model, the pipeline returns a dictionary with a single key.
-        # The name of the key depends on the task (e.g., 'summary_text' for summarization).
-        # Get the name of the key and return its value.
-        if self._task == "summarization":
-            generation = self._pipeline(
-                prompt, max_new_tokens=self._config.generation_config.max_new_tokens, truncation=True
-            )[0]
-            return generation["summary_text"]
+        messages = [
+            {"role": "system", "content": self._system_prompt},
+            {"role": "user", "content": prompt},
+        ]
+        generation = self._pipeline(messages, max_new_tokens=self._config.generation_config.max_new_tokens)[0]
+        return generation["generated_text"][-1]["content"]

--- a/notebooks/requirements.txt
+++ b/notebooks/requirements.txt
@@ -1,6 +1,7 @@
 -e ../lumigator/schemas
 -e ../lumigator/sdk
 datasets==2.20.0
+ipython==8.32.0
 ipywidgets==8.1.3
 jupyterlab==4.2.5
 loguru==0.7.2


### PR DESCRIPTION
# What's changing

HuggingFaceModelClient initialization and inference logic was based purely on task.

This PR updates it to be conditional based on task and whether the model is seq2seq.

This is because for seq2seq models (e.g. BART), we can call the HF pipeline with specific tasks like summarization or translation.

But for CausalLM models (e.g. Llama), HF pipeline should be called with the task as the generic "text-generation". Whether to perform summarization or translation or something else would be dictated by the system_prompt. 

Also if we call CausalLM pipepine with task as "summarization", it throws the following error:
```
ValueError: Unrecognized configuration class <class 'transformers.models.llama.configuration_llama.LlamaConfig'> for this kind of AutoModel: AutoModelForSeq2SeqLM.
Model type should be one of BartConfig, BigBirdPegasusConfig, BlenderbotConfig, BlenderbotSmallConfig, EncoderDecoderConfig, FSMTConfig, GPTSanJapaneseConfig, LEDConfig, LongT5Config, M2M100Config, MarianConfig, MBartConfig, MT5Config, MvpConfig, NllbMoeConfig, PegasusConfig, PegasusXConfig, PLBartConfig, ProphetNetConfig, Qwen2AudioConfig, SeamlessM4TConfig, SeamlessM4Tv2Config, SwitchTransformersConfig, T5Config, UMT5Config, XLMProphetNetConfig.
```






# How to test it

Steps to test the changes:

1. Upload dataset
2. Create experiment and run workflow
```
curl -X 'POST' \
  'http://localhost:8000/api/v1/experiments/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "name": "causal LM",
  "description": "summarization",
  "dataset": "bc6f834a-d412-4ff1-9d60-4032b918db4e",
  "max_samples": 1,
  "task_definition": {
    "task": "summarization"
  }
}'
```

```
curl -X 'POST' \
  'http://localhost:8000/api/v1/workflows/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "name": "causal LM",
  "description": "summarization",
  "experiment_id": "1",
  "task_definition": {
    "task": "summarization"
  },
  "model": "HuggingFaceTB/SmolLM2-1.7B-Instruct",
  "provider": "hf",
  "dataset": "bc6f834a-d412-4ff1-9d60-4032b918db4e",
  "max_samples": 1
}'
```

The above error is shown in ray logs when running from `main` but is fixed when running from this branch.

# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
