### PR TITLE
feat(models): replaced deprecated mistral-7B with ministral -8B

### DIFF
--- a/docs/source/get-started/suggested-models.md
+++ b/docs/source/get-started/suggested-models.md
@@ -86,7 +86,7 @@ launched it.
 | seq2seq    | facebook/bart-large-cnn                  |      X      |     |           |
 | seq2seq    | Falconsai/text_summarization             |      X      |     |           |
 | causal     | gpt-4o-mini, gpt-4o                      |             |  X  |           |
-| causal     | open-mistral-7b                          |             |  X  |           |
+| causal     | Ministral-8B                          |             |  X  |           |
 | causal     | Mistral-7B-Instruct                      |             |     |     X     |
 
 ## BART Large CNN
@@ -142,11 +142,10 @@ The GPT-4o Mini and GPT-4o models are causal language models developed by OpenAI
 
 There are no summarization-specific parameters for these models.
 
-## Open Mistral 7B
+## Ministral 8B
 
-The [Open Mistral 7B](https://mistral.ai/news/announcing-mistral-7b/) model is a causal language
-model developed by [Mistral AI](https://mistral.ai/). It is the smaller version of the
-Mistral AI family of models.
+The [Ministral 8B](https://mistral.ai/news/ministraux) model is an open, causal language
+model developed by [Mistral AI](https://mistral.ai/). It is a small but powerful edge model.
 
 There are no summarization-specific parameters for this model.
 

--- a/lumigator/backend/backend/models.yaml
+++ b/lumigator/backend/backend/models.yaml
@@ -78,11 +78,11 @@
     - summarization:
     - translation:
 
-- display_name: open-mistral-7b
-  model: open-mistral-7b
+- display_name: ministral-8b-latest
+  model: ministral-8b-latest
   provider: mistral
   website_url: https://mistral.ai/technology/#models
-  description: Mistral's 7B model, hosted by mistral
+  description: Mistral's 8B model, hosted by mistral
   requirements:
     - api_key
   tasks:

--- a/lumigator/backend/backend/models.yaml
+++ b/lumigator/backend/backend/models.yaml
@@ -78,7 +78,7 @@
     - summarization:
     - translation:
 
-- display_name: ministral-8b-latest
+- display_name: ministral-8b
   model: ministral-8b-latest
   provider: mistral
   website_url: https://mistral.ai/technology/#models

--- a/lumigator/backend/backend/tests/integration/api/routes/test_api_workflows.py
+++ b/lumigator/backend/backend/tests/integration/api/routes/test_api_workflows.py
@@ -492,7 +492,7 @@ def _test_launch_job_with_secret(
         dataset=str(created_dataset.id),
         max_samples=2,
         job_config=JobInferenceConfig(
-            model="open-mistral-7b",
+            model="ministral-8b-latest",
             provider="mistral",
         ),
     )
@@ -515,7 +515,7 @@ def _test_launch_job_with_secret(
         max_samples=2,
         api_keys=[secret_name],
         job_config=JobInferenceConfig(
-            model="open-mistral-7b",
+            model="ministral-8b-latest",
             provider="mistral",
         ),
     )

--- a/lumigator/backend/backend/tests/unit/api/routes/test_jobs.py
+++ b/lumigator/backend/backend/tests/unit/api/routes/test_jobs.py
@@ -129,7 +129,7 @@ def test_missing_api_key_in_job_creation(
         max_samples=2,
         api_keys=key_name,
         job_config=JobInferenceConfig(
-            model="open-mistral-7b",
+            model="ministral-8b-latest",
             provider="mistral",
         ),
     )

--- a/lumigator/backend/backend/tests/unit/services/test_job_service.py
+++ b/lumigator/backend/backend/tests/unit/services/test_job_service.py
@@ -82,7 +82,7 @@ def test_set_explicit_inference_job_params(job_record, job_service):
         # openai model (from API)
         ("gpt-4-turbo", "openai", "https://api.openai.com/v1", settings.OAI_API_URL),
         # mistral model (from API)
-        ("open-mistral-7b", "mistral", "https://api.mistral.ai/v1", settings.MISTRAL_API_URL),
+        ("ministral-8b-latest", "mistral", "https://api.mistral.ai/v1", settings.MISTRAL_API_URL),
         # deepseek model (from API)
         ("deepseek-chat", "deepseek", "https://api.deepseek.com/v1", settings.DEEPSEEK_API_URL),
     ],

--- a/notebooks/walkthrough.ipynb
+++ b/notebooks/walkthrough.ipynb
@@ -568,7 +568,7 @@
     "#    'Falconsai/text_summarization',\n",
     "#\n",
     "# Decoder models\n",
-    "#    'mistral/open-mistral-7b',\n",
+    "#    'mistral/ministral-8b-latest',\n",
     "#\n",
     "# GPTs\n",
     "#    \"gpt-4o-mini\",\n",


### PR DESCRIPTION
# What's changing

At the end of this month, Mistral is retiring one of the models we offer via API (Mistral-7B). Ministral-8B is its replacement. This PR simply does the switch and updates info + tests.

> If this PR is related to an issue or closes one, please link it here.

Closes #569

# How to test it
There are tests targeting this model. In addition, any custom script that was using M-7B should just as easily use Ministral-8B instead.

# I already...

- [ X] Tested the changes in a working environment to ensure they work as expected
- [X ] Added some tests for any new functionality
- [X ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ NA] Checked if a (backend) DB migration step was required and included it if required
