### PR TITLE
Settings: annotation supports API key

### DIFF
--- a/lumigator/backend/backend/api/routes/jobs.py
+++ b/lumigator/backend/backend/api/routes/jobs.py
@@ -79,6 +79,7 @@ def create_annotation_job(
     inference_job_create_config_dict = job_create_request.job_config.model_dump()
     inference_job_create_config_dict["model"] = "facebook/bart-large-cnn"
     inference_job_create_config_dict["provider"] = "hf"
+    inference_job_create_config_dict["secret_key_name"] = job_create_request.secret_name or "hf_api_key"
     inference_job_create_config_dict["output_field"] = "ground_truth"
     inference_job_create_config_dict["store_to_dataset"] = True
     inference_job_create_config_dict["job_type"] = JobType.INFERENCE

--- a/lumigator/schemas/lumigator_schemas/jobs.py
+++ b/lumigator/schemas/lumigator_schemas/jobs.py
@@ -151,7 +151,7 @@ class JobInferenceConfig(BaseJobConfig):
     )
 
 
-class JobAnnotateConfig(BaseModel):
+class JobAnnotateConfig(BaseJobConfig):
     job_type: Literal[JobType.ANNOTATION] = JobType.ANNOTATION
     task: TaskType = Field(default=TaskType.SUMMARIZATION)
     store_to_dataset: bool = False


### PR DESCRIPTION
# What's changing

Adds `secret_key_name` to be supplied on annotation job creation (and defaults to the Lumigator/UI expectation if not)

# How to test it

Steps to test the changes:

1. Start Lumigator
2. Create a secret for Hugging Face (with anything other than the name: `hf_api_key`)
3. ... or don't and the code should expect you have set `hf_api_key`.
4 ... the model we use doesn't need a token at present, so it's just future proofing
5. Create an annotation job and supply the secret key name in the config/payload.
6. You should be able to see the actual API key value in the Ray dashboard 😳 to check it was passed through

# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
