### PR TITLE
Services: exceptions missing call to base class init

### DIFF
--- a/lumigator/backend/backend/services/exceptions/base_exceptions.py
+++ b/lumigator/backend/backend/services/exceptions/base_exceptions.py
@@ -12,6 +12,7 @@ class ServiceError(Exception):
         :param message: error message
         :param exc: optional exception
         """
+        super().__init__(message)
         self.message = message
         self.exc = exc
 


### PR DESCRIPTION
# What's changing

Fix the missing call to the Exception base class to supply the message in service exceptions.

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
