### PR TITLE
Schema: Add schema util that allows merging of Pydantic schema models

### DIFF
--- a/lumigator/schemas/lumigator_schemas/tests/conftest.py
+++ b/lumigator/schemas/lumigator_schemas/tests/conftest.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+
+import pytest
+
+
+def load_json_from_file(file_path: Path) -> dict:
+    """Load JSON data from a file path and return it as a dictionary."""
+    with Path.open(file_path) as file:
+        return json.load(file)
+
+
+@pytest.fixture(scope="session")
+def resources_dir() -> Path:
+    return Path(__file__).parent / "data"
+
+
+@pytest.fixture(scope="session")
+def json_workflow_results(resources_dir) -> dict:
+    path = resources_dir / "workflow_results.json"
+    return load_json_from_file(path)
+
+
+@pytest.fixture(scope="session")
+def json_workflow_results_overlay_all(resources_dir) -> dict:
+    path = resources_dir / "workflow_results_overlay_all.json"
+    return load_json_from_file(path)
+
+
+@pytest.fixture(scope="session")
+def json_workflow_results_overlay_artifacts_same(resources_dir) -> dict:
+    path = resources_dir / "workflow_results_overlay_artifacts_same.json"
+    return load_json_from_file(path)
+
+
+@pytest.fixture(scope="session")
+def json_workflow_results_overlay_artifacts_missing(resources_dir) -> dict:
+    path = resources_dir / "workflow_results_overlay_artifacts_missing.json"
+    return load_json_from_file(path)

--- a/lumigator/schemas/lumigator_schemas/tests/data/workflow_results.json
+++ b/lumigator/schemas/lumigator_schemas/tests/data/workflow_results.json
@@ -1,0 +1,52 @@
+{
+    "metrics": {
+      "bertscore": {
+        "precision": [0.9999999403953552],
+        "recall": [0.9999999403953552],
+        "f1": [0.9999999403953552],
+        "hashcode": "roberta-large_L17_no-idf_version=0.3.12(hug_trans=4.48.0)",
+        "precision_mean": 0.9999999403953552,
+        "recall_mean": 0.9999999403953552,
+        "f1_mean": 0.9999999403953552
+      },
+      "meteor": {
+        "meteor": [0.9999976851851852],
+        "meteor_mean": 0.9999976851851852
+      },
+      "rouge": {
+        "rouge1": [1.0],
+        "rouge2": [1.0],
+        "rougeL": [1.0],
+        "rougeLsum": [1.0],
+        "rouge1_mean": 1.0,
+        "rouge2_mean": 1.0,
+        "rougeL_mean": 1.0,
+        "rougeLsum_mean": 1.0
+      },
+      "bleu": { "bleu": [1.0], "bleu_mean": 1.0 },
+      "g_eval_summarization": null,
+      "token_length": null
+    },
+    "parameters": {
+      "name": "test1-evaluation/b5700c88-57b5-42d7-a128-aedaf4338117",
+      "dataset": {
+        "path": "s3://lumigator-storage/datasets/23881187-4ec3-4256-9101-81f93956e6fa/dialogsum_mini_no_gt-annotated-facebook-bart-large-cnn-predictions.csv"
+      },
+      "evaluation": {
+        "metrics": ["rouge", "meteor", "bertscore", "bleu"],
+        "max_samples": 1,
+        "return_input_data": true,
+        "return_predictions": true,
+        "storage_path": "s3://lumigator-storage/jobs/results/"
+      }
+    },
+    "artifacts": {
+      "predictions": [
+        "A man has trouble breathing. He is sent to see a pulmonary specialist. The doctor tests him for asthma. He does not have any allergies that he knows of. He also has a heavy feeling in his chest when he tries to breathe. This happens a lot when he works out, he says."
+      ],
+      "ground_truth": [
+        "A man has trouble breathing. He is sent to see a pulmonary specialist. The doctor tests him for asthma. He does not have any allergies that he knows of. He also has a heavy feeling in his chest when he tries to breathe. This happens a lot when he works out, he says."
+      ],
+      "evaluation_time": 18.66808230098104
+    }
+  }

