### PR TITLE
`pre-commit`: fixes/updates

### DIFF
--- a/.github/workflows/lumigator_pipeline.yaml
+++ b/.github/workflows/lumigator_pipeline.yaml
@@ -31,21 +31,14 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
 
-      - name: Install python
-        run: uv python install
-
-      - name: Create a virtual environment
-        run: uv venv
+      - name: Install Python and virtual environment
+        run: uv sync
 
       - name: Install pre-commit
-        run: |
-          source .venv/bin/activate
-          uv pip install pre-commit
+        run: uv run pre-commit install
 
       - name: Run pre-commit
-        run: |
-          source .venv/bin/activate
-          pre-commit run --all-files
+        run: uv run pre-commit run --all-files
         continue-on-error: false
 
   lint-frontend:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,10 @@ repos:
         args:
           - --config
           - ruff.toml
+
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    # uv version.
+    rev: 0.6.9
+    hooks:
+      # Update the uv lockfile
+      - id: uv-lock

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ endef
 
 # Launches Lumigator in 'development' mode (all services running locally, code mounted in)
 local-up: config-generate-env
-	uv run pre-commit install
+	uv sync && uv run pre-commit install
 	RAY_ARCH_SUFFIX=$(RAY_ARCH_SUFFIX) ARCH=${ARCH} COMPUTE_TYPE=$(COMPUTE_TYPE) docker compose --env-file "$(CONFIG_BUILD_DIR)/.env" --profile local $(GPU_COMPOSE)  -f $(LOCAL_DOCKERCOMPOSE_FILE) -f $(DEV_DOCKER_COMPOSE_FILE) up --watch --build
 
 local-down: config-generate-env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Common deps to develop"
 requires-python = ">=3.11"
 dependencies = [
-    "pre-commit>=4.0.1",
+    "pre-commit>=4.2.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ requires-dist = [
     { name = "autodoc", marker = "extra == 'docs'", specifier = ">=0.5.0" },
     { name = "loguru", marker = "extra == 'docs'", specifier = "==0.7.2" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0.0" },
-    { name = "pre-commit", specifier = ">=4.0.1" },
+    { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pydantic", marker = "extra == 'docs'", specifier = ">=2.10.0" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.2.0" },
     { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = ">=0.5.2" },
@@ -2013,7 +2013,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.1.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -2022,9 +2022,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/13/b62d075317d8686071eb843f0bb1f195eb332f48869d3c31a4c6f1e063ac/pre_commit-4.1.0.tar.gz", hash = "sha256:ae3f018575a588e30dfddfab9a05448bfbd6b73d78709617b5a2b853549716d4", size = 193330 }
+sdist = { url = "https://files.pythonhosted.org/packages/08/39/679ca9b26c7bb2999ff122d50faa301e49af82ca9c066ec061cfbc0c6784/pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146", size = 193424 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/b3/df14c580d82b9627d173ceea305ba898dca135feb360b6d84019d0803d3b/pre_commit-4.1.0-py2.py3-none-any.whl", hash = "sha256:d29e7cb346295bcc1cc75fc3e92e343495e3ea0196c9ec6ba53f49f10ab6ae7b", size = 220560 },
+    { url = "https://files.pythonhosted.org/packages/88/74/a88bf1b1efeae488a0c0b7bdf71429c313722d1fc0f377537fbe554e6180/pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd", size = 220707 },
 ]
 
 [[package]]


### PR DESCRIPTION
# What's changing

* Update version of pre-commit to 4.2.0 (from 4.1.0)
* Ensure makefile forces the version of pre-commit specified in the pyproject.toml
* Refactor GHA pipeline to use uv more
* Add uv.lock to pre-commit checks
* Update uv.lock file

# How to test it

Steps to test the changes:

1.
2.
3.

# Additional notes for reviewers

Running `uv sync` will install the version of Python specified in the repo, create a .venv and source it for us.

We still run `uv run pre-commit install` to install the git hooks for pre-commit.

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
