### PR TITLE
Tracking client: update MLFlow run status when we update the status tag

### DIFF
--- a/lumigator/backend/backend/tests/unit/tracking/test_mlflow.py
+++ b/lumigator/backend/backend/tests/unit/tracking/test_mlflow.py
@@ -1,0 +1,62 @@
+import pytest
+from lumigator_schemas.workflows import WorkflowStatus
+from mlflow.entities import RunStatus
+
+from backend.tracking.mlflow import MLflowTrackingClient
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tracking_status, workflow_status, expected",
+    [
+        ("SCHEDULED", WorkflowStatus.CREATED, True),
+        ("RUNNING", WorkflowStatus.RUNNING, True),
+        ("FAILED", WorkflowStatus.FAILED, True),
+        ("FINISHED", WorkflowStatus.SUCCEEDED, True),
+        # Negative cases
+        ("FAILED", WorkflowStatus.SUCCEEDED, False),
+        ("RUNNING", WorkflowStatus.CREATED, False),
+    ],
+)
+async def test_is_status_mapped_valid_and_invalid_mappings(fake_s3fs, tracking_status, workflow_status, expected):
+    client = MLflowTrackingClient(tracking_uri="dummy_uri", s3_file_system=fake_s3fs)
+    result = await client.is_status_match(tracking_status, workflow_status)
+    assert result is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_status", ["INVALID", "", None, "123"])
+async def test_is_status_mapped_invalid_status_raises(fake_s3fs, invalid_status):
+    client = MLflowTrackingClient(tracking_uri="dummy_uri", s3_file_system=fake_s3fs)
+    with pytest.raises(ValueError, match="Status '.*' not valid."):
+        await client.is_status_match(invalid_status, WorkflowStatus.RUNNING)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tracking_status,expected_terminal",
+    [
+        ("FINISHED", True),
+        ("FAILED", True),
+        ("SCHEDULED", False),
+        ("RUNNING", False),
+    ],
+)
+async def test_is_status_terminal_valid_statuses(fake_s3fs, tracking_status, expected_terminal):
+    client = MLflowTrackingClient(tracking_uri="dummy_uri", s3_file_system=fake_s3fs)
+    result = await client.is_status_terminal(tracking_status)
+    assert result is expected_terminal
+
+
+@pytest.mark.asyncio
+async def test_is_status_terminal_invalid_status_string(fake_s3fs):
+    client = MLflowTrackingClient(tracking_uri="dummy_uri", s3_file_system=fake_s3fs)
+    with pytest.raises(ValueError, match="Status 'UNKNOWN' not valid."):
+        await client.is_status_terminal("UNKNOWN")
+
+
+@pytest.mark.asyncio
+async def test_is_status_terminal_unmapped_status(fake_s3fs, monkeypatch):
+    client = MLflowTrackingClient(tracking_uri="http://fake-tracking-uri", s3_file_system=fake_s3fs)
+    with pytest.raises(ValueError, match="Status 'KILLED' not found in mapping."):
+        await client.is_status_terminal(RunStatus.to_string(RunStatus.KILLED))

--- a/lumigator/backend/backend/tracking/tracking_interface.py
+++ b/lumigator/backend/backend/tracking/tracking_interface.py
@@ -105,6 +105,23 @@ class TrackingClient(Protocol):
         """List all jobs for a workflow."""
         ...
 
+    async def is_status_match(self, tracking_client_status: str, workflow_status: WorkflowStatus) -> bool:
+        """Checks whether the given tracking client status correctly maps to the specified workflow status.
+
+        :param tracking_client_status: The status understood by the tracking client.
+        :param workflow_status: A workflow status to compare against.
+        :return: True if the status matches, False otherwise.
+        """
+        ...
+
+    async def is_status_terminal(self, tracking_client_status: str) -> bool:
+        """Checks whether the given tracking client status is terminal.
+
+        :param tracking_client_status: The status understood by the tracking client.
+        :return: True if the status is terminal, False otherwise.
+        """
+        ...
+
 
 class TrackingClientManager(Protocol):
     """Interface for tracking client managers."""

--- a/lumigator/backend/pyproject.toml
+++ b/lumigator/backend/pyproject.toml
@@ -37,3 +37,4 @@ lumigator-schemas = { path = "../schemas", editable = true }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
# What's changing

* Updates the status of the run in MLFlow as well as the tag we create for status.

# How to test it

Steps to test the changes:

1.
2.
3.

# Additional notes for reviewers

This is the 'status' shown in MLFlow when we don't come back to update it at the end:

![image](https://github.com/user-attachments/assets/9a743e23-5fec-43ec-9802-8eeaca208a03)

Now the status no longer says 'Running'

![image](https://github.com/user-attachments/assets/0628dd9f-c522-411f-9450-8db75caa9794)

So we can see what was successful/failed in the MLFlow dashboard too:

![image](https://github.com/user-attachments/assets/954398a2-72a7-4c13-9225-468006541ad3)

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