--- a/lumigator/schemas/lumigator_schemas/tests/data/workflow_results_overlay_all.json
+++ b/lumigator/schemas/lumigator_schemas/tests/data/workflow_results_overlay_all.json
@@ -1,0 +1,52 @@
+{
+    "metrics": {
+      "bertscore": {
+        "precision": [0.2],
+        "recall": [0.1],
+        "f1": [0.9999999403953552],
+        "hashcode": "ROBOTO-large_L17_no-idf_version=0.3.12(hug_trans=4.48.0)",
+        "precision_mean": 0.9999999403953552,
+        "recall_mean": 0.9999999403953552,
+        "f1_mean": 0.9999999403953552
+      },
+      "meteor": {
+        "meteor": [0.555],
+        "meteor_mean": 0.9999976851851852
+      },
+      "rouge": {
+        "rouge1": [1.0],
+        "rouge2": [1.0],
+        "rougeL": [1.0],
+        "rougeLsum": [1.0],
+        "rouge1_mean": 1.0,
+        "rouge2_mean": 1.0,
+        "rougeL_mean": 1.0,
+        "rougeLsum_mean": 1.0
+      },
+      "bleu": { "bleu": [1.0], "bleu_mean": 1.0 },
+      "g_eval_summarization": null,
+      "token_length": null
+    },
+    "parameters": {
+      "name": "test2-evaluation/b5700c88-57b5-42d7-a128-aedaf4338117",
+      "dataset": {
+        "path": "s3://lumigator-storage/datasets/23881187-4ec3-4256-9101-81f93956e6fa/dialogsum_mini_no_gt-annotated-facebook-bart-large-cnn-predictions.csv"
+      },
+      "evaluation": {
+        "metrics": ["rouge", "meteor", "bertscore", "bleu"],
+        "max_samples": 1,
+        "return_input_data": true,
+        "return_predictions": true,
+        "storage_path": "s3://lumigator-storage/jobs/results/"
+      }
+    },
+    "artifacts": {
+      "predictions": [
+        "A person has trouble breathing. He is sent to see a pulmonary specialist. The doctor tests him for asthma. He does not have any allergies that he knows of. He also has a heavy feeling in his chest when he tries to breathe. This happens a lot when he works out, he says."
+      ],
+      "ground_truth": [
+        "A man has trouble breathing. He is sent to see a pulmonary specialist. The doctor tests him for asthma. He does not have any allergies that he knows of. He also has a heavy feeling in his chest when he tries to breathe. This happens a lot when he works out, he says."
+      ],
+      "evaluation_time": 18.66808230098104
+    }
+  }

--- a/lumigator/schemas/lumigator_schemas/tests/data/workflow_results_overlay_artifacts_missing.json
+++ b/lumigator/schemas/lumigator_schemas/tests/data/workflow_results_overlay_artifacts_missing.json
@@ -1,0 +1,44 @@
+{
+    "metrics": {
+      "bertscore": {
+        "precision": [0.2],
+        "recall": [0.1],
+        "f1": [0.9999999403953552],
+        "hashcode": "ROBOTO-large_L17_no-idf_version=0.3.12(hug_trans=4.48.0)",
+        "precision_mean": 0.9999999403953552,
+        "recall_mean": 0.9999999403953552,
+        "f1_mean": 0.9999999403953552
+      },
+      "meteor": {
+        "meteor": [0.555],
+        "meteor_mean": 0.9999976851851852
+      },
+      "rouge": {
+        "rouge1": [1.0],
+        "rouge2": [1.0],
+        "rougeL": [1.0],
+        "rougeLsum": [1.0],
+        "rouge1_mean": 1.0,
+        "rouge2_mean": 1.0,
+        "rougeL_mean": 1.0,
+        "rougeLsum_mean": 1.0
+      },
+      "bleu": { "bleu": [1.0], "bleu_mean": 1.0 },
+      "g_eval_summarization": null,
+      "token_length": null
+    },
+    "parameters": {
+      "name": "test2-evaluation/b5700c88-57b5-42d7-a128-aedaf4338117",
+      "dataset": {
+        "path": "s3://lumigator-storage/datasets/23881187-4ec3-4256-9101-81f93956e6fa/dialogsum_mini_no_gt-annotated-facebook-bart-large-cnn-predictions.csv"
+      },
+      "evaluation": {
+        "metrics": ["rouge", "meteor", "bertscore", "bleu"],
+        "max_samples": 1,
+        "return_input_data": true,
+        "return_predictions": true,
+        "storage_path": "s3://lumigator-storage/jobs/results/"
+      }
+    },
+    "artifacts": {}
+  }

