### PR TITLE
Deploy a Model with vLLM and Ray Serve

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -70,6 +70,7 @@ For more information about the backend routes, see the rendered API specs in the
    operations-guide/alembic
    operations-guide/local-development
    operations-guide/configure-S3
+   operations-guide/vllm-rayserve-deployment
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/operations-guide/vllm-rayserve-deployment.md
+++ b/docs/source/operations-guide/vllm-rayserve-deployment.md
@@ -1,0 +1,116 @@
+# vLLM Ray Serve deployment
+
+This guide provides step-by-step instructions to deploy a [vLLM](https://docs.vllm.ai/en/latest/)-supported model using
+[Ray Serve](https://docs.ray.io/en/latest/serve/index.html) on a Kubernetes cluster. The deployment exposes an
+OpenAI-compatible API for inference and supports advanced configurations like tensor parallelism, pipeline parallelism,
+and LoRA modules.
+
+## Prerequisites
+
+- A Kubernetes cluster with [KubeRay](https://github.com/ray-project/kuberay) installed.
+- GPU-enabled nodes for efficient inference.
+
+## Procedure
+
+1. Navigate to the `inference-service` Helm Chart, under the `infra` directory and configure your deployment, using the
+   `values.yaml` file. Here's a list of the options:
+
+   Ray Service configuration:
+
+   | Parameter                   | Description                                              | Default   |
+   |-----------------------------|----------------------------------------------------------|-----------|
+   | `inferenceServiceName`      | Name of the Ray Service (max 63 chars, DNS-compliant).   | -         |
+   | `inferenceServiceNamespace` | Namespace where the Ray Service is deployed.             | `default` |
+
+   Application configuration:
+
+   | Parameter                   | Description                                                 | Default                           |
+   |-----------------------------|-------------------------------------------------------------|-----------------------------------|
+   | `name`                      | Application name (e.g., deepseek-v3, llama-3).              | -                                 |
+   | `routePrefix`               | Route prefix for serving (e.g., "/").                       | `/`                               |
+   | `importPath`                | Import path for the model.                                  | `lumigator.jobs.vllm.serve:model` |
+   | `numReplicas`               | Number of replicas.                                         | `1`                               |
+   | `numCpus`                   | CPUs allocated per Ray actor.                               | -                                 |
+   | `workingDir`                | Model working directory.                                    | -                                 |
+   | `pip`                       | List of Python packages.                                    | `["vllm==0.7.2"]`                 |
+   | `modelID`                   | Model path (Hugging Face ID or local directory).            | -                                 |
+   | `servedModelName`           | Name of the served model.                                   | -                                 |
+   | `tensorParallelism`         | Tensor parallelism (GPUs per node).                         | -                                 |
+   | `pipelineParallelism`       | Pipeline parallelism (number of nodes).                     | -                                 |
+   | `dType`                     | Data type (`float32`, `float16`, `bfloat16`, etc.).         | -                                 |
+   | `gpuMemoryUtilization`      | Fraction of GPU memory allocated for inference.             | `0.80`                            |
+   | `distributedExecutorBackend`| Executor backend (`ray` or `mp`).                           | `ray`                             |
+   | `trustRemoteCode`           | Allow custom code from Hugging Face Hub.                    | `true`                            |
+
+   Ray Cluster configuration:
+
+   | Parameter                               | Description                                 | Default                           |
+   |-----------------------------------------|---------------------------------------------|-----------------------------------|
+   | `image`                                 | Docker image for Ray nodes.                 | `rayproject/ray:2.41.0-py311-gpu` |
+   | `dashboardHost`                         | Ray dashboard host.                         | `0.0.0.0`                         |
+   | `objectStoreMemory`                     | Object store memory allocation (bytes).     | `1000000000`                      |
+   | `persistentVolumeClaimName`             | (Optional) PVC for model storage.           | -                                 |
+   | `headGroup.resources.limits.cpu`        | Head node CPU limit.                        | -                                 |
+   | `headGroup.resources.limits.memory`     | Head node memory limit.                     | -                                 |
+   | `headGroup.resources.limits.gpuCount`   | (Optional) Head node GPU limit.             | -                                 |
+   | `headGroup.affinity.gpuClass`           | (Optional) GPU class for head node.         | -                                 |
+   | `headGroup.affinity.region`             | (Optional) Region for head node.            | -                                 |
+   | `workerGroup.groupName`                 | Worker group name.                          | `worker-group`                    |
+   | `workerGroup.replicas`                  | Number of worker group replicas.            | `1`                               |
+   | `workerGroup.resources.limits.cpu`      | Worker node CPU limit.                      | -                                 |
+   | `workerGroup.resources.limits.memory`   | Worker node memory limit.                   | -                                 |
+   | `workerGroup.resources.limits.gpuCount` | (Optional) Worker node GPU limit.           | -                                 |
+   | `workerGroup.affinity.gpuClass`         | (Optional) GPU class for workers.           | -                                 |
+   | `workerGroup.affinity.region`           | (Optional) Region for workers.              | -                                 |
+
+1. Install the Helm Chart:
+
+   ```console
+   user@host:~/lumigator$ helm install inference-service ./infra/helm/inference-service
+   ```
+
+   ```{note}
+   Depending on the model you're trying to deploy this step may take a while to complete.
+   ```
+
+## Verify
+
+1. Port-forward the Ray dashboard:
+
+   ```console
+   user@host:~/lumigator$ kubectl port-forward svc/inference-service-ray-dashboard 8265:8265
+   ```
+
+   Navigate to `http://localhost:8265` to access the Ray dashboard. Check that the Ray Serve deployment is running
+   and the GPU resources are allocated correctly.
+
+   ```{note}
+   The name of the service may vary depending on the name you've chosen for the Ray Service.
+   ```
+
+1. Port-forward the head node of the Ray cluster:
+
+   ```
+   user@host:~/lumigator$ kubectl port-forward pod/inference-service-ray-head-0 8080:8000
+   ```
+
+   ```{note}
+   The name of the pod may vary depending on the name you've chosen for the Ray Service.
+   ```
+
+1. Invoke the model:
+
+   ```console
+   user@host:~/lumigator$ curl "http://localhost:8080/v1/chat/completions" -H "Content-Type: application/json" -d '{"model": "<model-name>", "messages": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "Hello!"}]}'
+   ```
+
+   The response should be a JSON object with the model's prediction.
+
+   ```{note}
+   Replace `<model-name>` with the name of the model you've deployed.
+   ```
+
+## Conclusion
+
+You've successfully deployed a vLLM-supported model using Ray Serve on a Kubernetes cluster. You can now use the model
+for inference and explore advanced configurations like tensor parallelism, pipeline parallelism, and LoRA modules.

--- a/infra/helm/inference-service/Chart.yaml
+++ b/infra/helm/inference-service/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: inference-service
+description: A Helm chart for deploying models on Kubernetes, using Ray and vLLM.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.1.0-alpha"
+
+# An icon for the chart. Currently pointing to the vLLM logo.
+icon: https://raw.githubusercontent.com/vllm-project/media-kit/refs/heads/main/vLLM-Logo.png

--- a/infra/helm/inference-service/README.md
+++ b/infra/helm/inference-service/README.md
@@ -1,0 +1,81 @@
+# Inference Service Helm Chart
+
+This Helm chart is used for deploying models on Kubernetes using Ray and vLLM. Installing this chart will create a Ray
+cluster and deploy a model serving application on top of it. The application will serve the model using the vLLM
+library, and other libraries that are specified in the `runtimeEnv.pip` field.
+
+## Installation
+
+To install the Helm chart, you need to have the Helm CLI installed. You can install the Helm CLI by following the
+instructions [here](https://helm.sh/docs/intro/install/). Once you have the Helm CLI installed, you can install the
+chart by running the following command:
+
+```bash
+helm install <release-name> /path/to/inference-service-chart
+```
+
+You may also want to install the Helm chart from a Helm repository. To do this, you need to add the repository to your
+Helm CLI:
+
+```bash
+helm repo add <repository-name> <repository-url>
+helm repo update
+```
+
+Then, you can install the Helm chart from the repository:
+
+```bash
+helm install <release-name> <repository-name>/<chart-name>
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the `values.yaml` file and their default values.
+
+### Inference Service Configuration
+
+| Parameter                     | Description                                                                 | Default   |
+|-------------------------------|-----------------------------------------------------------------------------|-----------|
+| `inferenceServiceName`        | The name of the Ray Service to deploy. It should be 63 characters or less and must follow the DNS naming convention. | `""`      |
+| `inferenceServiceNamespace`   | The namespace where the Ray Service will be deployed.                       | `default` |
+
+### Application Configuration
+
+| Parameter                               | Description                                                                 | Default   |
+|-----------------------------------------|-----------------------------------------------------------------------------|-----------|
+| `name`                      | The name of the application (e.g., deepseek-v3, llama-3, etc.).             | `""`      |
+| `routePrefix`               | The route prefix used for serving the application (e.g., "/").              | `/`       |
+| `importPath`                | The import path for the model to serve (e.g., lumigator.jobs.vllm.serve:model). | `lumigator.jobs.vllm.serve:model` |
+| `numReplicas`               | The number of replicas for the deployment (e.g., 1).                        | `1`       |
+| `numCpus`                   | Number of CPUs allocated for the Ray actor (e.g., 80).                      | `""`      |
+| `workingDir`     | Working directory for the model (e.g., a zip file URL).                     | `""`      |
+| `pip`            | List of Python packages to install in the runtime environment.              | `["vllm==0.7.2"]` |
+| `modelID`| The path to the model. It can either be a model ID on Hugging Face Hub or a local path to the model directory. | `""`      |
+| `servedModelName` | The name of the served model (e.g., DeepSeek-V3). This is an arbitrary name that you can use to identify the served model. | `""`      |
+| `tensorParallelism` | Tensor parallelism level (e.g., 8) - number of GPUs per node.               | `""`      |
+| `pipelineParallelism` | Pipeline parallelism level (e.g., 4) - number of nodes.                     | `""`      |
+| `dType`  | Data type (e.g., "float32", "float16", "bfloat16", etc.).                   | `""`      |
+| `gpuMemoryUtilization` | GPU memory utilization (e.g., 0.80). Controls how much of the GPU's total memory (VRAM) is allocated for the model's weights, activations, and key-value (KV) cache during inference. | `0.80`    |
+| `distributedExecutorBackend` | Executor backend for distributed computing - 'ray' for Ray, 'mp' for multiprocessing. | `ray`     |
+| `trustRemoteCode` | Whether or not to allow for custom code defined on the Hub in their own modeling, configuration, tokenization or even pipeline files. | `true`    |
+
+### Ray Cluster Configuration
+
+| Parameter                               | Description                                                                 | Default   |
+|-----------------------------------------|-----------------------------------------------------------------------------|-----------|
+| `image`                      | The Docker image to be used for both head and worker nodes (e.g., "rayproject/ray:2.41.0-py311-gpu"). | `rayproject/ray:2.41.0-py311-gpu` |
+| `dashboardHost`              | The host for the Ray dashboard (e.g., "0.0.0.0").                           | `0.0.0.0` |
+| `objectStoreMemory`          | Memory allocation for the object store (e.g., "1000000000" bytes). By default Ray allocates 30% of available memory to object storage, this leads to OOM issues for jobs. This parameter allows you to set the memory allocation for the object store to a fixed, lower value. | `1000000000` |
+| `persistentVolumeClaimName`  | (Optional) Persistent volume claim name that stores the models (e.g., "models"). Leave it empty if you don't want to use a persistent volume claim. | `""`      |
+| `headGroup.resources.limits.cpu` | CPU limit for the head node (e.g., "80").                                   | `""`      |
+| `headGroup.resources.limits.memory` | Memory limit for the head node (e.g., "1000Gi").                            | `""`      |
+| `headGroup.resources.limits.gpuCount` | (Optional) GPU limit for the head node (e.g., "8"). Leave it empty if you don't want to allocate GPUs to the head node. | `""`      |
+| `headGroup.affinity.gpuClass` | (Optional) GPU class for node selection (e.g., "A100_NVLINK_80GB"). Leave it empty if you don't want to use GPU class for node selection. | `""`      |
+| `headGroup.affinity.region`  | (Optional) Region for node selection (e.g., "US-EAST-04"). Leave it empty if you don't want to use region for node selection. | `""`      |
+| `workerGroup.groupName`      | Name of the worker group (e.g., "worker-group").                            | `worker-group` |
+| `workerGroup.replicas`       | Number of replicas for the worker group (e.g., "3").                        | `1`       |
+| `workerGroup.resources.limits.cpu` | CPU limit for the worker nodes (e.g., "80").                                | `""`      |
+| `workerGroup.resources.limits.memory` | Memory limit for the worker nodes (e.g., "1000Gi").                         | `""`      |
+| `workerGroup.resources.limits.gpuCount` | (Optional) GPU limit for the worker nodes (e.g., "8"). Leave it empty if you don't want to allocate GPUs to the worker nodes. | `""`      |
+| `workerGroup.affinity.gpuClass` | (Optional) GPU class for node selection (e.g., "A100_NVLINK_80GB"). Leave it empty if you don't want to use GPU class for node selection. | `""`      |
+| `workerGroup.affinity.region` | (Optional) Region for node selection (e.g., "US-EAST-04"). Leave it empty if you don't want to use region for node selection. | `""`      |

--- a/infra/helm/inference-service/templates/_helpers.tpl
+++ b/infra/helm/inference-service/templates/_helpers.tpl
@@ -1,0 +1,11 @@
+{{/*
+Create a default app name and namespace.
+Truncate at 63 chars since Kubernetes name fields are limited by the DNS naming spec.
+*/}}
+{{- define "inference-service.name" -}}
+{{- default .Chart.Name .Values.inferenceServiceName | trunc 63 | trimSuffix "-" }}
+{{- end}}
+
+{{- define "inference-service.namespace" -}}
+{{- default "default" .Values.inferenceServiceNamespace }}
+{{- end}}

--- a/infra/helm/inference-service/templates/inference-service.yaml
+++ b/infra/helm/inference-service/templates/inference-service.yaml
@@ -1,0 +1,132 @@
+apiVersion: ray.io/v1
+kind: RayService
+metadata:
+  name: {{ include "inference-service.name" . }}
+  namespace: {{ include "inference-service.namespace" . }}
+spec:
+  serveConfigV2: |
+    applications:
+    - name: {{ .Values.application.name }}
+      route_prefix: {{ .Values.application.routePrefix }}
+      import_path: {{ .Values.application.importPath }}
+      deployments:
+      - name: VLLMDeployment
+        num_replicas: {{ .Values.application.numReplicas }}
+        ray_actor_options:
+          num_cpus: {{ .Values.application.numCpus }}
+      runtime_env:
+        working_dir: {{ .Values.application.runtimeEnv.workingDir }}
+        pip: {{ toYaml .Values.application.runtimeEnv.pip | nindent 8 }}
+        env_vars:
+          MODEL_ID: "{{ .Values.application.runtimeEnv.envVars.modelID }}"
+          SERVED_MODEL_NAME: "{{ .Values.application.runtimeEnv.envVars.servedModelName }}"
+          TENSOR_PARALLELISM: "{{ .Values.application.runtimeEnv.envVars.tensorParallelism }}"
+          PIPELINE_PARALLELISM: "{{ .Values.application.runtimeEnv.envVars.pipelineParallelism }}"
+          DTYPE: "{{ .Values.application.runtimeEnv.envVars.dType }}"
+          GPU_MEMORY_UTILIZATION: "{{ .Values.application.runtimeEnv.envVars.gpuMemoryUtilization }}"
+          DISTRIBUTED_EXECUTOR_BACKEND: "{{ .Values.application.runtimeEnv.envVars.distributedExecutorBackend }}"
+          TRUST_REMOTE_CODE: "{{ .Values.application.runtimeEnv.envVars.trustRemoteCode }}"
+  rayClusterConfig:
+    headGroupSpec:
+      rayStartParams:
+        dashboard-host: "{{ .Values.rayCluster.dashboardHost }}"
+        object-store-memory: "{{ .Values.rayCluster.objectStoreMemory }}"
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: {{ .Values.rayCluster.image }}
+              resources:
+                limits:
+                  cpu: "{{ .Values.rayCluster.headGroup.resources.limits.cpu }}"
+                  memory: "{{ .Values.rayCluster.headGroup.resources.limits.memory }}"
+                  {{- if .Values.rayCluster.headGroup.resources.limits.gpuCount }}
+                  nvidia.com/gpu: "{{ .Values.rayCluster.headGroup.resources.limits.gpuCount }}"
+                  {{- end }}
+              {{- if .Values.rayCluster.persistentVolumeClaimName }}
+              volumeMounts:
+              - mountPath: /mnt/models
+                name: models
+              {{- end }}
+              ports:
+                - containerPort: 6379
+                  name: gcs-server
+                - containerPort: 8265
+                  name: dashboard
+                - containerPort: 10001
+                  name: client
+                - containerPort: 8000
+                  name: serve
+          {{- if .Values.rayCluster.persistentVolumeClaimName }}
+          volumes:
+          - name: models
+            persistentVolumeClaim:
+              claimName: {{ .Values.rayCluster.persistentVolumeClaimName }}
+          {{- end }}
+          {{- if or .Values.rayCluster.workerGroup.affinity.gpuClass .Values.rayCluster.workerGroup.affinity.region }}
+          affinity:
+            nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                {{- if .Values.rayCluster.workerGroup.affinity.gpuClass }}
+                - key: gpu.nvidia.com/class
+                  operator: In
+                  values:
+                  - {{ .Values.rayCluster.workerGroup.affinity.gpuClass }}
+                {{- end }}
+                {{- if .Values.rayCluster.workerGroup.affinity.region }}
+                - key: topology.kubernetes.io/region
+                  operator: In
+                  values:
+                  - {{ .Values.rayCluster.workerGroup.affinity.region }}
+                {{- end }}
+          {{- end }}
+    workerGroupSpecs:
+      - groupName: {{ .Values.rayCluster.workerGroup.groupName }}
+        replicas: {{ .Values.rayCluster.workerGroup.replicas }}
+        rayStartParams:
+          dashboard-host: "{{ .Values.rayCluster.dashboardHost }}"
+          object-store-memory: "{{ .Values.rayCluster.objectStoreMemory }}"
+        template:
+          spec:
+            containers:
+              - name: ray-worker
+                image: {{ .Values.rayCluster.image }}
+                resources:
+                  limits:
+                    cpu: "{{ .Values.rayCluster.workerGroup.resources.limits.cpu }}"
+                    memory: "{{ .Values.rayCluster.workerGroup.resources.limits.memory }}"
+                    {{- if .Values.rayCluster.workerGroup.resources.limits.gpuCount }}
+                    nvidia.com/gpu: "{{ .Values.rayCluster.workerGroup.resources.limits.gpuCount }}"
+                    {{- end }}
+                {{- if .Values.rayCluster.persistentVolumeClaimName }}
+                volumeMounts:
+                - mountPath: /mnt/models
+                  name: models
+                {{- end }}
+            {{- if .Values.rayCluster.persistentVolumeClaimName }}
+            volumes:
+            - name: models
+              persistentVolumeClaim:
+                claimName: {{ .Values.rayCluster.persistentVolumeClaimName }}
+            {{- end }}
+            {{- if or .Values.rayCluster.workerGroup.affinity.gpuClass .Values.rayCluster.workerGroup.affinity.region }}
+            affinity:
+              nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  {{- if .Values.rayCluster.workerGroup.affinity.gpuClass }}
+                  - key: gpu.nvidia.com/class
+                    operator: In
+                    values:
+                    - {{ .Values.rayCluster.workerGroup.affinity.gpuClass }}
+                  {{- end }}
+                  {{- if .Values.rayCluster.workerGroup.affinity.region }}
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                    - {{ .Values.rayCluster.workerGroup.affinity.region }}
+                  {{- end }}
+            {{- end }}

--- a/infra/helm/inference-service/values.yaml
+++ b/infra/helm/inference-service/values.yaml
@@ -1,0 +1,129 @@
+# The name of the Ray Service to deploy.
+# It should be 63 characters or less and must follow the DNS naming convention.
+inferenceServiceName: ""
+# The namespace where the Ray Service will be deployed.
+inferenceServiceNamespace: "default"
+
+# -------------------------------------------------------------------------------------------------------------------- #
+# ---------------------------------------------- Application Configuration ------------------------------------------- #
+# -------------------------------------------------------------------------------------------------------------------- #
+
+application:
+  # The name of the application (e.g., deepseek-v3, llama-3, etc.).
+  name: ""
+  # The route prefix used for serving the application (e.g., "/").
+  routePrefix: "/"
+  # The import path for the model to serve (e.g., lumigator.jobs.vllm.serve:model).
+  importPath: "lumigator.jobs.vllm.serve:model"
+  # The number of replicas for the deployment (e.g., 1).
+  numReplicas: "1"
+  # Number of CPUs allocated for the Ray actor (e.g., 80).
+  numCpus: ""
+  # Configuration for the runtime environment.
+  runtimeEnv:
+    # Working directory for the model (e.g., a zip file URL).
+    workingDir: ""
+    # List of Python packages to install in the runtime environment.
+    # Add the package name and version in the list, separated by '==' (e.g., "vllm==0.7.2").
+    pip:
+      - "vllm==0.7.2"
+    # List of environment variables to set for the application.
+    envVars:
+      # The path to the model.
+      # It can either be a model ID on Hugging Face Hub or a local path to the model directory.
+      # (e.g., 'deepseek-ai/DeepSeek-V3', '/mnt/models/DeepSeek-V3-bf16').
+      modelID: ""
+      # The name of the served model (e.g., DeepSeek-V3).
+      # This is an arbitrary name that you can use to identify the served model. It is the value that you'll pass to the
+      # "model" parameter when making inference requests to a server following the OpenAPI specification.
+      servedModelName: ""
+      # Tensor parallelism level (e.g., 8) - number of GPUs per node.
+      # If your model is too large to fit in a single GPU, but it can fit in a single node with multiple GPUs, you can
+      # use tensor parallelism. The tensor parallel size is the number of GPUs you want to use. For example, if you have
+      # 4 GPUs in a single node, you can set the tensor parallel size to 4.
+      tensorParallelism: ""
+      # Pipeline parallelism level (e.g., 4) - number of nodes.
+      # If your model is too large to fit in a single node, you can use tensor parallel together with pipeline
+      # parallelism. The tensor parallel size is the number of GPUs you want to use in each node, and the pipeline
+      # parallel size is the number of nodes you want to use. For example, if you have 16 GPUs in 2 nodes (8 GPUs per
+      # node), you can set the tensor parallel size to 8 and the pipeline parallel size to 2.
+      pipelineParallelism: ""
+      # Data type (e.g., "float32", "float16", "bfloat16", etc.).
+      dType: ""
+      # GPU memory utilization (e.g., 0.80).
+      # Controls how much of the GPU's total memory (VRAM) is allocated for the model's weights, activations, and
+      # key-value (KV) cache during inference. This sets a safety margin so that system processes, CUDA context, or
+      # other applications can find their place in GPU’s memory without causing out-of-memory issues to your inference
+      # process.
+      gpuMemoryUtilization: "0.80"
+      # Executor backend for distributed computing - 'ray' for Ray, 'mp' for multipocessing.
+      # Multiprocessing (mp) will be used by default when not running in a Ray placement group and if there are
+      # sufficient GPUs available on the same node for the configured 'tensorParallelism', otherwise Ray will be used.
+      distributedExecutorBackend: "ray"
+      # Whether or not to allow for custom code defined on the Hub in their own modeling, configuration, tokenization or
+      # even pipeline files. This option should only be set to True for repositories you trust and in which you have
+      # read the code, as it will execute code present on the Hub on your local machine.
+      trustRemoteCode: "true"
+
+# -------------------------------------------------------------------------------------------------------------------- #
+# ---------------------------------------------- Ray Cluster Configuration ------------------------------------------- #
+# -------------------------------------------------------------------------------------------------------------------- #
+
+rayCluster:
+  # The Docker image to be used for both head and worker nodes (e.g., "rayproject/ray:2.41.0-py311-gpu").
+  image: "rayproject/ray:2.41.0-py311-gpu"
+  # The host for the Ray dashboard (e.g., "0.0.0.0").
+  dashboardHost: "0.0.0.0"
+  # Memory allocation for the object store (e.g., "1000000000" bytes).
+  # By default Ray allocates 30% of available memory to object storage, this leads to OOM issues for jobs.
+  # This parametere allows you to set the memory allocation for the object store to a fixed, lower value.
+  objectStoreMemory: "1000000000" # 1GB
+  # (Optional) Persistent volume claim name that stores the models (e.g., "models").
+  # Leave it empty if you don't want to use a persistent volume claim.
+  persistentVolumeClaimName: ""
+  # Configuration for the head node of the Ray cluster.
+  headGroup:
+    # Resource requests and limits for the head node
+    resources:
+      limits:
+        # CPU limit (e.g., "80")
+        cpu: ""
+        # Memory limit (e.g., "1000Gi")
+        memory: ""
+        # GPU limit (e.g., "8").
+        # (Optional) Leave it empty if you don't want to allocate GPUs to the head node.
+        gpuCount: ""
+    # (Optional) Node affinity for scheduling the head node.
+    # Leave both fields empty if you don't want to use node affinity.
+    affinity:
+      # (Optional) GPU class for node selection (e.g., "A100_NVLINK_80GB").
+      # Leave it empty if you don't want to use GPU class for node selection.
+      gpuClass: ""
+      # (Optional) Region for node selection (e.g., "US-EAST-04").
+      # Leave it empty if you don't want to use region for node selection.
+      region: ""
+  # Configuration for worker nodes in the Ray cluster
+  workerGroup:
+    # Name of the worker group (e.g., "worker-group")
+    groupName: "worker-group"
+    # Number of replicas for the worker group (e.g., "3")
+    replicas: "1"
+    # Resource requests and limits for the worker nodes
+    resources:
+      limits:
+        # CPU limit (e.g., "80")
+        cpu: ""
+        # Memory limit (e.g., "1000Gi")
+        memory: ""
+        # (Optional) GPU limit (e.g., "8")
+        # Leave it empty if you don't want to allocate GPUs to the worker nodes.
+        gpuCount: ""
+    # (Optional) Node affinity for scheduling the worker nodes.
+    # Leave both fields empty if you don't want to use node affinity.
+    affinity:
+      # (Optional) GPU class for node selection (e.g., "A100_NVLINK_80GB").
+      # Leave it empty if you don't want to use GPU class for node selection.
+      gpuClass: ""
+      # (Optional) Region for node selection (e.g., "US-EAST-04").
+      # Leave it empty if you don't want to use region for node selection.
+      region: ""

--- a/lumigator/rayserve/README.md
+++ b/lumigator/rayserve/README.md
@@ -1,0 +1,32 @@
+# vLLM Ray Serve Deployment
+
+This repository provides a [Ray Serve](https://docs.ray.io/en/latest/serve/index.html) deployment for running any
+[vLLM](https://docs.vllm.ai/en/latest/)-supported model on a Kubernetes cluster. The deployment is built using FastAPI
+and exposes an OpenAI-compatible API for inference.
+
+## Prerequisites
+
+  - Kubernetes cluster with [KubeRay](https://github.com/ray-project/kuberay) installed.
+  - GPU-enabled nodes for efficient inference.
+
+## Features
+
+  - Supports any vLLM-compatible model.
+  - OpenAI API-compatible `/v1/chat/completions`` endpoint.
+  - LoRA modules and prompt adapters support.
+  - Optimized for Kubernetes deployment with Ray Serve.
+
+## Environment Variables
+
+The script expects the following environment variables:
+
+| Variable                      | Description                                                                         |
+|-------------------------------|-------------------------------------------------------------------------------------|
+| `MODEL_ID`                    | The identifier for the model to be deployed (e.g., `deepseek-ai/DeepSeek-V3`).      |
+| `SERVED_MODEL_NAME`           | The name under which the model will be served.                                      |
+| `TENSOR_PARALLELISM`          | Number of tensor parallelism partitions for model inference (i.e., number of GPUs). |
+| `PIPELINE_PARALLELISM`        | Number of pipeline parallelism stages (i.e., number of nodes).                      |
+| `DTYPE`                       | Weights data type (e.g., `float16`, `bfloat16`, etc.).                              |
+| `GPU_MEMORY_UTILIZATION`      | Fraction of GPU memory to be used for the model (e.g., `"0.8"` for 80%).            |
+| `DISTRIBUTED_EXECUTOR_BACKEND`| The backend used for distributed execution (`ray` or `mp`).                         |
+| `TRUST_REMOTE_CODE`           | Whether to allow loading external model code (`"true"` or `"false"`).               |

--- a/lumigator/rayserve/serve.py
+++ b/lumigator/rayserve/serve.py
@@ -1,0 +1,151 @@
+import logging
+import os
+
+from fastapi import FastAPI
+from ray import serve
+from starlette.requests import Request
+from starlette.responses import JSONResponse, StreamingResponse
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.engine.async_llm_engine import AsyncLLMEngine
+from vllm.entrypoints.logger import RequestLogger
+from vllm.entrypoints.openai.cli_args import make_arg_parser
+from vllm.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ErrorResponse,
+)
+from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
+from vllm.entrypoints.openai.serving_models import BaseModelPath, LoRAModulePath, OpenAIServingModels, PromptAdapterPath
+from vllm.utils import FlexibleArgumentParser
+
+logger = logging.getLogger("ray.serve")
+
+app = FastAPI()
+
+
+@serve.deployment(name="VLLMDeployment")
+@serve.ingress(app)
+class VLLMDeployment:
+    def __init__(
+        self,
+        engine_args: AsyncEngineArgs,
+        response_role: str,
+        lora_modules: list[LoRAModulePath] | None = None,
+        prompt_adapters: list[PromptAdapterPath] | None = None,
+        request_logger: RequestLogger | None = None,
+        chat_template: str | None = None,
+    ):
+        # See: https://github.com/vllm-project/vllm/issues/8402#issuecomment-2489432973
+        if "CUDA_VISIBLE_DEVICES" in os.environ:
+            del os.environ["CUDA_VISIBLE_DEVICES"]
+
+        logger.info(f"Starting with engine args: {engine_args}")
+        self.openai_serving_chat = None
+        self.engine_args = engine_args
+        self.response_role = response_role
+        self.lora_modules = lora_modules
+        self.prompt_adapters = prompt_adapters
+        self.request_logger = request_logger
+        self.chat_template = chat_template
+
+        self.engine = AsyncLLMEngine.from_engine_args(engine_args)
+
+    @app.post("/v1/chat/completions")
+    async def create_chat_completion(self, request: ChatCompletionRequest, raw_request: Request):
+        """OpenAI-compatible HTTP endpoint.
+
+        API reference:
+            - https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
+        """
+        if not self.openai_serving_chat:
+            model_config = await self.engine.get_model_config()
+            logger.info(f"Model config: {model_config}")
+
+            # Determine the name of the served model for the OpenAI client.
+            model_path = BaseModelPath(self.engine_args.served_model_name[0], self.engine_args.model)
+            logger.info(f"Serving model: {model_path}")
+
+            models = OpenAIServingModels(
+                engine_client=self.engine,
+                model_config=model_config,
+                base_model_paths=[model_path],
+                lora_modules=self.lora_modules,
+                prompt_adapters=self.prompt_adapters,
+            )
+
+            self.openai_serving_chat = OpenAIServingChat(
+                self.engine,
+                model_config,
+                models,
+                self.response_role,
+                request_logger=self.request_logger,
+                chat_template=self.chat_template,
+                chat_template_content_format="auto",
+            )
+
+        logger.info(f"Request: {request}")
+        generator = await self.openai_serving_chat.create_chat_completion(request, raw_request)
+
+        if isinstance(generator, ErrorResponse):
+            return JSONResponse(content=generator.model_dump(), status_code=generator.code)
+        if request.stream:
+            return StreamingResponse(content=generator, media_type="text/event-stream")
+        else:
+            assert isinstance(generator, ChatCompletionResponse)
+            return JSONResponse(content=generator.model_dump())
+
+
+def parse_vllm_args(cli_args: dict[str, str], trust_remote_code: bool):
+    """Parses vLLM args based on CLI inputs.
+
+    Currently uses argparse because vLLM doesn't expose Python models for all of the
+    config options we want to support.
+    """
+    arg_parser = FlexibleArgumentParser(description="vLLM OpenAI-Compatible RESTful API server.")
+
+    parser = make_arg_parser(arg_parser)
+    arg_strings = []
+    for key, value in cli_args.items():
+        arg_strings.extend([f"--{key}", str(value)])
+    if trust_remote_code:
+        arg_strings.extend(["--trust-remote-code"])
+
+    logger.info(arg_strings)
+    parsed_args = parser.parse_args(args=arg_strings)
+    return parsed_args
+
+
+def build_app(cli_args: dict[str, str], trust_remote_code: bool = False) -> serve.Application:
+    """Builds the Serve app based on CLI arguments.
+
+    See https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#command-line-arguments-for-the-server
+    for the complete set of arguments.
+
+    Supported engine arguments: https://docs.vllm.ai/en/latest/models/engine_args.html.
+    """  # noqa: E501
+    parsed_args = parse_vllm_args(cli_args, trust_remote_code)
+    engine_args = AsyncEngineArgs.from_cli_args(parsed_args)
+    engine_args.worker_use_ray = True
+
+    return VLLMDeployment.bind(
+        engine_args,
+        parsed_args.response_role,
+        parsed_args.lora_modules,
+        parsed_args.prompt_adapters,
+        cli_args.get("request_logger"),
+        parsed_args.chat_template,
+    )
+
+
+model = build_app(
+    {
+        "model": os.environ["MODEL_ID"],
+        "served-model-name": os.environ["SERVED_MODEL_NAME"],
+        "tensor-parallel-size": os.environ["TENSOR_PARALLELISM"],
+        "pipeline-parallel-size": os.environ["PIPELINE_PARALLELISM"],
+        "dtype": os.environ["DTYPE"],
+        "gpu-memory-utilization": os.environ["GPU_MEMORY_UTILIZATION"],
+        "distributed_executor_backend": os.environ["DISTRIBUTED_EXECUTOR_BACKEND"],
+    },
+    trust_remote_code=True if os.getenv("TRUST_REMOTE_CODE", None) == "true" else False,
+)


### PR DESCRIPTION
# What's changing

Introduce the Helm Chart and Python source code to deploy any vLLM-supported model on a Kubernetes cluster, using vLLM and Ray Serve.

Refs #952

# How to test it

Follow the corresponding operations guide, available in the PR.

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [x] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
