### PR TITLE
fix: dont render metrics columns if they're null/undefined

### DIFF
--- a/lumigator/frontend/src/helpers/getExperimentResults.ts
+++ b/lumigator/frontend/src/helpers/getExperimentResults.ts
@@ -36,13 +36,13 @@ export type TableDataForWorkflowResults = {
   Examples: string
   'Ground Truth': string
   predictions: string
-  'rouge-1': string | number
-  'rouge-2': string | number
-  'rouge-l': string | number
-  meteor: string | number
-  'bert-p': string | number
-  'bert-f1': string | number
-  bleu: string | number
+  'rouge-1'?: string
+  'rouge-2'?: string
+  'rouge-l'?: string
+  meteor?: string
+  'bert-p'?: string
+  'bert-f1'?: string
+  bleu?: string
   model_size?: string
   parameters?: string
   // evaluation_time: string
@@ -55,12 +55,6 @@ function transformExperimentResults(
 ): TableDataForExperimentResults {
   const data = objectData
   const model = models.find((model) => model.model === data.artifacts.model)
-  // const filteredMetrics  = Object.keys(data.metrics).reduce((acc, key) => {
-  //  if(data.metrics[key]) {
-  //     acc[key as any] = data.metrics[key]
-  //   }
-  //   return acc
-  // }, {})
 
   return {
     model: data.artifacts.model,
@@ -97,25 +91,16 @@ export function transformWorkflowResults(
       Examples: example,
       'Ground Truth': objectData.artifacts.ground_truth?.[index],
       predictions: objectData.artifacts.predictions?.[index],
-      meteor: objectData.metrics.meteor?.meteor?.[index].toFixed(2) ?? 0,
-      'bert-p': objectData.metrics.bertscore?.precision?.[index].toFixed(2) ?? 0,
-      'bert-r': objectData.metrics.bertscore?.recall?.[index].toFixed(2) ?? 0,
-      'bert-f1': objectData.metrics.bertscore?.f1?.[index].toFixed(2) ?? 0,
-      'rouge-1': objectData.metrics.rouge?.rouge1?.[index].toFixed(2) ?? 0,
-      'rouge-2': objectData.metrics.rouge?.rouge2?.[index].toFixed(2) ?? 0,
-      'rouge-l': objectData.metrics.rouge?.rougeL?.[index].toFixed(2) ?? 0,
-      bleu: objectData.metrics.bleu?.bleu?.[index].toFixed(2) ?? 0,
-      // bert_recall: objectData.metrics.bertscore?.recall?.[index].toFixed(2) ?? 0,
-      evaluation_time: objectData.artifacts.evaluation_time.toFixed(2) ?? 0,
-      // meteor_mean: objectData.metrics.meteor?.meteor_mean.toFixed(2) ?? 0,
-      // bleu_mean: objectData.metrics.bleu?.bleu_mean.toFixed(2) ?? 0,
-      // model: objectData.artifacts.model,
-      // rouge1_mean: objectData.metrics.rouge?.rouge1_mean.toFixed(2) ?? 0,
-      // rouge2_mean: objectData.metrics.rouge?.rouge2_mean.toFixed(2) ?? 0,
-      // rougeL_mean: objectData.metrics.rouge?.rougeL_mean.toFixed(2) ?? 0,
-      // rougeLsum: objectData.metrics.rouge?.rougeLsum?.[index].toFixed(2) ?? 0,
-      // rougeLsum_mean: objectData.metrics.rouge?.rougeLsum_mean.toFixed(2) ?? 0,
-      inference_time: objectData.artifacts.inference_time.toFixed(2) ?? 0,
+      ...(objectData.metrics.meteor && { meteor: objectData.metrics.meteor.meteor?.[index].toFixed(2) }),
+      ...(objectData.metrics.bertscore && { 'bert-p': objectData.metrics.bertscore.precision?.[index].toFixed(2) }),
+      ...(objectData.metrics.bertscore && { 'bert-r': objectData.metrics.bertscore.recall?.[index].toFixed(2) }),
+      ...(objectData.metrics.bertscore && { 'bert-f1': objectData.metrics.bertscore.f1?.[index].toFixed(2) }),
+      ...(objectData.metrics.rouge && { 'rouge-1': objectData.metrics.rouge.rouge1?.[index].toFixed(2) }),
+      ...(objectData.metrics.rouge && { 'rouge-2': objectData.metrics.rouge.rouge2?.[index].toFixed(2) }),
+      ...(objectData.metrics.rouge && { 'rouge-l': objectData.metrics.rouge.rougeL?.[index].toFixed(2) }),
+      ...(objectData.metrics.bleu && { bleu: objectData.metrics.bleu.bleu?.[index].toFixed(2) }),
+      evaluation_time: String(objectData.artifacts.evaluation_time.toFixed(2) ?? '0'),
+      inference_time: String(objectData.artifacts.inference_time.toFixed(2) ?? '0'),
     }
   })
 }

