### PR TITLE
Fix DB default location

### DIFF
--- a/.default.conf
+++ b/.default.conf
@@ -36,7 +36,7 @@ MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin # pragma: allowlist secret
 MINIO_API_CORS_ALLOW_ORIGIN="*"
 DEPLOYMENT_TYPE=local
-DATABASE_URL=sqlite:///local.db
+DATABASE_URL=sqlite:////db-data/local.db
 # LUMIGATOR_API_CORS_ALLOWED_ORIGINS:
 # Array of origins (See: https://developer.mozilla.org/en-US/docs/Glossary/Origin)
 # that should be allowed to make Cross-Domain (CORS) API requests to the Lumigator backend API.


### PR DESCRIPTION
# What's changing

The default location for the DB is restored to the mounted `/db-data/local.db` path.

Closes #1077 

# How to test it

1. Start Lumigator
2. Upload a dataset and perform an experiment
3. Restart Lumigator
4. The dataset and experiment data should still be present

# Additional notes for reviewers

N/A

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
  - No DB change needed