--- a/lumigator/schemas/lumigator_schemas/tests/data/workflow_results_overlay_artifacts_same.json
+++ b/lumigator/schemas/lumigator_schemas/tests/data/workflow_results_overlay_artifacts_same.json
@@ -1,0 +1,52 @@
+{
+    "metrics": {
+      "bertscore": {
+        "precision": [0.2],
+        "recall": [0.1],
+        "f1": [0.9999999403953552],
+        "hashcode": "ROBOTO-large_L17_no-idf_version=0.3.12(hug_trans=4.48.0)",
+        "precision_mean": 0.9999999403953552,
+        "recall_mean": 0.9999999403953552,
+        "f1_mean": 0.9999999403953552
+      },
+      "meteor": {
+        "meteor": [0.555],
+        "meteor_mean": 0.9999976851851852
+      },
+      "rouge": {
+        "rouge1": [1.0],
+        "rouge2": [1.0],
+        "rougeL": [1.0],
+        "rougeLsum": [1.0],
+        "rouge1_mean": 1.0,
+        "rouge2_mean": 1.0,
+        "rougeL_mean": 1.0,
+        "rougeLsum_mean": 1.0
+      },
+      "bleu": { "bleu": [1.0], "bleu_mean": 1.0 },
+      "g_eval_summarization": null,
+      "token_length": null
+    },
+    "parameters": {
+      "name": "test2-evaluation/b5700c88-57b5-42d7-a128-aedaf4338117",
+      "dataset": {
+        "path": "s3://lumigator-storage/datasets/23881187-4ec3-4256-9101-81f93956e6fa/dialogsum_mini_no_gt-annotated-facebook-bart-large-cnn-predictions.csv"
+      },
+      "evaluation": {
+        "metrics": ["rouge", "meteor", "bertscore", "bleu"],
+        "max_samples": 1,
+        "return_input_data": true,
+        "return_predictions": true,
+        "storage_path": "s3://lumigator-storage/jobs/results/"
+      }
+    },
+    "artifacts": {
+      "predictions": [
+        "A man has trouble breathing. He is sent to see a pulmonary specialist. The doctor tests him for asthma. He does not have any allergies that he knows of. He also has a heavy feeling in his chest when he tries to breathe. This happens a lot when he works out, he says."
+      ],
+      "ground_truth": [
+        "A man has trouble breathing. He is sent to see a pulmonary specialist. The doctor tests him for asthma. He does not have any allergies that he knows of. He also has a heavy feeling in his chest when he tries to breathe. This happens a lot when he works out, he says."
+      ],
+      "evaluation_time": 18.66808230098104
+    }
+  }

