### PR TITLE
UI: Pass secret key names for each workflow based on the provider it is targetting

### DIFF
--- a/lumigator/backend/backend/services/workflows.py
+++ b/lumigator/backend/backend/services/workflows.py
@@ -91,7 +91,7 @@ class WorkflowService:
             # we store the dataset explicitly below, so it gets queued before eval
             store_to_dataset=False,
             generation_config=request.generation_config,
-            api_key=request.secret_key_name,
+            secret_key_name=request.secret_key_name,
         )
         job_infer_create = JobCreate(
             name=f"{request.name}-inference",

--- a/lumigator/frontend/src/components/views/Settings.vue
+++ b/lumigator/frontend/src/components/views/Settings.vue
@@ -84,6 +84,7 @@ const toast = useToast()
 const maskedValue = '****************'
 
 // API key map is used to track API key names (based on the provider name) to their corresponding ref, title and whether the setting exists remotely.
+// NOTE: the key names are based on the provider name and should not be changed: ${provider}_api_key
 const apiKeyMap = new Map<
   string,
   { reference: Ref<string>; existsRemotely: boolean; title: string }

--- a/lumigator/frontend/src/sdk/experimentsService.ts
+++ b/lumigator/frontend/src/sdk/experimentsService.ts
@@ -101,6 +101,7 @@ export async function createExperimentWithWorkflows(
         experiment_id: experimentId,
         model: model.model,
         provider: model.provider,
+        secret_key_name: `${model.provider}_api_key`,
         base_url: model.base_url,
       }),
     ),

--- a/lumigator/frontend/src/sdk/experimentsService.ts
+++ b/lumigator/frontend/src/sdk/experimentsService.ts
@@ -101,7 +101,7 @@ export async function createExperimentWithWorkflows(
         experiment_id: experimentId,
         model: model.model,
         provider: model.provider,
-        secret_key_name: `${model.provider}_api_key`,
+...(model.requirements.includes('api-key') && {secret_key_name: `${model.provider}_api_key`}),
         base_url: model.base_url,
       }),
     ),

--- a/lumigator/frontend/src/types/Workflow.ts
+++ b/lumigator/frontend/src/types/Workflow.ts
@@ -52,6 +52,7 @@ export type CreateWorkflowPayload = {
   experiment_id: string
   model: string
   provider: string
+  secret_key_name?: string
   dataset: string
   max_samples: number
   base_url?: string


### PR DESCRIPTION
# What's changing

Now that jobs and workflows can be given the secret key name to grab from Lumigator and supply to underlying jobs, the UI needs to support sending in the right secret name key based on the provider.

UI has strong opinions on the name of settings saved via the UI following the format: `{provider}_api_key` and this PR continues that.

Refs: https://github.com/mozilla-ai/lumigator/issues/924

One thing we might decide later is to include some copy/content on the site explaining which settings need to be saved before you run the experiments.

# How to test it

Steps to test the changes:

1.
2.
3.

# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
