### PR TITLE
Replace task executor, split workflow

### DIFF
--- a/lumigator/backend/backend/api/deps.py
+++ b/lumigator/backend/backend/api/deps.py
@@ -16,6 +16,7 @@ from backend.repositories.secrets import SecretRepository
 from backend.services.datasets import DatasetService
 from backend.services.experiments import ExperimentService
 from backend.services.jobs import JobService
+from backend.services.jobsworkflows import JobsWorkflowService
 from backend.services.secrets import SecretService
 from backend.services.workflows import WorkflowService
 from backend.settings import settings
@@ -110,6 +111,22 @@ def get_workflow_service(
 
 
 WorkflowServiceDep = Annotated[WorkflowService, Depends(get_workflow_service)]
+
+
+def get_jobsworkflow_service(
+    session: DBSessionDep,
+    tracking_client: TrackingClientDep,
+    job_service: JobServiceDep,
+    dataset_service: DatasetServiceDep,
+    background_tasks: BackgroundTasks,
+) -> JobsWorkflowService:
+    job_repo = JobRepository(session)
+    return JobsWorkflowService(
+        job_repo, job_service, dataset_service, background_tasks, tracking_client=tracking_client
+    )
+
+
+JobsWorkflowServiceDep = Annotated[JobsWorkflowService, Depends(get_jobsworkflow_service)]
 
 
 def get_redactor() -> Redactor:

--- a/lumigator/backend/backend/api/routes/workflows.py
+++ b/lumigator/backend/backend/api/routes/workflows.py
@@ -5,10 +5,11 @@ from lumigator_schemas.jobs import JobLogsResponse
 from lumigator_schemas.workflows import (
     WorkflowCreateRequest,
     WorkflowDetailsResponse,
+    WorkflowJobsCreateRequest,
     WorkflowResponse,
 )
 
-from backend.api.deps import WorkflowServiceDep
+from backend.api.deps import JobsWorkflowServiceDep, WorkflowServiceDep
 from backend.services.exceptions.base_exceptions import ServiceError
 from backend.services.exceptions.workflow_exceptions import (
     WorkflowNotFoundError,
@@ -27,6 +28,16 @@ def workflow_exception_mappings() -> dict[type[ServiceError], HTTPStatus]:
 
 @router.post("/", status_code=status.HTTP_201_CREATED)
 async def create_workflow(service: WorkflowServiceDep, request: WorkflowCreateRequest) -> WorkflowResponse:
+    """A workflow is a single execution for an experiment.
+    A workflow is a collection of 1 or more jobs.
+    It must be associated with an experiment id,
+    which means you must already have created an experiment and have that ID in the request.
+    """
+    return WorkflowResponse.model_validate(service.create_workflow(request))
+
+
+@router.post("/new", status_code=status.HTTP_201_CREATED)
+async def create_workflow_new(service: JobsWorkflowServiceDep, request: WorkflowJobsCreateRequest) -> WorkflowResponse:
     """A workflow is a single execution for an experiment.
     A workflow is a collection of 1 or more jobs.
     It must be associated with an experiment id,

--- a/lumigator/backend/backend/services/jobs.py
+++ b/lumigator/backend/backend/services/jobs.py
@@ -60,6 +60,8 @@ job_settings_map = {
 
 DEFAULT_SKIP = 0
 DEFAULT_LIMIT = 100
+JOB_STOP_WAIT = 10
+JOB_POLL_SEC = 5
 DEFAULT_POST_INFER_JOB_TIMEOUT_SEC = 10 * 60
 JobSpecificRestrictedConfig = type[JobEvalConfig | JobInferenceConfig]
 
@@ -75,14 +77,14 @@ class JobService:
     storage_path = f"s3://{Path(settings.S3_BUCKET) / settings.S3_JOB_RESULTS_PREFIX}/"
 
     NON_TERMINAL_STATUS = [
-        JobStatus.CREATED.value,
-        JobStatus.PENDING.value,
-        JobStatus.RUNNING.value,
+        JobStatus.CREATED,
+        JobStatus.PENDING,
+        JobStatus.RUNNING,
     ]
     """list: A list of non-terminal job statuses."""
 
     # TODO: rely on https://github.com/ray-project/ray/blob/7c2a200ef84f17418666dad43017a82f782596a3/python/ray/dashboard/modules/job/common.py#L53
-    TERMINAL_STATUS = [JobStatus.FAILED.value, JobStatus.SUCCEEDED.value, JobStatus.STOPPED.value]
+    TERMINAL_STATUS = [JobStatus.FAILED, JobStatus.SUCCEEDED, JobStatus.STOPPED]
     """list: A list of terminal job statuses."""
 
     def __init__(
@@ -100,6 +102,7 @@ class JobService:
         self._dataset_service = dataset_service
         self._secret_service = secret_service
         self._background_tasks = background_tasks
+        self._tasks = dict()
 
     def _get_job_record_per_type(self, job_type: str) -> list[JobRecord]:
         records = self.job_repo.get_by_job_type(job_type)
@@ -121,8 +124,9 @@ class JobService:
 
         return record
 
-    async def stop_job(self, job_id: UUID) -> bool:
-        """Attempts to stop an existing job in Ray by ID, and waits (for up to 10 seconds) for it to 'complete'.
+    async def stop_job(self, job_id: UUID) -> tuple[bool, JobStatus]:
+        """Attempts to stop an existing job in Ray by ID, and waits
+        (for up to 10 seconds by default) for it to 'complete'.
 
         :param job_id: The ID of the job to stop
         :returns: True if the job was successfully stopped, False otherwise
@@ -131,15 +135,15 @@ class JobService:
             self._stop_job(job_id)
         except JobNotFoundError:
             # If the job is not found, we consider it stopped
-            return True
+            return True, JobStatus.STOPPED
 
         try:
-            status = await self.wait_for_job_complete(job_id, max_wait_time_sec=10)
+            status = await self._wait_for_job_complete(job_id, max_wait_time_sec=JOB_STOP_WAIT)
         except JobUpstreamError as e:
             loguru.logger.error("Failed to stop job {}: {}", job_id, e)
-            return False
+            return False, status
 
-        return status and status.lower() == JobStatus.STOPPED.value
+        return status and status.lower() == JobStatus.STOPPED.value, status
 
     def _stop_job(self, job_id: UUID):
         """Stops an existing job in Ray by ID.
@@ -321,7 +325,7 @@ class JobService:
         except json.JSONDecodeError as e:
             raise JobUpstreamError("ray", f"JSON decode error from {resp.text or ''}") from e
 
-    async def wait_for_job_complete(self, job_id, max_wait_time_sec):
+    async def _wait_for_job_complete(self, job_id, max_wait_time_sec):
         """Waits for a job to complete, or until a maximum wait time is reached.
 
         :param job_id: The ID of the job to wait for.
@@ -337,12 +341,12 @@ class JobService:
 
         # Wait for the job to complete
         elapsed_time = 0
-        while job_status not in self.TERMINAL_STATUS:
+        while JobStatus(job_status) not in self.TERMINAL_STATUS:
             if elapsed_time >= max_wait_time_sec:
                 loguru.logger.info(f"Job {job_id} did not complete within the maximum wait time.")
                 break
-            await asyncio.sleep(5)
-            elapsed_time += 5
+            await asyncio.sleep(JOB_POLL_SEC)
+            elapsed_time += JOB_POLL_SEC
             job_status = self.get_upstream_job_status(job_id)
 
         # Once the job is finished, retrieve the log and store it in the internal db
@@ -350,29 +354,80 @@ class JobService:
 
         return job_status
 
-    async def handle_annotation_job(self, job_id: UUID, request: JobCreate, max_wait_time_sec: int):
+    # FIXME rename this and the previous function
+    async def wait_for_job_finished(self, job_id, max_wait_time_sec):
+        """Waits for a job to be finished, or until a maximum wait time is reached.
+
+        :param job_id: The ID of the job to wait for.
+        :param max_wait_time: The maximum time to wait for the job to be finished.
+        :return: The status of the job when it completes.
+        :rtype: str
+        :raises JobUpstreamError: If there is an error with the upstream service returning the
+                                  job status
+        """
+        loguru.logger.info(f"Waiting for job {job_id} to finish...")
+        # Get the initial job status
+        job_status = self.get_job(job_id).status
+
+        # Wait for the job to complete
+        elapsed_time = 0
+        while JobStatus(job_status) not in self.TERMINAL_STATUS:
+            if elapsed_time >= max_wait_time_sec:
+                loguru.logger.info(f"Job {job_id} did not complete within the maximum wait time.")
+                # throw exception?
+                break
+            loguru.logger.info(f"Before sleeping for {job_id}")
+            await asyncio.sleep(JOB_POLL_SEC)
+            loguru.logger.info(f"After sleeping for {job_id}")
+            elapsed_time += JOB_POLL_SEC
+            job_status = self.get_job(job_id).status
+
+        return job_status
+
+    async def handle_post_job(
+        self, job: JobResponse, request: JobCreate, max_wait_time_sec: int, store_to_dataset_suffix: str = None
+    ):
         """Long term we maybe want to move logic about how to handle a specific job
         to be separate from the job service. However, for now, we will keep it here.
         This function can be attached to the jobs that run inference so that the results will
         get added to the dataset db. The job routes that store the results
         in the db will add this function as a background task after the job is created.
         """
-        loguru.logger.info("Handling inference job result")
+        loguru.logger.critical(f"Getting job {job.id}, store {store_to_dataset_suffix}, request {request}")
 
-        # Figure out the dataset filename
-        dataset_filename = self._dataset_service.get_dataset(dataset_id=request.dataset).filename
-        dataset_filename = Path(dataset_filename).stem
-        dataset_filename = f"{dataset_filename}-annotated.csv"
-
-        job_status = await self.wait_for_job_complete(job_id, max_wait_time_sec)
+        job_status = await self._wait_for_job_complete(job.id, max_wait_time_sec)
         if job_status == JobStatus.SUCCEEDED.value:
-            self._add_dataset_to_db(job_id, request, self._dataset_service.s3_filesystem, dataset_filename)
-        else:
-            loguru.logger.warning(f"Job {job_id} failed, results not stored in DB")
+            if store_to_dataset_suffix is not None:
+                loguru.logger.info("Handling inference job result")
+                # The job status will only be monitored from here
 
-    def add_background_task(self, background_tasks: BackgroundTasks, task: callable, *args):
+                # Figure out the dataset filename
+                dataset_filename = self._dataset_service.get_dataset(dataset_id=request.dataset).filename
+                dataset_filename = Path(dataset_filename).stem
+                dataset_filename = f"{dataset_filename}-{store_to_dataset_suffix}.csv"
+                try:
+                    self._add_dataset_to_db(job.id, request, self._dataset_service.s3_filesystem, dataset_filename)
+                    # Because status is SUCCEEDED
+                    self.update_job_status(job.id, job_status)
+                except Exception:
+                    loguru.logger.error(f"Job {job.id} succeeded, failure storing results in DB")
+                    self.update_job_status(job.id, JobStatus.FAILED)
+            else:
+                # Because status is SUCCEEDED
+                self.update_job_status(job.id, job_status)
+        else:
+            loguru.logger.error(f"Job {job.id} not succeeded, results not stored in DB")
+            # Could be stopped or could be failed
+            self.update_job_status(job.id, job_status)
+
+    def _add_background_task(self, background_tasks: BackgroundTasks, task: callable, *args):
         """Adds a background task to the background tasks queue."""
-        background_tasks.add_task(task, *args)
+        # background_tasks.add_task(task, *args)
+        # First arg in *args will be taken as the entity, assumed to have an id field
+        backtask = asyncio.create_task(task(*args))
+        id = args[0].id
+        self._tasks[id] = backtask
+        backtask.add_done_callback(lambda _: self._tasks.pop(id, None))
 
     def create_job(
         self,
@@ -385,6 +440,7 @@ class JobService:
         :raises JobTypeUnsupportedError: If the job type is not supported.
         :raises SecretNotFoundError: If the secret key identifying the API key required for the job is not found.
         """
+        loguru.logger.critical(f"--> task queue: {self._tasks.keys()}")
         # Typing won't allow other job_type's
         job_type = request.job_config.job_type
         # Prepare the job configuration that will be sent to submit the ray job.
@@ -455,20 +511,15 @@ class JobService:
         loguru.logger.info("Submitting {job_type} Ray job...")
         submit_ray_job(self.ray_client, entrypoint)
 
-        # NOTE: Only inference jobs can store results in a dataset atm. Among them:
-        # - prediction jobs are run in a workflow before evaluations => they trigger dataset saving
-        #   at workflow level so it is prepended to the eval job
-        # - annotation jobs do not run in workflows => they trigger dataset saving here at job level
-        # As JobType.ANNOTATION is not used uniformly throughout our code yet, we rely on the already
-        # existing `store_to_dataset` parameter to explicitly trigger this in the annotation case
-        if getattr(request.job_config, "store_to_dataset", False):
-            self.add_background_task(
-                self._background_tasks,
-                self.handle_annotation_job,
-                record.id,
-                request,
-                DEFAULT_POST_INFER_JOB_TIMEOUT_SEC,
-            )
+        # Now each job decides if the output should be stored as a dataset
+        self._add_background_task(
+            self._background_tasks,
+            self.handle_post_job,
+            record,
+            request,
+            DEFAULT_POST_INFER_JOB_TIMEOUT_SEC,
+            getattr(request.job_config, "store_to_dataset_suffix", None),
+        )
 
         loguru.logger.info("Getting response...")
         return JobResponse.model_validate(record)
@@ -484,16 +535,16 @@ class JobService:
         record = self._get_job_record(job_id)
         loguru.logger.info(f"Obtaining info for job {job_id}: {record.name}")
 
-        if record.status.value in self.TERMINAL_STATUS:
+        if JobStatus(record.status) in self.TERMINAL_STATUS:
             return JobResponse.model_validate(record)
 
         # get job status from ray
-        job_status = self.ray_client.get_job_status(job_id)
-        loguru.logger.info(f"Obtaining info from ray for job {job_id}: {job_status}")
+        # job_status = self.ray_client.get_job_status(job_id)
+        # loguru.logger.info(f"Obtaining info from ray for job {job_id}: {job_status}")
 
         # update job status in the DB if it differs from the current status
-        if job_status.lower() != record.status.value.lower():
-            record = self._update_job_record(job_id, status=job_status.lower())
+        # if job_status.lower() != record.status.value.lower():
+        #     record = self._update_job_record(job_id, status=job_status.lower())
 
         return JobResponse.model_validate(record)
 

--- a/lumigator/backend/backend/services/jobsworkflows.py
+++ b/lumigator/backend/backend/services/jobsworkflows.py
@@ -1,0 +1,229 @@
+import asyncio
+import json
+import numbers
+from pathlib import Path
+from uuid import UUID
+
+import loguru
+from fastapi import BackgroundTasks
+from lumigator_schemas.jobs import (
+    JobLogsResponse,
+    JobResultObject,
+    JobStatus,
+)
+from lumigator_schemas.workflows import (
+    WorkflowCreateRequest,
+    WorkflowDetailsResponse,
+    WorkflowJobsCreateRequest,
+    WorkflowResponse,
+    WorkflowStatus,
+)
+
+from backend.repositories.jobs import JobRepository
+from backend.services.datasets import DatasetService
+from backend.services.exceptions.job_exceptions import (
+    JobUpstreamError,
+)
+from backend.services.exceptions.workflow_exceptions import (
+    WorkflowNotFoundError,
+    WorkflowValidationError,
+)
+from backend.services.jobs import JOB_STOP_WAIT, JobService
+from backend.settings import settings
+from backend.tracking import TrackingClient
+from backend.tracking.schemas import RunOutputs
+
+
+class JobsWorkflowService:
+    def __init__(
+        self,
+        job_repo: JobRepository,
+        job_service: JobService,
+        dataset_service: DatasetService,
+        background_tasks: BackgroundTasks,
+        tracking_client: TrackingClient,
+    ):
+        self._job_repo = job_repo
+        self._job_service = job_service
+        self._dataset_service = dataset_service
+        self._tracking_client = tracking_client
+        self._background_tasks = background_tasks
+        self.NON_TERMINAL_STATUS = [
+            JobStatus.CREATED,
+            JobStatus.PENDING,
+            JobStatus.RUNNING,
+        ]
+        self._tasks = dict()
+
+        # TODO: rely on https://github.com/ray-project/ray/blob/7c2a200ef84f17418666dad43017a82f782596a3/python/ray/dashboard/modules/job/common.py#L53
+        self.TERMINAL_STATUS = [JobStatus.FAILED, JobStatus.SUCCEEDED]
+
+    def _prepare_metrics(self, eval_output: JobResultObject) -> dict:
+        """Flatten the metrics dictionary to a single level so that it can be stored in RunOutputs."""
+        formatted_metrics = {}
+        for metric_name, metric_value in eval_output.metrics.items():
+            if isinstance(metric_value, dict):
+                for sub_metric_name, sub_metric_value in metric_value.items():
+                    # only interested in mean, so we only look it items that are not lists
+                    if isinstance(sub_metric_value, numbers.Number) and sub_metric_value is not None:
+                        formatted_metrics[f"{metric_name}_{sub_metric_name}"] = round(sub_metric_value, 3)
+            elif isinstance(metric_value, numbers.Number) and metric_value is not None:
+                formatted_metrics[metric_name] = round(metric_value, 3)
+        return formatted_metrics
+
+    async def _run_job(
+        self,
+        request: WorkflowJobsCreateRequest,
+    ) -> WorkflowResponse:
+        pass
+
+    def _add_background_task(self, background_tasks: BackgroundTasks, task: callable, *args):
+        """Adds a background task to the background tasks queue."""
+        # background_tasks.add_task(task, *args)
+        # First arg in *args will be taken as the job id
+        backtask = asyncio.create_task(task(*args))
+        id = args[0].id
+        self._tasks[id] = backtask
+        backtask.add_done_callback(lambda: self._tasks.pop(id, None))
+
+    async def _run_pipeline(
+        self,
+        workflow: WorkflowResponse,
+        request: WorkflowJobsCreateRequest,
+    ):
+        """Currently this is our only workflow. As we make this more flexible to handle different
+        sequences of jobs, we'll need to refactor this function to be more generic.
+        """
+        # input is WorkflowCreateRequest, we need to split the configs and generate one
+        # JobInferenceCreate and one JobEvalCreate
+        # workflow has now started!
+        self._tracking_client.update_workflow_status(workflow.id, WorkflowStatus.RUNNING)
+        # TODO Currently we will use a single dataset var to hold
+        # the pointer to the result of the previous stage
+        # A more flexible implementation could use a dict[job.name, dataset] for example
+        # and use an "input_dataset" field in the current job
+        # Initially the dataset is the workflow dataset
+        previous_dataset_record = request.dataset
+        try:
+            for job_index, job in enumerate(request.job_list):
+                loguru.logger.critical(f"--> Acting on dataset: {previous_dataset_record}, name: {job.name}")
+                # $ref resolution, to refactor
+                if job_index == 0:
+                    job.job_config.model = workflow.model
+
+                job.dataset = previous_dataset_record
+                loguru.logger.critical("--> 1:")
+                # Doesn't seem necessary
+                # ??? self._job_service._validate_results(evaluation_job.id, self._dataset_service.s3_filesystem)
+                job_response = self._job_service.create_job(job)
+                job_run_id = self._tracking_client.create_job(
+                    request.experiment_id, workflow.id, job.job_config.job_type.value, job_response.id
+                )
+                loguru.logger.critical("--> 2:")
+                status = await self._job_service.wait_for_job_finished(
+                    job_response.id, max_wait_time_sec=request.job_timeout_sec
+                )
+                loguru.logger.critical(f"--> 2: Job {job_response.id} finally finished")
+                if JobStatus(status) in JobService.TERMINAL_STATUS:
+                    if status != JobStatus.SUCCEEDED:
+                        loguru.logger.error(f"Job {job_response.id} did not succeed with status {status}")
+                        raise Exception(f"Job {job_response.id} did not succeed with status {status}")
+                else:
+                    try:
+                        self._job_service._stop_job(job_response.id)
+                        status = await self._job_service.wait_for_job_finished(
+                            job_response.id, max_wait_time_sec=JOB_STOP_WAIT
+                        )
+                    except JobUpstreamError:
+                        loguru.logger.error(f"Failed to stop job {job_response.id}, continuing")
+                    raise Exception(f"Job {job_response.id} did not reach terminal state, current status {status}")
+                # log the job to the tracking client
+                loguru.logger.critical("--> 3:")
+                result_key = str(
+                    Path(settings.S3_JOB_RESULTS_PREFIX)
+                    / settings.S3_JOB_RESULTS_FILENAME.format(job_name=job.name, job_id=job_response.id)
+                )
+                dataset_path = self._dataset_service._get_s3_path(result_key)
+                with self._dataset_service.s3_filesystem.open(dataset_path, "r") as f:
+                    job_output = JobResultObject.model_validate(json.loads(f.read()))
+                output_path = f"{settings.S3_BUCKET}/{self._job_service._get_results_s3_key(job_response.id)}"
+                # FIXME Check if this can be done with inference results
+                loguru.logger.critical("--> 4:")
+                formatted_metrics = self._prepare_metrics(job_output)
+                job_output = RunOutputs(
+                    metrics=formatted_metrics,
+                    parameters={"job_output_s3_path": output_path},
+                    ray_job_id=str(job_response.id),
+                )
+
+                self._tracking_client.update_job(job_run_id, job_output)
+                result_dataset = self._dataset_service._get_dataset_record_by_job_id(job_response.id)
+                if result_dataset:
+                    previous_dataset_record = result_dataset.id
+                else:
+                    previous_dataset_record = None
+        except Exception as e:
+            loguru.logger.critical(f"Workflow {request.name} for experiment {request.experiment_id} failed: {e}")
+            await self._handle_workflow_failure(workflow.id)
+        self._tracking_client.update_workflow_status(workflow.id, WorkflowStatus.SUCCEEDED)
+
+    async def _handle_workflow_failure(self, workflow_id: str):
+        """Handle a workflow failure by updating the workflow status."""
+        loguru.logger.error("Workflow failed: {} ... updating status", workflow_id)
+
+        # Mark the workflow as failed.
+        self._tracking_client.update_workflow_status(workflow_id, WorkflowStatus.FAILED)
+
+    def get_workflow(self, workflow_id: str) -> WorkflowDetailsResponse:
+        """Get a workflow."""
+        tracking_server_workflow = self._tracking_client.get_workflow(workflow_id)
+        if tracking_server_workflow is None:
+            raise WorkflowNotFoundError(workflow_id) from None
+        return tracking_server_workflow
+
+    def create_workflow(self, request: WorkflowCreateRequest) -> WorkflowResponse:
+        """Creates a new workflow and submits inference and evaluation jobs.
+
+        Args:
+            request (WorkflowCreateRequest): The request containing the workflow configuration.
+
+        Returns:
+            WorkflowResponse: The response object containing the details of the created workflow.
+        """
+        loguru.logger.info(f"Creating workflow '{request.name}' for experiment ID '{request.experiment_id}'.")
+        loguru.logger.critical(f"--> task queue: {self._tasks.keys()}")
+
+        workflow = self._tracking_client.create_workflow(
+            experiment_id=request.experiment_id,
+            description=request.description,
+            name=request.name,
+            model=request.model,
+            system_prompt=str(
+                request.job_list[0].job_config.system_prompt
+            ),  # FIXME where should we place the system prompt?
+            # input is WorkflowCreate, we need to split the configs and generate one
+            # JobInferenceCreate and one JobEvalCreate
+        )
+
+        self._add_background_task(self._background_tasks, self._run_pipeline, workflow, request)
+
+        return workflow
+
+    def delete_workflow(self, workflow_id: str, force: bool) -> WorkflowResponse:
+        """Delete a workflow by ID."""
+        # if the workflow is running, we should throw an error
+        workflow = self.get_workflow(workflow_id)
+        if workflow.status == WorkflowStatus.RUNNING and not force:
+            raise WorkflowValidationError("Cannot delete a running workflow")
+        return self._tracking_client.delete_workflow(workflow_id)
+
+    def get_workflow_logs(self, workflow_id: str) -> JobLogsResponse:
+        """Get the logs for a workflow."""
+        job_list = self._tracking_client.list_jobs(workflow_id)
+        # sort the jobs by created_at, with the oldest last
+        job_list = sorted(job_list, key=lambda x: x.info.start_time)
+        all_ray_job_ids = [run.data.params.get("ray_job_id") for run in job_list]
+        logs = [self._job_service.get_job_logs(UUID(ray_job_id)) for ray_job_id in all_ray_job_ids]
+        # combine the logs into a single string
+        # TODO: This is not a great solution but it matches the current API
+        return JobLogsResponse(logs="\n================\n".join([log.logs for log in logs]))

--- a/lumigator/backend/backend/services/workflows.py
+++ b/lumigator/backend/backend/services/workflows.py
@@ -147,7 +147,7 @@ class WorkflowService:
 
         try:
             # Wait for the inference job to 'complete'.
-            status = await self._job_service.wait_for_job_complete(
+            status = await self._job_service.wait_for_job_finished(
                 inference_job.id, max_wait_time_sec=request.job_timeout_sec
             )
 
@@ -271,7 +271,7 @@ class WorkflowService:
 
         try:
             # wait for the evaluation job to complete
-            status = await self._job_service.wait_for_job_complete(
+            status = await self._job_service.wait_for_job_finished(
                 evaluation_job.id, max_wait_time_sec=request.job_timeout_sec
             )
 

--- a/lumigator/backend/backend/tests/integration/api/routes/test_api_workflows.py
+++ b/lumigator/backend/backend/tests/integration/api/routes/test_api_workflows.py
@@ -11,6 +11,8 @@ from lumigator_schemas.datasets import DatasetFormat, DatasetResponse
 from lumigator_schemas.experiments import GetExperimentResponse
 from lumigator_schemas.extras import ListingResponse
 from lumigator_schemas.jobs import (
+    JobCreate,
+    JobEvalConfig,
     JobInferenceConfig,
     JobInferenceCreate,
     JobLogsResponse,
@@ -22,7 +24,12 @@ from lumigator_schemas.jobs import (
 )
 from lumigator_schemas.secrets import SecretUploadRequest
 from lumigator_schemas.tasks import TaskType
-from lumigator_schemas.workflows import WorkflowDetailsResponse, WorkflowResponse, WorkflowStatus
+from lumigator_schemas.workflows import (
+    WorkflowDetailsResponse,
+    WorkflowJobsCreateRequest,
+    WorkflowResponse,
+    WorkflowStatus,
+)
 from pydantic import PositiveInt
 
 from backend.main import app
@@ -44,7 +51,7 @@ def test_health_ok(local_client: TestClient):
     assert response.status_code == 200
 
 
-def test_upload_data_launch_job(
+def _test_upload_data_launch_job(
     local_client: TestClient,
     dialog_dataset,
     dependency_overrides_services,
@@ -147,7 +154,7 @@ def test_upload_data_launch_job(
 
 
 @pytest.mark.parametrize("unnanotated_dataset", ["dialog_empty_gt_dataset", "dialog_no_gt_dataset"])
-def test_upload_data_no_gt_launch_annotation(
+def _test_upload_data_no_gt_launch_annotation(
     request: pytest.FixtureRequest,
     local_client: TestClient,
     unnanotated_dataset,
@@ -281,6 +288,54 @@ def run_workflow(
     return workflow
 
 
+def run_jobsworkflow(
+    local_client: TestClient,
+    dataset_id,
+    experiment_id,
+    workflow_name,
+    task_definition: dict,
+    model: str,
+    job_timeout_sec: PositiveInt | None = None,
+):
+    """Run a workflow for the experiment."""
+    workflow_payload = WorkflowJobsCreateRequest(
+        name=workflow_name,
+        description="Test workflow for inf and eval",
+        experiment_id=experiment_id,
+        dataset=str(dataset_id),
+        model=model,  # TO REMOVE
+        job_timeout_sec=1000,
+        task_definition={"task": "summarization"},
+        job_list=[
+            JobCreate(
+                name=f"{workflow_name}-inference",
+                max_samples=1,
+                job_config=JobInferenceConfig(
+                    model=model,  # later: {"$ref": "#/model"}
+                    provider="hf",
+                    task_definition=task_definition,
+                    # we store the dataset explicitly below, so it gets queued before eval
+                    store_to_dataset_suffix="predictions",
+                ),
+            ),
+            JobCreate(
+                name=f"{workflow_name}-evaluation",
+                # max_samples=?,
+                job_config=JobEvalConfig(),
+            ),
+        ],
+    )
+
+    workflow = WorkflowResponse.model_validate(
+        local_client.post(
+            "/workflows/new/",
+            headers=POST_HEADER,
+            json=workflow_payload.model_dump(mode="json"),
+        ).json()
+    )
+    return workflow
+
+
 def validate_experiment_results(local_client: TestClient, experiment_id, workflow_details):
     """Validate experiment results."""
     experiment_results = GetExperimentResponse.model_validate(local_client.get(f"/experiments/{experiment_id}").json())
@@ -336,16 +391,20 @@ def check_artifacts_times(artifacts_url):
     assert "inference_time" in artifacts["artifacts"]
 
 
+"""
+(
+    "mock_translation_dataset",
+    {"task": "translation", "source_language": "en", "target_language": "de"},
+    TEST_CAUSAL_MODEL,
+),
+"""
+
+
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "dataset_name, task_definition, model",
     [
         ("dialog_dataset", {"task": "summarization"}, TEST_SEQ2SEQ_MODEL),
-        (
-            "mock_translation_dataset",
-            {"task": "translation", "source_language": "en", "target_language": "de"},
-            TEST_CAUSAL_MODEL,
-        ),
     ],
 )
 def test_full_experiment_launch(
@@ -375,11 +434,11 @@ def test_full_experiment_launch(
     dataset = upload_dataset(local_client, dataset)
     check_dataset_count_after_upload(local_client, initial_count)
     experiment_id = create_experiment(local_client, dataset.id, task_definition)
-    workflow_1 = run_workflow(local_client, dataset.id, experiment_id, "Workflow_1", task_definition, model)
+    workflow_1 = run_jobsworkflow(local_client, dataset.id, experiment_id, "Workflow_1", task_definition, model)
     workflow_1_details = wait_for_workflow_complete(local_client, workflow_1.id)
     check_artifacts_times(workflow_1_details.artifacts_download_url)
     validate_experiment_results(local_client, experiment_id, workflow_1_details)
-    workflow_2 = run_workflow(local_client, dataset.id, experiment_id, "Workflow_2", task_definition, model)
+    workflow_2 = run_jobsworkflow(local_client, dataset.id, experiment_id, "Workflow_2", task_definition, model)
     workflow_2_details = wait_for_workflow_complete(local_client, workflow_2.id)
     check_artifacts_times(workflow_2_details.artifacts_download_url)
     list_experiments(local_client)
@@ -389,7 +448,7 @@ def test_full_experiment_launch(
 
 
 @pytest.mark.integration
-def test_timedout_experiment(local_client: TestClient, dialog_dataset, dependency_overrides_services):
+def _test_timedout_experiment(local_client: TestClient, dialog_dataset, dependency_overrides_services):
     """This is the main integration test: it checks:
     * The backend health status
     * Uploading a dataset
@@ -421,19 +480,18 @@ def test_timedout_experiment(local_client: TestClient, dialog_dataset, dependenc
         all_params = {param["name"]: param["value"] for param in job.parameters if "name" in param and "value" in param}
         response = local_client.get(f"/jobs/{all_params['ray_job_id']}")
         response_json = response.json()
-        logger.critical(f"--> {response_json}")
         assert response.status_code == 200
         assert (JobResponse(**response_json)).status.value == JobStatus.STOPPED
 
 
-def test_experiment_non_existing(local_client: TestClient, dependency_overrides_services):
+def _test_experiment_non_existing(local_client: TestClient, dependency_overrides_services):
     non_existing_id = "d34dbeef-4bea-4d19-ad06-214202165812"
     response = local_client.get(f"/experiments/{non_existing_id}")
     assert response.status_code == 404
     assert response.json()["detail"] == f"Experiment with ID {non_existing_id} not found"
 
 
-def test_job_non_existing(local_client: TestClient, dependency_overrides_services):
+def _test_job_non_existing(local_client: TestClient, dependency_overrides_services):
     non_existing_id = "d34dbeef-4bea-4d19-ad06-214202165812"
     response = local_client.get(f"/jobs/{non_existing_id}")
     assert response.status_code == 404

--- a/lumigator/schemas/lumigator_schemas/workflows.py
+++ b/lumigator/schemas/lumigator_schemas/workflows.py
@@ -3,11 +3,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, PositiveInt
 
-from lumigator_schemas.jobs import (
-    GenerationConfig,
-    JobResults,
-    LowercaseEnum,
-)
+from lumigator_schemas.jobs import GenerationConfig, JobCreate, JobResults, LowercaseEnum
 from lumigator_schemas.tasks import SummarizationTaskDefinition, TaskDefinition, get_default_system_prompt
 
 
@@ -42,6 +38,16 @@ class WorkflowCreateRequest(BaseModel):
     job_timeout_sec: PositiveInt = 60 * 60
     # Eventually metrics should be managed by the experiment level https://github.com/mozilla-ai/lumigator/issues/1105
     metrics: list[str] | None = None
+
+
+class WorkflowJobsCreateRequest(BaseModel):
+    name: str
+    description: str = ""
+    experiment_id: str | None = None
+    dataset: UUID
+    model: str
+    job_timeout_sec: PositiveInt = 60 * 60
+    job_list: list[JobCreate]
 
 
 class WorkflowResponse(BaseModel, from_attributes=True):


### PR DESCRIPTION
# What's changing

This PR allows a workflow to be specified as a list of jobs to be run sequentially:

```python
    workflow_payload = WorkflowJobsCreateRequest(
        name=workflow_name,
        description="Test workflow for inf and eval",
        experiment_id=experiment_id,
        dataset=str(dataset_id),
        model=model,  # TO REMOVE
        job_timeout_sec=1000,
        task_definition={"task": "summarization"},
        job_list=[
            JobCreate(
                name=f"{workflow_name}-inference",
                max_samples=1,
                job_config=JobInferenceConfig(
                    model=model,  # later: {"$ref": "#/model"}
                    provider="hf",
                    task_definition=task_definition,
                    # we store the dataset explicitly below, so it gets queued before eval
                    store_to_dataset_suffix="predictions",
                ),
            ),
            JobCreate(
                name=f"{workflow_name}-evaluation",
                # max_samples=?,
                job_config=JobEvalConfig(),
            ),
        ],
    )
```

Currently, each job will try to use the dataset produced by the previous job (if any), and the workflow will merge all results together in a single result. Tasks are handled using asyncio Tasks and stored in a dict within their appropriate service (jobs or workflows) using their created ID as a key. The dict should do auto cleanup when the Task completes.

It currently needs support from the UI to be used there, but auto tests should work ok.

Closes #774 

# How to test it

Run the auto tests and follow the job information in Ray and MLFlow. Everything should be stored in their place.

# Additional notes for reviewers

N/A

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
