### PR TITLE
Add default api key if none is provided

### DIFF
--- a/lumigator/backend/backend/models.yaml
+++ b/lumigator/backend/backend/models.yaml
@@ -149,7 +149,7 @@
 
 - display_name: Llamafile/Mistral-7B-Instruct-v0.2
   model: mistralai/Mistral-7B-Instruct-v0.2
-  provider: openai
+  provider: hosted_vllm
   base_url: http://localhost:8080/v1
   website_url: https://huggingface.co/Mozilla/Mistral-7B-Instruct-v0.2-llamafile
   description: A llamafile package of Mistral's 7B Instruct model. Assumes that llamafile is running on the same system where the Ray cluster is located.

--- a/lumigator/backend/backend/tests/integration/api/routes/test_api_workflows.py
+++ b/lumigator/backend/backend/tests/integration/api/routes/test_api_workflows.py
@@ -421,7 +421,6 @@ def test_timedout_experiment(local_client: TestClient, dialog_dataset, dependenc
         all_params = {param["name"]: param["value"] for param in job.parameters if "name" in param and "value" in param}
         response = local_client.get(f"/jobs/{all_params['ray_job_id']}")
         response_json = response.json()
-        logger.critical(f"--> {response_json}")
         assert response.status_code == 200
         assert (JobResponse(**response_json)).status.value == JobStatus.STOPPED
 

--- a/lumigator/jobs/inference/model_clients/external_api_clients.py
+++ b/lumigator/jobs/inference/model_clients/external_api_clients.py
@@ -22,9 +22,9 @@ class LiteLLMModelClient(BaseModelClient):
     """
 
     def __init__(self, config: InferenceJobConfig, api_key: str | None = None) -> None:
+        self.api_key = api_key
         self.config = config
         self.system_prompt = self.config.system_prompt
-        self.api_key = api_key
         logger.info(f"LiteLLMModelClient initialized with config: {config}")
 
     @retry_with_backoff(max_retries=3)


### PR DESCRIPTION
# What's changing

In the inference job, if no `api_key` environment variable has been set, `None` will be passed to LiteLLM as the value for the API key. Apparently, the OpenAI client does not interpret this correctly in the case of non-authenticated OpenAI-compatible endpoints like Llama, and needs some dummy value for the API key.

See https://github.com/BerriAI/litellm/issues/3225#issuecomment-2733944679 for more context.

Closes #1201 

# How to test it

Create a new Experiment using a Llamafile-served model, like Mistral. It should not yield `AuthenticationError`and work normally.

Note that HTTP requests passed by e.g. `curl` without any kind of Auth headers will run ok. This seems a limitation of the OpenAI client itself (used by LiteLLM).

# Additional notes for reviewers

N/A

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
