### PR TITLE
Remove Alchemy DB env var in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ RAY_WORKER_GPUS ?= 0
 RAY_WORKER_GPUS_FRACTION ?= 0.0
 GPU_COMPOSE :=
 MODEL_CACHE_COMPOSE :=
-export SQLALCHEMY_DATABASE_URL ?= sqlite:////tmp/local.db
 
 DEBUGPY_ARGS :=
 ifneq ($(shell echo $(DEBUGPY) | grep -i '^true$$'),)
@@ -240,12 +239,14 @@ test-sdk: test-sdk-unit test-sdk-integration-containers
 # Integration tests require all containers to be up, so as a safety measure
 # `test-sdk-integration-containers` is usually called and this will either
 # start them if they are not present or use the currently running ones.
+test-backend-unit: export SQLALCHEMY_DATABASE_URL = sqlite:////tmp/local.db
 test-backend-unit:
 	@source ./scripts/set_env_vars.sh && \
 	cd lumigator/backend/ && \
 	PYTHONPATH=../jobs:$$PYTHONPATH \
 	uv run $(DEBUGPY_ARGS) -m pytest -s -o python_files="backend/tests/unit/*/test_*.py backend/tests/unit/test_*.py"
 
+test-backend-integration: export SQLALCHEMY_DATABASE_URL = sqlite:////tmp/local.db
 test-backend-integration: config-generate-env
 	@if [ "$(USE_ENV_FILE)" = "true" ]; then \
 		source ./scripts/set_env_vars.sh "$(CONFIG_BUILD_DIR)/.env"; \


### PR DESCRIPTION
# What's changing

The wrong location for the SQL Alchemy env var was being set in the `Makefile`, overriding the defaults present in the `.default.conf` file.

Closes #928 

# How to test it

Steps to test the changes:

1. Start Lumigator
2. Perform some annotation job or an experiment
3. Close Lumigator and start it again
4. Jobs from step 2 should still be visible

# Additional notes for reviewers

N/A

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
  - No DB changes needed