### PR TITLE
Job Logs: Fix bug where logs were not updated after first check

### DIFF
--- a/lumigator/backend/backend/services/jobs.py
+++ b/lumigator/backend/backend/services/jobs.py
@@ -297,17 +297,32 @@ class JobService:
             raise JobUpstreamError("ray", "error getting Ray job status", e) from e
 
     def get_job_logs(self, job_id: UUID) -> JobLogsResponse:
-        db_logs = self.job_repo.get(job_id)
-        if not db_logs:
-            raise JobNotFoundError(job_id, "Failed to find the job record holding the logs") from None
-        elif not db_logs.logs:
-            ray_db_logs = self.retrieve_job_logs(job_id)
-            self._update_job_record(job_id, logs=ray_db_logs.logs)
-            return ray_db_logs
-        else:
-            return JobLogsResponse(logs=db_logs.logs)
+        """Retrieves the logs for a job from the upstream service.
 
-    def retrieve_job_logs(self, job_id: UUID) -> JobLogsResponse:
+        :param job_id: The ID of the job to retrieve logs for.
+        :return: The logs for the job.
+        :raises JobNotFoundError: If the job cannot be found.
+        :raises JobUpstreamError: If there is an error with the upstream service returning the job logs,
+                and there are no logs currently persisted in Lumigator's storage.
+        """
+        job = self.job_repo.get(job_id)
+        if not job:
+            raise JobNotFoundError(job_id) from None
+
+        try:
+            job_logs = self._retrieve_job_logs(job_id)
+        except JobUpstreamError:
+            # If we have logs stored, just return them to support 'offline' Ray
+            if job.logs:
+                return JobLogsResponse(logs=job.logs)
+            raise
+
+        # Update the database with the latest logs
+        self._update_job_record(job_id, logs=job_logs.logs)
+
+        return job_logs
+
+    def _retrieve_job_logs(self, job_id: UUID) -> JobLogsResponse:
         resp = requests.get(urljoin(settings.RAY_JOBS_URL, f"{job_id}/logs"), timeout=5)  # 5 seconds
         if resp.status_code == HTTPStatus.NOT_FOUND:
             raise JobUpstreamError("ray", "job_id not found when retrieving logs") from None


### PR DESCRIPTION
# What's changing

This PR fixes a bug where the first call to `jobs/{job_id}/logs` retrieved all current logs for the job, but subsequent calls returned the same value as the first call. 

We now try to get updated logs from Ray when possible, and fallback to returning what we have stored in the DB if Ray returns us errors.

> If this PR is related to an issue or closes one, please link it here.

Closes #1088 

# How to test it

Steps to test the changes:

1. `make local-up`
2. Upload a dataset and create an experiment
3. Click on one of the jobs in the experiment, and click logs from the right hand side panel... watch and wait for logs

# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [x] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
