### PR TITLE
[BUG] Mlflow data was not being persisted on container recreation

### DIFF
--- a/.default.conf
+++ b/.default.conf
@@ -27,16 +27,16 @@ HF_TOKEN=
 MISTRAL_API_KEY=
 # Access token to use when attempting to interact with OpenAI's API
 OPENAI_API_KEY=
-# MLFlow Configuration
-MLFLOW_TRACKING_URI=http://mlflow:5000
-MLFLOW_DATABASE_URL=sqlite:///mlflow.db
-MLFLOW_S3_ROOT_PATH=s3://mlflow
 # S3 Configuration (MinIO)
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin # pragma: allowlist secret
 MINIO_API_CORS_ALLOW_ORIGIN="*"
 DEPLOYMENT_TYPE=local
 DATABASE_URL=sqlite:////db-data/local.db
+# MLFlow Configuration
+MLFLOW_TRACKING_URI=http://mlflow:5000
+MLFLOW_DATABASE_URL=sqlite:////db-data/mlflow.db
+MLFLOW_S3_ROOT_PATH=s3://${S3_BUCKET}/mlflow
 # LUMIGATOR_API_CORS_ALLOWED_ORIGINS:
 # Array of origins (See: https://developer.mozilla.org/en-US/docs/Glossary/Origin)
 # that should be allowed to make Cross-Domain (CORS) API requests to the Lumigator backend API.

--- a/.default.conf
+++ b/.default.conf
@@ -27,16 +27,16 @@ HF_TOKEN=
 MISTRAL_API_KEY=
 # Access token to use when attempting to interact with OpenAI's API
 OPENAI_API_KEY=
+# MLFlow Configuration
+MLFLOW_TRACKING_URI=http://mlflow:5000
+MLFLOW_DATABASE_URL=sqlite:////db-data/mlflow.db
+MLFLOW_S3_ROOT_PATH=s3://${S3_BUCKET}/mlflow
 # S3 Configuration (MinIO)
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin # pragma: allowlist secret
 MINIO_API_CORS_ALLOW_ORIGIN="*"
 DEPLOYMENT_TYPE=local
 DATABASE_URL=sqlite:////db-data/local.db
-# MLFlow Configuration
-MLFLOW_TRACKING_URI=http://mlflow:5000
-MLFLOW_DATABASE_URL=sqlite:////db-data/mlflow.db
-MLFLOW_S3_ROOT_PATH=s3://${S3_BUCKET}/mlflow
 # LUMIGATOR_API_CORS_ALLOWED_ORIGINS:
 # Array of origins (See: https://developer.mozilla.org/en-US/docs/Glossary/Origin)
 # that should be allowed to make Cross-Domain (CORS) API requests to the Lumigator backend API.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -230,6 +230,8 @@ services:
       - "localhost:host-gateway"
     profiles:
       - local
+    volumes:
+      - mlflow-database-data:/db-data
 
 volumes:
     minio-data:
@@ -242,5 +244,8 @@ volumes:
       labels:
         ai.mozilla.product_name: lumigator
     ray-pip-cache:
+      labels:
+        ai.mozilla.product_name: lumigator
+    mlflow-database-data:
       labels:
         ai.mozilla.product_name: lumigator


### PR DESCRIPTION
# What's changing

Mlflow was mapping to a sqlite location that wasn't persisted outside the container, meaning that it would be reset whenever the container was removed or re-created.

> If this PR is related to an issue or closes one, please link it here.

Refs #1135 

# How to test it

Steps to test the changes:

1. `make start-lumigator-build`
2. `run experiment + workflow`
3. `make stop-lumigator`
4. `make start-lumigator-build`
5. Check the UI / Mlflow and see that everything is still there.

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
