### PR TITLE
Job: Redaction - Add case for redaction where the value is an object

### DIFF
--- a/lumigator/schemas/lumigator_schemas/redactor.py
+++ b/lumigator/schemas/lumigator_schemas/redactor.py
@@ -25,8 +25,10 @@ class Redactor:
                 return {k: redact_value(k, v) for k, v in value.items()}
             elif isinstance(value, list):
                 return [redact_value(key, v) for v in value]  # Use parent key for lists
-            elif isinstance(value, str):
-                return next((self.redaction_value for pattern in self.sensitive_patterns if pattern.search(key)), value)
+            elif hasattr(value, "__dict__"):
+                return {k: redact_value(k, v) for k, v in value.__dict__.items()}  # Treat objects like dicts
+            elif any(pattern.search(key) for pattern in self.sensitive_patterns):
+                return self.redaction_value
             return value
 
         return {k: redact_value(k, v) for k, v in data.items()}

--- a/lumigator/schemas/lumigator_schemas/tests/unit/test_redactor.py
+++ b/lumigator/schemas/lumigator_schemas/tests/unit/test_redactor.py
@@ -10,6 +10,12 @@ sensitive_patterns = [
 ]
 
 
+class _TestObject:
+    def __init__(self, name, secret):
+        self.name = name
+        self.secret = secret
+
+
 @pytest.mark.parametrize(
     "redaction_value, input_data, expected_output",
     [
@@ -38,6 +44,18 @@ sensitive_patterns = [
             "HIDDEN",
             {"config": {"api_key": "abcdef", "nested": {"secret": "hidden"}}},
             {"config": {"api_key": "HIDDEN", "nested": {"secret": "HIDDEN"}}},  # pragma: allowlist secret
+        ),
+        # Object redaction (treating objects like dictionaries)
+        (
+            "<REDACTED>",
+            {"user": _TestObject("user1", "mysecret")},
+            {"user": {"name": "user1", "secret": "<REDACTED>"}},
+        ),
+        # Non-sensitive data (no redaction)
+        (
+            "<REDACTED>",
+            {"username": "user1", "email": "user1@example.com"},
+            {"username": "user1", "email": "user1@example.com"},
         ),
     ],
 )


### PR DESCRIPTION
# What's changing

Adds a case (and tests) for redaction where the value associated with a key in a dict is an object.

# How to test it

Unit tests have been updated to cover this.

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [x] Added some tests for any new functionality
- [x] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
