### PR TITLE
GHA: Disable inference model cache for docs

### DIFF
--- a/.github/workflows/build_and_publish_docs.yaml
+++ b/.github/workflows/build_and_publish_docs.yaml
@@ -29,7 +29,7 @@ jobs:
         run: uv python install
 
       - name: Start Lumigator Docker Compose stack
-        run: make start-lumigator-build
+        run: ENABLE_FIRST_TIME_CACHE=false make start-lumigator-build
 
       - name: Check the OpenAPI spec
         run: make check-openapi-docs


### PR DESCRIPTION
# What's changing

Don't use the caching model container for the docs OpenAPI update

Refs: https://github.com/mozilla-ai/lumigator/pull/1183
Refs: https://github.com/mozilla-ai/lumigator/pull/1187

# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
