### PR TITLE
DevEx: Update dev container overrides to ignore more .venvs and test folders

### DIFF
--- a/.devcontainer/docker-compose.override.yaml
+++ b/.devcontainer/docker-compose.override.yaml
@@ -19,15 +19,24 @@ services:
           action: sync
           ignore:
             - .venv/
+            - .pytest_cache/
+            - .ruff_cache/
+            - backend/tests/
         - path: lumigator/jobs/
           target: /mzai/lumigator/jobs
           action: sync
           ignore:
             - .venv/
+            - jobs/inference/.venv/
+            - jobs/evaluation/.venv/
+            - .pytest_cache/
+            - .ruff_cache/
         - path: lumigator/schemas/
           target: /mzai/lumigator/schemas
           action: sync
           ignore:
             - .venv/
+            - .pytest_cache/
+            - .ruff_cache/
         - path: lumigator/backend/pyproject.toml
           action: rebuild


### PR DESCRIPTION
# What's changing

Adds some more paths to ignore when running the containers in `watch` mode (via `make local-up`).

This prevents the app trying to reload when things inside the `.venv`, test or cache folders change.

# How to test it


# Additional notes for reviewers


# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
