### PR TITLE
Check type fields in evaluator

### DIFF
--- a/lumigator/backend/backend/tests/unit/api/routes/test_jobs.py
+++ b/lumigator/backend/backend/tests/unit/api/routes/test_jobs.py
@@ -138,6 +138,5 @@ def test_missing_api_key_in_job_creation(
     with patch("backend.api.deps.JobSubmissionClient"):
         with patch.object(job_service, "create_job", side_effect=SecretNotFoundError("test error msg")):
             response = app_client.post("/jobs/inference/", headers=POST_HEADER, json=infer_payload)
-            loguru.logger.critical(f"response text: {response.text}")
             assert response is not None
             assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/lumigator/jobs/evaluator/tests/test_eval_metrics.py
+++ b/lumigator/jobs/evaluator/tests/test_eval_metrics.py
@@ -1,6 +1,13 @@
+import shutil
+from pathlib import Path
+
 import numpy as np
 import pytest
+from datasets import load_dataset, load_from_disk
 from eval_metrics import EvaluationMetrics
+from evaluator import run_eval
+
+from schemas import DatasetConfig, EvalJobConfig, EvaluationConfig
 
 
 @pytest.fixture
@@ -57,3 +64,17 @@ def test_token_length_empty_strings(evaluation_metrics):
     assert result["pred_token_length"] == [0, int(len("Some text".split()) / 0.75)]
     assert result["ref_token_length_mean"] == 0.0
     assert result["pred_token_length_mean"] == result["pred_token_length"][1] / 2
+
+
+def test_empty_fields_cast_as_float64():
+    test_path_csv = Path("../../sample_data/summarization/predictions_gibberish.csv")
+    test_path = test_path_csv.with_suffix("")
+    csv = load_dataset("csv", data_files=str(test_path_csv), split="train")
+    csv.save_to_disk(test_path)
+    eval = EvalJobConfig(
+        name="test",
+        dataset=DatasetConfig(path=str(test_path)),
+        evaluation=EvaluationConfig(metrics=["rouge"], storage_path="/tmp/test_empty_fields_cast_as_float64.metrics"),
+    )
+    run_eval(eval)
+    shutil.rmtree(test_path)

--- a/lumigator/sample_data/summarization/predictions_gibberish.csv
+++ b/lumigator/sample_data/summarization/predictions_gibberish.csv
@@ -1,0 +1,55 @@
+predictions,examples,ground_truth
+,"#Person1#: Hello, how are you doing today?
+#Person2#: I ' Ve been having trouble breathing lately.
+#Person1#: Have you had any type of cold lately?
+#Person2#: No, I haven ' t had a cold. I just have a heavy feeling in my chest when I try to breathe.
+#Person1#: Do you have any allergies that you know of?
+#Person2#: No, I don ' t have any allergies that I know of.
+#Person1#: Does this happen all the time or mostly when you are active?
+#Person2#: It happens a lot when I work out.
+#Person1#: I am going to send you to a pulmonary specialist who can run tests on you for asthma.
+#Person2#: Thank you for your help, doctor.",#Person2# has trouble breathing. The doctor asks #Person2# about it and will send #Person2# to a pulmonary specialist.
+,"#Person1#: Hey Jimmy. Let's go workout later today.
+#Person2#: Sure. What time do you want to go?
+#Person1#: How about at 3:30?
+#Person2#: That sounds good. Today we work on Legs and forearm.
+#Person1#: Hey. I just played basketball earlier, so my legs are a little sore. Let's work out on arms and stomach today.
+#Person2#: I'm on a weekly schedule. You're messing everything up.
+#Person1#: C'mon. We're only switching two days. You can do legs on Friday.
+#Person2#: Aright. I'll meet you at the gym at 3:30 then.",#Person1# invites Jimmy to go workout and persuades him into working out on arms and stomach.
+,"#Person1#: I need to stop eating such unhealthy foods.
+#Person2#: I know what you mean. I've started eating better myself.
+#Person1#: What foods do you eat now?
+#Person2#: I tend to stick to fruits, vegetables, and chicken.
+#Person1#: Those are the only things you eat?
+#Person2#: That's basically what I eat.
+#Person1#: Why aren't you eating anything else?
+#Person2#: Well, fruits and vegetables are very healthy.
+#Person1#: And the chicken?
+#Person2#: It's really healthy to eat when you bake it.
+#Person1#: I guess that does sound a lot healthier.","#Person1# plans to stop eating unhealthy foods, and #Person2# shares #Person2#'s healthy recipe with #Person1#."
+,"#Person1#: Do you believe in UFOs?
+#Person2#: Of course, they are out there.
+#Person1#: But I never saw them.
+#Person2#: Are you stupid? They are called UFOs, so not everybody can see them.
+#Person1#: You mean that you can them.
+#Person2#: That's right. I can see them in my dreams.
+#Person1#: They come to the earth?
+#Person2#: No. Their task is to send the aliens here from the outer space.
+#Person1#: Aliens from the outer space? Do you talk to them? What do they look like?
+#Person2#: OK, OK, one by one, please! They look like robots, but they can speak. Their mission is to make friends with human beings.
+#Person1#: That means that you talk to them? In which language?
+#Person2#: Of course in English, they learn English on Mars too.
+#Person1#: Wow. Sounds fantastic!",#Person2# believes in UFOs and can see them in dreams. #Person1# asks #Person2# about UFOs and aliens in #Person2#'s dreams and finds #Person2#'s dreams fantastic.
+,"#Person1#: Did you go to school today?
+#Person2#: Of course. Did you?
+#Person1#: I didn't want to, so I didn't.
+#Person2#: That's sad, but have you gone to the movies recently?
+#Person1#: That's a switch.
+#Person2#: I'm serious, have you?
+#Person1#: No, I haven't. Why?
+#Person2#: I really want to go to the movies this weekend.
+#Person1#: So go then.
+#Person2#: I really don't want to go by myself.
+#Person1#: Well anyway, do you plan on going to school tomorrow?
+#Person2#: No, I think I'm going to go to the movies.",#Person1# didn't go to school today. #Person2# wants to skip class tomorrow to go to the movies.


### PR DESCRIPTION
# What's changing

Columns with empty values will be incorrectly identified as type `float64` by HF `datasets` library. This PR updates the type to `string`and converts `None` values to `''`.

Closes #646 

# How to test it

An automated case is provided. Some testing models will yield empty fields, causing this error.

# Additional notes for reviewers

N/A

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [x] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [x] Checked if a (backend) DB migration step was required and included it if required
  - No DB migration required.