--- a/lumigator/schemas/lumigator_schemas/tests/unit/test_utils_model_operations.py
+++ b/lumigator/schemas/lumigator_schemas/tests/unit/test_utils_model_operations.py
@@ -1,0 +1,310 @@
+from typing import Any
+
+import pytest
+from lumigator_schemas.jobs import JobResultObject
+from lumigator_schemas.utils.model_operations import _deep_merge_dicts, merge_models
+from pydantic import BaseModel
+
+
+class TestModel(BaseModel):
+    name: str
+    metadata: dict[str, Any] | None = None
+
+
+@pytest.mark.parametrize(
+    "base_model, overlay_model, deep_merge, expected_merged, expected_overwritten, expected_unmerged, expected_skipped",
+    [
+        # Case 1: base_model is None, overlay_model is provided
+        (
+            None,
+            TestModel(name="overlay", metadata={"key": "value"}),
+            False,
+            TestModel(name="overlay", metadata={"key": "value"}),
+            set(),
+            set(),
+            set(),
+        ),
+        # Case 2: overlay_model is None, base_model is provided
+        (
+            TestModel(name="base", metadata={"key": "base_value"}),
+            None,
+            False,
+            TestModel(name="base", metadata={"key": "base_value"}),
+            set(),
+            set(),
+            set(),
+        ),
+        # Case 3: Base and Overlay models are provided, shallow merge (no deep merge)
+        (
+            TestModel(name="base", metadata={"key": "base_value"}),
+            TestModel(name="overlay", metadata={"key": "overlay_value"}),
+            False,
+            TestModel(name="overlay", metadata={"key": "overlay_value"}),
+            {"name", "metadata"},
+            set(),
+            set(),
+        ),
+        # Case 4: Base and Overlay models are provided, shallow merge (no deep merge)
+        (
+            TestModel(name="base", metadata={"key": "base_value"}),
+            TestModel(name="overlay", metadata={"key": "base_value"}),
+            False,
+            TestModel(name="overlay", metadata={"key": "base_value"}),
+            {"name"},
+            set(),
+            {"metadata"},
+        ),
+        # Case 5: Base and Overlay models are provided, deep merge (nested dictionaries), subkey3 only in base
+        (
+            TestModel(
+                name="base",
+                metadata={
+                    "key": {"subkey": "base_value", "subkey2": "base_value2", "subkey3": "base_value3"},
+                },
+            ),
+            TestModel(name="overlay", metadata={"key": {"subkey": "overlay_value", "subkey2": "base_value2"}}),
+            True,
+            TestModel(
+                name="overlay",
+                metadata={
+                    "key": {"subkey": "overlay_value", "subkey2": "base_value2", "subkey3": "base_value3"},
+                },
+            ),
+            {"name", "metadata.key.subkey"},
+            {"metadata.key.subkey3"},
+            {"metadata.key.subkey2"},
+        ),
+    ],
+)
+def test_merge_models(
+    base_model, overlay_model, deep_merge, expected_merged, expected_overwritten, expected_unmerged, expected_skipped
+):
+    merged_model, overwritten_keys, unmerged_keys, skipped_keys = merge_models(base_model, overlay_model, deep_merge)
+
+    assert merged_model == expected_merged
+    assert overwritten_keys == expected_overwritten
+    assert skipped_keys == expected_skipped
+    assert unmerged_keys == expected_unmerged
+
+
+@pytest.mark.parametrize(
+    "a, b, expected_overwritten, expected_unmerged, expected_skipped",
+    [
+        (
+            "json_workflow_results",
+            "json_workflow_results_overlay_all",
+            {
+                "artifacts.predictions",
+                "metrics.bertscore.hashcode",
+                "metrics.bertscore.precision",
+                "metrics.bertscore.recall",
+                "metrics.meteor.meteor",
+                "parameters.name",
+            },
+            set(),
+            {
+                "artifacts.evaluation_time",
+                "artifacts.ground_truth",
+                "metrics.bertscore.f1",
+                "metrics.bertscore.f1_mean",
+                "metrics.bertscore.precision_mean",
+                "metrics.bertscore.recall_mean",
+                "metrics.bleu.bleu",
+                "metrics.bleu.bleu_mean",
+                "metrics.g_eval_summarization",
+                "metrics.meteor.meteor_mean",
+                "metrics.rouge.rouge1",
+                "metrics.rouge.rouge1_mean",
+                "metrics.rouge.rouge2",
+                "metrics.rouge.rouge2_mean",
+                "metrics.rouge.rougeL",
+                "metrics.rouge.rougeL_mean",
+                "metrics.rouge.rougeLsum",
+                "metrics.rouge.rougeLsum_mean",
+                "metrics.token_length",
+                "parameters.dataset.path",
+                "parameters.evaluation.max_samples",
+                "parameters.evaluation.metrics",
+                "parameters.evaluation.return_input_data",
+                "parameters.evaluation.return_predictions",
+                "parameters.evaluation.storage_path",
+            },
+        ),
+        (
+            "json_workflow_results",
+            "json_workflow_results_overlay_artifacts_same",
+            {
+                "metrics.bertscore.hashcode",
+                "metrics.bertscore.precision",
+                "metrics.bertscore.recall",
+                "metrics.meteor.meteor",
+                "parameters.name",
+            },
+            set(),
+            {
+                "artifacts.evaluation_time",
+                "artifacts.ground_truth",
+                "artifacts.predictions",
+                "metrics.bertscore.f1",
+                "metrics.bertscore.f1_mean",
+                "metrics.bertscore.precision_mean",
+                "metrics.bertscore.recall_mean",
+                "metrics.bleu.bleu",
+                "metrics.bleu.bleu_mean",
+                "metrics.g_eval_summarization",
+                "metrics.meteor.meteor_mean",
+                "metrics.rouge.rouge1",
+                "metrics.rouge.rouge1_mean",
+                "metrics.rouge.rouge2",
+                "metrics.rouge.rouge2_mean",
+                "metrics.rouge.rougeL",
+                "metrics.rouge.rougeL_mean",
+                "metrics.rouge.rougeLsum",
+                "metrics.rouge.rougeLsum_mean",
+                "metrics.token_length",
+                "parameters.dataset.path",
+                "parameters.evaluation.max_samples",
+                "parameters.evaluation.metrics",
+                "parameters.evaluation.return_input_data",
+                "parameters.evaluation.return_predictions",
+                "parameters.evaluation.storage_path",
+            },
+        ),
+        (
+            "json_workflow_results",
+            "json_workflow_results_overlay_artifacts_missing",
+            {
+                "metrics.bertscore.hashcode",
+                "metrics.bertscore.precision",
+                "metrics.bertscore.recall",
+                "metrics.meteor.meteor",
+                "parameters.name",
+            },
+            {
+                "artifacts.evaluation_time",
+                "artifacts.ground_truth",
+                "artifacts.predictions",
+            },
+            {
+                "metrics.bertscore.f1",
+                "metrics.bertscore.f1_mean",
+                "metrics.bertscore.precision_mean",
+                "metrics.bertscore.recall_mean",
+                "metrics.bleu.bleu",
+                "metrics.bleu.bleu_mean",
+                "metrics.g_eval_summarization",
+                "metrics.meteor.meteor_mean",
+                "metrics.rouge.rouge1",
+                "metrics.rouge.rouge1_mean",
+                "metrics.rouge.rouge2",
+                "metrics.rouge.rouge2_mean",
+                "metrics.rouge.rougeL",
+                "metrics.rouge.rougeL_mean",
+                "metrics.rouge.rougeLsum",
+                "metrics.rouge.rougeLsum_mean",
+                "metrics.token_length",
+                "parameters.dataset.path",
+                "parameters.evaluation.max_samples",
+                "parameters.evaluation.metrics",
+                "parameters.evaluation.return_input_data",
+                "parameters.evaluation.return_predictions",
+                "parameters.evaluation.storage_path",
+            },
+        ),
+    ],
+)
+def test_merge_job_results(a, b, expected_overwritten, expected_unmerged, expected_skipped, request):
+    # Create JobResultObjects from the JSON data
+    job_result_1 = JobResultObject(**request.getfixturevalue(a))
+    job_result_2 = JobResultObject(**request.getfixturevalue(b))
+
+    # Merge the models using your merge_models function
+    merged_model, overwritten_keys, unmerged_keys, skipped_keys = merge_models(
+        job_result_1, job_result_2, deep_merge=True
+    )
+
+    # Assert the merged model is as expected
+    bertscore = merged_model.metrics.get("bertscore", {})
+    assert bertscore != {}
+    bertscore_precision = bertscore.get("precision", [])
+    assert len(bertscore_precision) > 0
+    assert bertscore_precision[0] == 0.2
+    bertscore_hashcode = bertscore.get("hashcode", "")
+    assert bertscore_hashcode == "ROBOTO-large_L17_no-idf_version=0.3.12(hug_trans=4.48.0)"
+    assert merged_model.parameters.get("name", "") == "test2-evaluation/b5700c88-57b5-42d7-a128-aedaf4338117"
+    meteor = merged_model.metrics.get("meteor", {})
+    assert meteor != {}
+    meteor_meteor = meteor.get("meteor", [])
+    assert len(meteor_meteor) > 0
+    assert meteor_meteor[0] == 0.555
+
+    # Assert the overwritten keys are as expected
+    assert overwritten_keys == expected_overwritten
+    assert unmerged_keys == expected_unmerged
+    assert skipped_keys == expected_skipped
+
+
+@pytest.mark.parametrize(
+    "base_dict, overlay_dict, deep_merge, expected_merged, expected_overwritten, expected_unmerged, expected_skipped",
+    [
+        # Case 1: Shallow merge (no recursion)
+        (
+            {"key": "base_value"},
+            {"key": "overlay_value"},
+            False,
+            {"key": "overlay_value"},
+            {"key"},
+            set(),
+            set(),
+        ),
+        # Case 2: Deep merge (nested dictionaries)
+        (
+            {"key": {"subkey": "base_value"}},
+            {"key": {"subkey": "overlay_value"}},
+            True,
+            {"key": {"subkey": "overlay_value"}},
+            {"key.subkey"},
+            set(),
+            set(),
+        ),
+        # Case 3: Overwriting a top-level key (non-nested)
+        (
+            {"key": "base_value"},
+            {"key": "overlay_value"},
+            True,
+            {"key": "overlay_value"},
+            {"key"},
+            set(),
+            set(),
+        ),
+        # Case 4: Overwriting a nested key (deep merge)
+        (
+            {"key": {"subkey": "base_value", "subkey2": "base_value2"}},
+            {"key": {"subkey": "overlay_value"}},
+            True,
+            {"key": {"subkey": "overlay_value", "subkey2": "base_value2"}},
+            {"key.subkey"},
+            {"key.subkey2"},
+            set(),
+        ),
+        # Case 5: No overlay values, so base_dict remains the same
+        (
+            {"key": "base_value"},
+            {},
+            False,
+            {"key": "base_value"},
+            set(),
+            {"key"},
+            set(),
+        ),
+    ],
+)
+def test_deep_merge_dicts(
+    base_dict, overlay_dict, deep_merge, expected_merged, expected_overwritten, expected_unmerged, expected_skipped
+):
+    merged_dict, overwritten_keys, unmerged_keys, skipped_keys = _deep_merge_dicts(base_dict, overlay_dict, deep_merge)
+
+    assert overwritten_keys == expected_overwritten
+    assert skipped_keys == expected_skipped
+    assert unmerged_keys == expected_unmerged
+    assert merged_dict == expected_merged

