### PR TITLE
Fix generated dataset filenames

### DIFF
--- a/lumigator/backend/backend/services/jobs.py
+++ b/lumigator/backend/backend/services/jobs.py
@@ -418,7 +418,7 @@ class JobService:
         # - annotation jobs do not run in workflows => they trigger dataset saving here at job level
         # As JobType.ANNOTATION is not used uniformly throughout our code yet, we rely on the already
         # existing `store_to_dataset` parameter to explicitly trigger this in the annotation case
-        if ("store_to_dataset" in request.job_config.model_dump()) and request.job_config.store_to_dataset:
+        if getattr(request.job_config, "store_to_dataset", False):
             self.add_background_task(
                 self._background_tasks,
                 self.handle_annotation_job,

--- a/lumigator/backend/backend/services/workflows.py
+++ b/lumigator/backend/backend/services/workflows.py
@@ -108,7 +108,7 @@ class WorkflowService:
         request_dataset = self._dataset_service.get_dataset(dataset_id=request.dataset)
         dataset_filename = request_dataset.filename
         dataset_filename = Path(dataset_filename).stem
-        dataset_filename = f"{dataset_filename}-{request.model}-predictions.csv"
+        dataset_filename = f"{dataset_filename}-{request.model.replace('/', '-')}-predictions.csv"
 
         # Inference jobs produce a new dataset
         # Add the dataset to the (local) database

--- a/lumigator/backend/backend/services/workflows.py
+++ b/lumigator/backend/backend/services/workflows.py
@@ -104,12 +104,20 @@ class WorkflowService:
             # raise Exception(f"Inference job {inference_job.id} failed")
             return
 
+        # Figure out the dataset filename
+        request_dataset = self._dataset_service.get_dataset(dataset_id=request.dataset)
+        dataset_filename = request_dataset.filename
+        dataset_filename = Path(dataset_filename).stem
+        dataset_filename = f"{dataset_filename}-{request.model}-predictions.csv"
+
         # Inference jobs produce a new dataset
         # Add the dataset to the (local) database
         self._job_service._add_dataset_to_db(
             inference_job.id,
             job_infer_create,
             self._dataset_service.s3_filesystem,
+            dataset_filename,
+            request_dataset.generated,
         )
         # log the job to the tracking client
         inf_path = f"{settings.S3_BUCKET}/{self._job_service._get_results_s3_key(inference_job.id)}"


### PR DESCRIPTION
# What's changing

Annotations now use `{original}-annotated.csv` as filename for results, whereas inferences use `{original}-{model}-predictions.csv`,

Closes #897 

# How to test it

Try out annotations and evaluations, and check that the dataset names are according to the jobs performed.

# Additional notes for reviewers

N/A

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
  - No DB change needed.
