### PR TITLE
API: Models response excludes `null`/`None` values and supplies defaults for each task value in `.tasks` 

### DIFF
--- a/lumigator/backend/backend/tests/conftest.py
+++ b/lumigator/backend/backend/tests/conftest.py
@@ -25,6 +25,7 @@ from lumigator_schemas.jobs import (
     JobStatus,
     JobType,
 )
+from lumigator_schemas.models import ModelsResponse
 from mypy_boto3_s3 import S3Client
 from s3fs import S3FileSystem
 from sqlalchemy import Engine, create_engine
@@ -524,9 +525,12 @@ def job_definition_fixture():
     )
 
 
-@pytest.fixture
-def model_specs_data():
+@pytest.fixture(scope="function")
+def model_specs_data() -> list[ModelsResponse]:
     """Fixture that loads and returns the YAML data."""
     with Path(MODELS_PATH).open() as file:
         model_specs = yaml.safe_load(file)
-    return model_specs
+
+    models = [ModelsResponse.model_validate(item) for item in model_specs]
+
+    return models

--- a/lumigator/backend/backend/tests/unit/api/routes/test_models.py
+++ b/lumigator/backend/backend/tests/unit/api/routes/test_models.py
@@ -1,5 +1,3 @@
-import json
-
 from fastapi.testclient import TestClient
 from lumigator_schemas.extras import ListingResponse
 from lumigator_schemas.models import ModelsResponse
@@ -7,31 +5,31 @@ from lumigator_schemas.models import ModelsResponse
 from backend.api.routes.models import _filter_models_by_tasks, _get_supported_tasks
 
 
-def test_get_suggested_models_single_task_ok(app_client: TestClient, model_specs_data: dict):
+def test_get_suggested_models_single_task_ok(app_client: TestClient, model_specs_data):
     response = app_client.get("/models/?tasks=summarization")
     assert response.status_code == 200
     models = ListingResponse[ModelsResponse].model_validate(response.json())
 
     # Filter models that only support summarization
-    filtered_data = _filter_models_by_tasks(model_specs_data, ["summarization"])
+    filtered_data = _filter_models_by_tasks(model_specs_data, {"summarization"})
 
     assert models.total == len(filtered_data)
     assert len(models.items) == len(filtered_data)
 
 
-def test_get_suggested_models_multiple_tasks_ok(app_client: TestClient, model_specs_data: dict):
+def test_get_suggested_models_multiple_tasks_ok(app_client: TestClient, model_specs_data):
     response = app_client.get("/models/?tasks=summarization&tasks=translation")
     assert response.status_code == 200
     models = ListingResponse[ModelsResponse].model_validate(response.json())
 
     # Filter models that support either summarization or translation
-    filtered_data = _filter_models_by_tasks(model_specs_data, ["summarization", "translation"])
+    filtered_data = _filter_models_by_tasks(model_specs_data, {"summarization", "translation"})
 
     assert models.total == len(filtered_data)
     assert len(models.items) == len(filtered_data)
 
 
-def test_get_suggested_models_no_task_specified(app_client: TestClient, model_specs_data: dict):
+def test_get_suggested_models_no_task_specified(app_client: TestClient, model_specs_data):
     # Should return all models based on your implementation
     response = app_client.get("/models/")
     assert response.status_code == 200
@@ -41,7 +39,7 @@ def test_get_suggested_models_no_task_specified(app_client: TestClient, model_sp
     assert len(models.items) == len(model_specs_data)
 
 
-def test_get_suggested_models_invalid_task(app_client: TestClient, model_specs_data: dict):
+def test_get_suggested_models_invalid_task(app_client: TestClient, model_specs_data):
     response = app_client.get("/models/?tasks=invalid_task")
     assert response.status_code == 400
 

--- a/lumigator/schemas/lumigator_schemas/models.py
+++ b/lumigator/schemas/lumigator_schemas/models.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class ModelRequirement(str, Enum):
@@ -54,6 +54,15 @@ class ModelsResponse(BaseModel):
         "or `{ModelRequirement.API_KEY}` to indicate that an API key is necessary)",
     )
     info: ModelInfo | None = Field(None, title="Model info", description="Detailed model capabilities")
-    tasks: list[dict[str, dict | None]] = Field(
+    tasks: list[dict[str, dict]] = Field(
         ..., title="Applicable tasks", description="List of tasks to which the model can be applied"
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def ensure_empty_dict_for_none_task_values(cls, values):
+        """Ensure that every task dictionary has an empty dictionary as the default for the value."""
+        values["tasks"] = [
+            {key: (value if value else {}) for key, value in task.items()} for task in values.get("tasks", [])
+        ]
+        return values


### PR DESCRIPTION
# What's changing

Improve the API by:

* removing `null` values that were seen when `info` was missing from an object
* providing an empty dict as a default for a listed `task`

Refs: https://github.com/mozilla-ai/lumigator/pull/1172

# How to test it

Steps to test the changes:

1. `make local-up`
2. Use the [API docs](http://localhost:8000/docs#/models/get_suggested_models_api_v1_models__get) to get suggested models
3. Try with no tasks query parameter, `summarization`, `translation` and `foo` to see the differences

# Additional notes for reviewers

More information here: https://github.com/mozilla-ai/lumigator/pull/1172#discussion_r1993249086

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
