### PR TITLE
Job service: fix bug in getting incomplete jobs that Ray no longer knows about

### DIFF
--- a/lumigator/backend/backend/services/jobs.py
+++ b/lumigator/backend/backend/services/jobs.py
@@ -110,15 +110,15 @@ class JobService:
         secret_service: SecretService,
         background_tasks: BackgroundTasks,
     ):
-        self.job_repo = job_repo
-        self.result_repo = result_repo
-        self.ray_client = ray_client
+        self._job_repo = job_repo
+        self._result_repo = result_repo
+        self._ray_client = ray_client
         self._dataset_service = dataset_service
         self._secret_service = secret_service
         self._background_tasks = background_tasks
 
     def _get_job_record_per_type(self, job_type: str) -> list[JobRecord]:
-        records = self.job_repo.get_by_job_type(job_type)
+        records = self._job_repo.get_by_job_type(job_type)
         if records is None:
             return []
         return records
@@ -131,7 +131,7 @@ class JobService:
         :rtype: JobRecord
         :raises JobNotFoundError: If the job does not exist
         """
-        record = self.job_repo.get(job_id)
+        record = self._job_repo.get(job_id)
         if record is None:
             raise JobNotFoundError(job_id) from None
 
@@ -182,7 +182,7 @@ class JobService:
         :rtype: JobRecord
         :raises JobNotFoundError: If the job does not exist in the database
         """
-        record = self.job_repo.update(job_id, **updates)
+        record = self._job_repo.update(job_id, **updates)
         if record is None:
             raise JobNotFoundError(job_id) from None
 
@@ -312,18 +312,20 @@ class JobService:
     def get_upstream_job_status(self, job_id: UUID) -> str:
         """Returns the (lowercase) status of the upstream job.
 
-        Example: PENDING, RUNNING, STOPPED, SUCCEEDED, FAILED.
+        Example: pending, running, stopped, succeeded, failed.
 
         :param job_id: The ID of the job to retrieve the status for.
         :return: The status of the upstream job.
-        :rtype: str
-        :raises JobUpstreamError: If there is an error with the upstream service returning the
-                                  job status
+        :raises JobNotFoundError: If the job cannot be found in the upstream service.
+        :raises JobUpstreamError: If there is an error with the upstream service returning the job status
         """
         try:
-            status_response = self.ray_client.get_job_status(str(job_id))
+            status_response = self._ray_client.get_job_status(str(job_id))
             return str(status_response.value.lower())
         except RuntimeError as e:
+            # See: https://github.com/ray-project/ray/blob/24ad12d81f8201859f2f00919929e00a750fa4d2/python/ray/dashboard/modules/dashboard_sdk.py#L282-L285
+            if "status code 404" in str(e):
+                raise JobNotFoundError(job_id, "Job not found in upstream Ray service") from e
             raise JobUpstreamError("ray", "error getting Ray job status") from e
 
     def get_job_logs(self, job_id: UUID) -> JobLogsResponse:
@@ -335,7 +337,7 @@ class JobService:
         :raises JobUpstreamError: If there is an error with the upstream service returning the job logs,
                 and there are no logs currently persisted in Lumigator's storage.
         """
-        job = self.job_repo.get(job_id)
+        job = self._job_repo.get(job_id)
         if not job:
             raise JobNotFoundError(job_id) from None
 
@@ -456,7 +458,7 @@ class JobService:
         # Create a db record for the job
         # To find the experiment that a job belongs to,
         # we'd use https://mlflow.org/docs/latest/python_api/mlflow.client.html#mlflow.client.MlflowClient.search_runs
-        record = self.job_repo.create(name=request.name, description=request.description, job_type=job_type)
+        record = self._job_repo.create(name=request.name, description=request.description, job_type=job_type)
         job_result_storage_path = self._get_s3_uri(record.id)
         dataset_s3_path = self._dataset_service.get_dataset_s3_path(request.dataset)
         job_config = job_settings.generate_config(request, record.id, dataset_s3_path, job_result_storage_path)
@@ -506,7 +508,7 @@ class JobService:
             num_gpus=settings.RAY_WORKER_GPUS,
         )
         loguru.logger.info(f"Submitting {job_type} Ray job...")
-        submit_ray_job(self.ray_client, entrypoint)
+        submit_ray_job(self._ray_client, entrypoint)
 
         # NOTE: Only inference jobs can store results in a dataset atm. Among them:
         # - prediction jobs are run in a workflow before evaluations => they trigger dataset saving
@@ -532,20 +534,21 @@ class JobService:
         :return: the job record which includes information on whether a job belongs to an experiment
         :rtype: JobRecord
         :raises JobNotFoundError: If the job does not exist
+        :raises JobUpstreamError: If there is an error with the upstream service returning the latest job status.
         """
         record = self._get_job_record(job_id)
