### PR TITLE
MLFlow: Update docker deployment for MLFlow to support S3

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -215,6 +215,7 @@ services:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - AWS_DEFAULT_REGION
+      - AWS_ENDPOINT_URL
       - MLFLOW_TRACKING_URI
       - MLFLOW_DATABASE_URL
       - MLFLOW_S3_ROOT_PATH
@@ -223,7 +224,13 @@ services:
     depends_on:
       minio:
         condition: service_healthy
-    command: mlflow server --backend-store-uri ${MLFLOW_DATABASE_URL} --default-artifact-root ${MLFLOW_S3_ROOT_PATH} --host 0.0.0.0
+    command:
+      - sh
+      - -c
+      - |
+        pip install --upgrade pip > /dev/null 2>&1
+        pip install --no-cache-dir mlflow[extras] > /dev/null 2>&1
+        mlflow server --backend-store-uri ${MLFLOW_DATABASE_URL} --default-artifact-root ${MLFLOW_S3_ROOT_PATH} --host 0.0.0.0
     extra_hosts:
       - "localhost:host-gateway"
     profiles:


### PR DESCRIPTION
# What's changing

* Updates Docker compose file to:
  * `boto3` Python package needs to be manually installed
  * `AWS_ENDPOINT_URL` is needed by `boto3` so we know where to contact minio


Refs #1276 

# How to test it

Steps to test the changes:

1. `make local-up`
2. Run an experiment
3. Browser to http://localhost:8001/ and try to list the experiments artifacts
4. Should get no error

# Additional notes for reviewers

You can check local S3 storage via http://localhost:9001.

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
