### PR TITLE
Update docs to fix broken links

### DIFF
--- a/docs/source/user-guides/local-models.md
+++ b/docs/source/user-guides/local-models.md
@@ -149,7 +149,7 @@ user@host:~/$ export HUGGING_FACE_HUB_TOKEN=<your_huggingface_token>
 
 ### Procedure
 
-1. Setup vLLM Completions Endpoint Locally. While vLLM provides an [official Docker image](https://docs.vllm.ai/en/latest/deployment/docker.html#use-vllm-s-official-docker-image), it assumes that you have GPUs available. However, if you are running vLLM on a machine without GPUs, you can use the [Dockerfile.cpu](https://github.com/vllm-project/vllm/blob/main/Dockerfile.cpu) for x86 architecture and [Dockerfile.arm](https://github.com/vllm-project/vllm/blob/main/Dockerfile.arm) for ARM architecture.
+1. Setup vLLM Completions Endpoint Locally. While vLLM provides an [official Docker image](https://docs.vllm.ai/en/latest/deployment/docker.html#use-vllm-s-official-docker-image), it assumes that you have GPUs available. However, if you are running vLLM on a machine without GPUs, you can use the [Dockerfile.cpu](https://github.com/vllm-project/vllm/blob/main/docker/Dockerfile.cpu) for x86 architecture and [Dockerfile.arm](https://github.com/vllm-project/vllm/blob/main/docker/Dockerfile.arm) for ARM architecture.
 
    ```console
    user@host:~/$ git clone https://github.com/vllm-project/vllm.git


### PR DESCRIPTION
# What's changing

VLLM project [moved their docker files](https://github.com/vllm-project/vllm/pull/14549) to `docker/`, this PR updates the docs links.


# How to test it

Steps to test the changes:

1. If the GHA tests all pass, we're good.

# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