--- a/lumigator/frontend/src/helpers/getExperimentResults.ts
+++ b/lumigator/frontend/src/helpers/getExperimentResults.ts
@@ -21,14 +21,14 @@ export async function getExperimentResults(
 
 export type TableDataForExperimentResults = {
   model: string
-  'bert-p': string
-  Meteor: string
-  'bert-r': string
-  'bert-f1': string
-  'rouge-1': string
-  'rouge-2': string
-  'rouge-l': string
-  bleu: string
+  'bert-p'?: string
+  Meteor?: string
+  'bert-r'?: string
+  'bert-f1'?: string
+  'rouge-1'?: string
+  'rouge-2'?: string
+  'rouge-l'?: string
+  bleu?: string
   // runTime: string | undefined
   subRows: TableDataForWorkflowResults[]
 }
@@ -36,13 +36,13 @@ export type TableDataForWorkflowResults = {
   Examples: string
   'Ground Truth': string
   predictions: string
-  'rouge-1': string
-  'rouge-2': string
-  'rouge-l': string
-  meteor: string
-  'bert-p': string
-  'bert-f1': string
-  bleu: string
+  'rouge-1': string | number
+  'rouge-2': string | number
+  'rouge-l': string | number
+  meteor: string | number
+  'bert-p': string | number
+  'bert-f1': string | number
+  bleu: string | number
   model_size?: string
   parameters?: string
   // evaluation_time: string
@@ -55,16 +55,23 @@ function transformExperimentResults(
 ): TableDataForExperimentResults {
   const data = objectData
   const model = models.find((model) => model.model === data.artifacts.model)
+  // const filteredMetrics  = Object.keys(data.metrics).reduce((acc, key) => {
+  //  if(data.metrics[key]) {
+  //     acc[key as any] = data.metrics[key]
+  //   }
+  //   return acc
+  // }, {})
+
   return {
     model: data.artifacts.model,
-    Meteor: data.metrics.meteor.meteor_mean.toFixed(2),
-    'bert-p': data.metrics.bertscore.precision_mean.toFixed(2),
-    'bert-r': data.metrics.bertscore.recall_mean.toFixed(2),
-    'bert-f1': data.metrics.bertscore.f1_mean.toFixed(2),
-    'rouge-1': data.metrics.rouge.rouge1_mean.toFixed(2),
-    'rouge-2': data.metrics.rouge.rouge2_mean.toFixed(2),
-    'rouge-l': data.metrics.rouge.rougeL_mean.toFixed(2),
-    bleu: data.metrics.bleu.bleu_mean.toFixed(2),
+    ...(data.metrics.meteor && { Meteor: data.metrics.meteor.meteor_mean.toFixed(2) }),
+    ...(data.metrics.bertscore && { 'bert-p': data.metrics.bertscore.precision_mean.toFixed(2) }),
+    ...(data.metrics.bertscore && { 'bert-r': data.metrics.bertscore.recall_mean.toFixed(2) }),
+    ...(data.metrics.bertscore && { 'bert-f1': data.metrics.bertscore.f1_mean.toFixed(2) }),
+    ...(data.metrics.rouge && { 'rouge-1': data.metrics.rouge.rouge1_mean.toFixed(2) }),
+    ...(data.metrics.rouge && { 'rouge-2': data.metrics.rouge.rouge2_mean.toFixed(2) }),
+    ...(data.metrics.rouge && { 'rouge-l': data.metrics.rouge.rougeL_mean.toFixed(2) }),
+    ...(data.metrics.bleu && { bleu: data.metrics.bleu.bleu_mean.toFixed(2) }),
     ...(model &&
       model.info && {
         'model size': model.info.model_size.replace(/(\d+(?:\.\d+)?)([a-zA-Z]+)/g, '$1 $2'),

--- a/lumigator/frontend/src/helpers/getExperimentResults.ts
+++ b/lumigator/frontend/src/helpers/getExperimentResults.ts
@@ -91,13 +91,27 @@ export function transformWorkflowResults(
       Examples: example,
       'Ground Truth': objectData.artifacts.ground_truth?.[index],
       predictions: objectData.artifacts.predictions?.[index],
-      ...(objectData.metrics.meteor && { meteor: objectData.metrics.meteor.meteor?.[index].toFixed(2) }),
-      ...(objectData.metrics.bertscore && { 'bert-p': objectData.metrics.bertscore.precision?.[index].toFixed(2) }),
-      ...(objectData.metrics.bertscore && { 'bert-r': objectData.metrics.bertscore.recall?.[index].toFixed(2) }),
-      ...(objectData.metrics.bertscore && { 'bert-f1': objectData.metrics.bertscore.f1?.[index].toFixed(2) }),
-      ...(objectData.metrics.rouge && { 'rouge-1': objectData.metrics.rouge.rouge1?.[index].toFixed(2) }),
-      ...(objectData.metrics.rouge && { 'rouge-2': objectData.metrics.rouge.rouge2?.[index].toFixed(2) }),
-      ...(objectData.metrics.rouge && { 'rouge-l': objectData.metrics.rouge.rougeL?.[index].toFixed(2) }),
+      ...(objectData.metrics.meteor && {
+        meteor: objectData.metrics.meteor.meteor?.[index].toFixed(2),
+      }),
+      ...(objectData.metrics.bertscore && {
+        'bert-p': objectData.metrics.bertscore.precision?.[index].toFixed(2),
+      }),
+      ...(objectData.metrics.bertscore && {
+        'bert-r': objectData.metrics.bertscore.recall?.[index].toFixed(2),
+      }),
+      ...(objectData.metrics.bertscore && {
+        'bert-f1': objectData.metrics.bertscore.f1?.[index].toFixed(2),
+      }),
+      ...(objectData.metrics.rouge && {
+        'rouge-1': objectData.metrics.rouge.rouge1?.[index].toFixed(2),
+      }),
+      ...(objectData.metrics.rouge && {
+        'rouge-2': objectData.metrics.rouge.rouge2?.[index].toFixed(2),
+      }),
+      ...(objectData.metrics.rouge && {
+        'rouge-l': objectData.metrics.rouge.rougeL?.[index].toFixed(2),
+      }),
       ...(objectData.metrics.bleu && { bleu: objectData.metrics.bleu.bleu?.[index].toFixed(2) }),
       evaluation_time: String(objectData.artifacts.evaluation_time.toFixed(2) ?? '0'),
       inference_time: String(objectData.artifacts.inference_time.toFixed(2) ?? '0'),

--- a/lumigator/frontend/src/types/Metrics.ts
+++ b/lumigator/frontend/src/types/Metrics.ts
@@ -15,10 +15,10 @@ export type Artifacts = {
 }
 
 export type MetricsResult = {
-  bertscore: Bertscore
-  meteor: Meteor
-  rouge: Rouge
-  bleu: {
+  bertscore?: Bertscore
+  meteor?: Meteor
+  rouge?: Rouge
+  bleu?: {
     bleu: number[]
     bleu_mean: number
   }


### PR DESCRIPTION
# What's changing

When running evaluation via the SDK or API, users can select a subset of metrics -> this PR renders only the chosen metrics

> If this PR is related to an issue or closes one, please link it here.

Refs #...
Closes #...

# How to test it

Steps to test the changes:

1.
2.
3.

# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
