### PR TITLE
UI: fix to use `api_key` instead of `api-key`

### DIFF
--- a/lumigator/frontend/src/sdk/experimentsService.ts
+++ b/lumigator/frontend/src/sdk/experimentsService.ts
@@ -101,7 +101,9 @@ export async function createExperimentWithWorkflows(
         experiment_id: experimentId,
         model: model.model,
         provider: model.provider,
-...(model.requirements.includes('api-key') && {secret_key_name: `${model.provider}_api_key`}),
+        secret_key_name: model.requirements.includes('api_key')
+          ? `${model.provider}_api_key`
+          : undefined,
         base_url: model.base_url,
       }),
     ),


### PR DESCRIPTION
# What's changing

Fixes typo and adjusts the syntax to make it a bit easier to read.


# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
