### PR TITLE
Disable default cache

### DIFF
--- a/.default.conf
+++ b/.default.conf
@@ -19,7 +19,7 @@ NVIDIA_VISIBLE_DEVICES=all
 GPU_COUNT=0
 # Cache for HuggingFace models and artifacts
 HF_HOME=${HOME}/.cache/huggingface
-ENABLE_FIRST_TIME_CACHE=true
+ENABLE_FIRST_TIME_CACHE=false
 MODELS_CACHED="facebook/bart-large-cnn,roberta-large" #ensure values are comma separated
 # MLFlow Configuration
 MLFLOW_TRACKING_URI=http://mlflow:5000


### PR DESCRIPTION
# What's changing

Disabling the inference-model container by default. We're currently experience some issues downloading models from huggingface. 


There will be a full review of the README.md tomorrow so I'll update the parts that mention the cache in a follow up PR.
Steps to test the changes:

1. Run lumigator in any of the variants (local-up , start-lumigator) with the default settings for cache and see that the inference-model container is not created

# I already...

- [X] Tested the changes in a working environment to ensure they work as expected
- [N/A] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [N/A] Checked if a (backend) DB migration step was required and included it if required
