### PR TITLE
Move back to setting the API key in the runtime env

### DIFF
--- a/lumigator/backend/backend/services/workflows.py
+++ b/lumigator/backend/backend/services/workflows.py
@@ -75,7 +75,7 @@ class WorkflowService:
         workflow: WorkflowResponse,
         request: WorkflowCreateRequest,
     ):
-        """Currently this is our only "workflow. As we make this more flexible to handle different
+        """Currently this is our only workflow. As we make this more flexible to handle different
         sequences of jobs, we'll need to refactor this function to be more generic.
         """
         # input is WorkflowCreateRequest, we need to split the configs and generate one

--- a/lumigator/backend/backend/tests/integration/api/routes/test_api_workflows.py
+++ b/lumigator/backend/backend/tests/integration/api/routes/test_api_workflows.py
@@ -488,7 +488,6 @@ def _test_launch_job_with_secret(
         description="Test run for Huggingface model",
         dataset=str(created_dataset.id),
         max_samples=2,
-        api_keys=secret_name,
         job_config=JobInferenceConfig(
             model="open-mistral-7b",
             provider="mistral",

--- a/lumigator/backend/backend/tests/unit/services/test_job_service.py
+++ b/lumigator/backend/backend/tests/unit/services/test_job_service.py
@@ -103,19 +103,19 @@ def test_set_model(job_service, model, provider, input_base_url, returned_base_u
     assert base_url == returned_base_url
 
 
-def test_check_api_key_in_job_creation(
+def test_check_api_key_not_in_job_creation_config(
     job_service, secret_service, dataset_service, valid_upload_file, dependency_overrides_fakes
 ):
     key_name = "MISTRAL_KEY"
     key_value = "12345"
 
-    def submit_ray_job_fixture_side_effect(client: JobSubmissionClient, entrypoint: RayJobEntrypoint):
+    def submit_ray_job_fixture_side_effect(_: JobSubmissionClient, entrypoint: RayJobEntrypoint):
         parsed_args = json.loads(entrypoint.config.args["--config"])
-        if parsed_args["api_key"] != key_value:
-            raise Exception(f"Passed api key <{parsed_args['api_key']}> different from expected <{key_value}>")
+        if parsed_args.get("api_key") == key_value:
+            raise Exception(f"Passed API key <{parsed_args['api_key']}> in config")
 
     test_dataset = dataset_service.upload_dataset(valid_upload_file, DatasetFormat.JOB)
-    secret_service.upload_secret(key_name, SecretUploadRequest(value="12345", description="Mistral key"))
+    secret_service.upload_secret(key_name, SecretUploadRequest(value=key_value, description="Mistral key"))
     request = JobCreate(
         name="test_run_hugging_face",
         description="Test run for Huggingface model",

--- a/lumigator/jobs/evaluator/schemas.py
+++ b/lumigator/jobs/evaluator/schemas.py
@@ -29,8 +29,6 @@ class EvalJobConfig(BaseModel):
     name: str
     dataset: DatasetConfig
     evaluation: EvaluationConfig
-    # Optional API key which can be used to access evaluation services such as GEval.
-    api_key: str | None = None
     model_config = ConfigDict(extra="forbid")
 
 

--- a/lumigator/jobs/inference/schemas.py
+++ b/lumigator/jobs/inference/schemas.py
@@ -64,8 +64,6 @@ class InferenceJobConfig(BaseModel):
     name: str
     dataset: DatasetConfig
     job: JobConfig
-    # Optional API key which can be used to access inference services such as OpenAI, or gated models in Hugging Face.
-    api_key: str | None = None
     system_prompt: str | None = None
     inference_server: InferenceServerConfig | None = None
     generation_config: GenerationConfig | None = None


### PR DESCRIPTION
# What's changing

In a previous [PR](https://github.com/mozilla-ai/lumigator/pull/1090) we wired up passing the API key to jobs, however it seems that supplying this via config opens us up to exposing the values in even more places than anticipated (rather than just to folks that log into the Ray dashboard).

It turns up via:

* Our API for Ray logs (as our current inference and eval jobs log the config)
* `results.json` as params
* MLFlow mentions it when meddling with results
* who knows where else

This change moves to using the runtime env vars supplied to Ray to hold the API key. While it is still visible in the Ray dashboard, it limits the scope of where we see it (unless someone decides to log the env vars in their job, in which case it will appear in the Ray logs - which are difficult to parse on the fly to redact, as they're just one single string for the entire log).

Once the PR is merged, I will contribute to: https://github.com/mozilla-ai/lumigator/pull/1145 to update how things are working

Apologies to @javiermtorres who was intending to follow this approach initially before I insisted on using the config. 😳 

Refs https://github.com/mozilla-ai/lumigator/issues/930

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