-        loguru.logger.info(f"Obtaining info for job {job_id}: {record.name}")
+        loguru.logger.info(f"Obtained info for job ID: {job_id} name: {record.name}")
 
+        # If the job is finished (successfully or not), return the record.
         if record.status.value in self.TERMINAL_STATUS:
             return JobResponse.model_validate(record)
 
-        # get job status from ray
-        job_status = self.ray_client.get_job_status(job_id)
-        loguru.logger.info(f"Obtaining info from ray for job {job_id}: {job_status}")
+        # Attempt to get the latest job status from the upstream service.
+        job_status = self.get_upstream_job_status(job_id)
 
-        # update job status in the DB if it differs from the current status
-        if job_status.lower() != record.status.value.lower():
-            record = self._update_job_record(job_id, status=job_status.lower())
+        # Update job status in the DB if it differs from the current status
+        if job_status != record.status.value.lower():
+            record = self._update_job_record(job_id, status=job_status)
 
         return JobResponse.model_validate(record)
 
@@ -558,7 +561,7 @@ class JobService:
         # It would be better if we could just feed an empty dict,
         # but this complicates things at the ORM level,
         # see https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.or_
-        records = self.job_repo.list(
+        records = self._job_repo.list(
             skip,
             limit,
             criteria=[or_(*[JobRecord.job_type == job_type for job_type in job_types])],
@@ -593,7 +596,7 @@ class JobService:
         :rtype: JobResultResponse
         :raises JobNotFoundError: if the job does not exist
         """
-        result_record = self.result_repo.get_by_job_id(job_id)
+        result_record = self._result_repo.get_by_job_id(job_id)
         if result_record is None:
             raise JobNotFoundError(job_id) from None
 

--- a/lumigator/backend/backend/tests/conftest.py
+++ b/lumigator/backend/backend/tests/conftest.py
@@ -26,6 +26,7 @@ from lumigator_schemas.jobs import (
     JobType,
 )
 from lumigator_schemas.models import ModelsResponse
+from ray.dashboard.modules.job.sdk import JobSubmissionClient
 from s3fs import S3FileSystem
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.orm import Session
@@ -443,8 +444,18 @@ def job_record(db_session):
 
 
 @pytest.fixture(scope="function")
-def job_service(db_session, job_repository, result_repository, dataset_service, secret_service, background_tasks):
-    return JobService(job_repository, result_repository, None, dataset_service, secret_service, background_tasks)
+def fake_ray_client() -> JobSubmissionClient:
+    """Mocked Ray client for testing."""
+    return MagicMock(spec=JobSubmissionClient)
+
+
+@pytest.fixture(scope="function")
+def job_service(
+    db_session, job_repository, result_repository, fake_ray_client, dataset_service, secret_service, background_tasks
+):
+    return JobService(
+        job_repository, result_repository, fake_ray_client, dataset_service, secret_service, background_tasks
+    )
 
 
 @pytest.fixture(scope="function")
@@ -541,3 +552,9 @@ def model_specs_data() -> list[ModelsResponse]:
     models = [ModelsResponse.model_validate(item) for item in model_specs]
 
     return models
+
+
+@pytest.fixture(scope="function")
+def valid_job_id() -> UUID:
+    """Fixture that returns a random UUID."""
+    return UUID("d34dbeef-4bea-4d19-ad06-214202165812")


### PR DESCRIPTION
# What's changing

* Improved granularity of error handling for `get_upstream_job_status`
* Added tests for `get_upstream_job_status`
* Changed `get_job` to use `get_upstream_job_status` instead of the Ray client directly.
* Minor renaming to indicate that the class fields are private

Closes #1296

# How to test it

Steps to test the changes:

1. `make local-up`
2. Start some jobs/experiments (don't let them finish)
3. `make local-down` and `make clean-all` to remove everything (except the database it seems, which is good for this test)
4. `make local-up` and visit the UI .. we shouldn't be getting the wild logs in the server now

# Additional notes for reviewers


# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
