### PR TITLE
GHA: Adjust names for failed logs

### DIFF
--- a/.github/workflows/lumigator_pipeline.yaml
+++ b/.github/workflows/lumigator_pipeline.yaml
@@ -253,7 +253,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ray-logs
+          name: ray-logs-${{ matrix.test }}
           overwrite: true
           path: /tmp/raylogs/ray/session_*/logs/
 
@@ -261,7 +261,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ray-docker-log
+          name: ray-docker-log-${{ matrix.test }}
           overwrite: true
           path: /tmp/raydocker.log
 
@@ -269,7 +269,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: backend-log
+          name: backend-log-${{ matrix.test }}
           overwrite: true
           path: /tmp/backendlogs/backend.log
 
@@ -337,7 +337,8 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ray-logs
+          name: ray-logs-${{ matrix.test }}
+          overwrite: true
           path: /tmp/raylogs/ray/session_*/logs/
 
   notebook-integration-test:


### PR DESCRIPTION
# What's changing

When integration tests fail, we sometimes see errors in uploading the logs in GitHub Actions.

It seems that in `v4` of `actions/upload-artifact`:

> users lose the ability to upload to the same named artifact multiple times. Once an artifact is uploaded cannot be altered, and there cannot be multiple v4 artifacts with the same name, in the same workflow run.

See: https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/#compatibility

This seems to align with what we see in the GitHub Actions runner output:

```console
Run actions/upload-artifact@v4
With the provided path, there will be 90 files uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

See: https://github.com/mozilla-ai/lumigator/actions/runs/13929363164/job/38983212742?pr=1215#step:11:15

This PR uses the current matrix of the test as part of the name to prevent multiple uploads of the same name, and also sets overwrite `true` on one that didn't already have it set (`integration-tests-postgres`).

# How to test it

Steps to test the changes:

1.
2.
3.

# Additional notes for reviewers

![image](https://github.com/user-attachments/assets/9da6f870-1d27-4ea4-aa1e-7856a20116b3)

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