--- a/lumigator/schemas/lumigator_schemas/utils/model_operations.py
+++ b/lumigator/schemas/lumigator_schemas/utils/model_operations.py
@@ -1,0 +1,93 @@
+from typing import Any, NamedTuple, TypeVar
+
+from pydantic import BaseModel
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class MergeModelResult(NamedTuple):
+    merged_model: T
+    overwritten_keys: set[str]
+    unmerged_keys: set[str]
+    skipped_keys: set[str]
+
+
+def merge_models(base_model: T | None, overlay_model: T | None, deep_merge: bool | None = True) -> MergeModelResult:
+    """Merge two Pydantic model instances with overlay_model taking precedence when it has a value.
+
+    :param base_model: Base model to merge into
+    :param overlay_model: Model with values that will override base_model
+    :param deep_merge: Whether to recursively merge nested dictionaries (True)
+                or just overwrite top-level keys (False). Defaults to True if not supplied.
+    :returns: Tuple of (merged dictionary,
+                set of overwritten key names,
+                set of unmerged key names that were present in the base but absent in the overlay,
+                set of skipped key names - values were the same).
+    """
+    if base_model is None:
+        model_class = type(overlay_model) if overlay_model is not None else None
+        if model_class is None:
+            raise ValueError("Both models cannot be None")
+        return MergeModelResult(
+            overlay_model.model_copy() if overlay_model is not None else model_class(), set(), set(), set()
+        )
+
+    if overlay_model is None:
+        return MergeModelResult(base_model.model_copy(), set(), set(), set())
+
+    # Convert both to dictionaries
+    base_dict = base_model.model_dump()
+    overlay_dict = overlay_model.model_dump()
+
+    # Merge dictionaries recursively or at top level
+    merged_dict, overwritten_keys, unmerged_keys, skipped_keys = _deep_merge_dicts(base_dict, overlay_dict, deep_merge)
+
+    # Create a new instance of the same type as the input models
+    model_class = type(base_model)
+    return MergeModelResult(model_class.model_validate(merged_dict), overwritten_keys, unmerged_keys, skipped_keys)
+
+
+def _deep_merge_dicts(
+    base_dict: dict[str, Any], overlay_dict: dict[str, Any], deep_merge: bool | None = True
+) -> tuple[dict[str, Any], set[str], set[str], set[str]]:
+    """Recursively merge dictionaries with overlay_dict taking precedence when it has a value.
+
+    :param base_dict: Base dictionary
+    :param overlay_dict: Dictionary with values that will override base_dict
+    :param deep_merge: Whether to recursively merge nested dictionaries (True)
+                or just overwrite top-level keys (False). Defaults to True if not supplied.
+    :returns: Tuple of (merged dictionary,
+                set of overwritten key names,
+                set of unmerged key names that were present in the base but absent in the overlay,
+                set of skipped key names - values were the same).
+    """
+    result = base_dict.copy()
+    overwritten_keys = set()
+    skipped_keys = set()
+    # Add missing keys from base_dict that aren't in overlay_dict
+    unmerged_keys = set(base_dict.keys() - overlay_dict.keys())
+
+    for key, value in overlay_dict.items():
+        if deep_merge and key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            # Recursively merge nested dictionaries
+            nested_result, nested_overwritten, nested_missing, nested_skipped = _deep_merge_dicts(
+                result[key], value, deep_merge
+            )
+            result[key] = nested_result
+            # Add nested keys with their path
+            overwritten_keys.update({f"{key}.{nested_key}" for nested_key in nested_overwritten})
+            unmerged_keys.update({f"{key}.{nested_key}" for nested_key in nested_missing})
+            skipped_keys.update({f"{key}.{nested_key}" for nested_key in nested_skipped})
+        elif key in result:
+            if result[key] != value:
+                # If the value is different, overwrite it
+                overwritten_keys.add(key)
+                result[key] = value
+            else:
+                # If the value is the same, mark it as skipped
+                skipped_keys.add(key)
+        else:
+            # If the key is not in the base_dict, just add it
+            result[key] = value
+
+    return result, overwritten_keys, unmerged_keys, skipped_keys


### PR DESCRIPTION
# What's changing

Adds `merge_models` from `model_operations` as a schema util that allows you to merge two of the same Pydantic models (including a deep merge). 

It returns the resulting merged model ... along with some sets identifying:

* Overwritten keys that appeared in both models and the values were different
* Un-merged keys that only appeared in the base model and not the overlay (they are present in the final model)
* Skipped keys that existed in both, but already had the same value

Added tests to cover the functionality.

# How to test it

Unit tests in the PR cover testing.

# Additional notes for reviewers

This can be used to merge job results in the MLFlow tracking client when it attempts to generate the compiled results for a workflow.

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
