### PR TITLE
Parse and provide Lumigator backend version

### DIFF
--- a/lumigator/backend/backend/main.py
+++ b/lumigator/backend/backend/main.py
@@ -76,6 +76,7 @@ def create_app() -> FastAPI:
     _init_db()
 
     app = FastAPI(**LUMIGATOR_APP_TAGS)
+    logger.info(f"Lumigator backend, version: {settings.VERSION}")
 
     # Get the allowed origins for CORS requests.
     origins = settings.API_CORS_ALLOWED_ORIGINS

--- a/lumigator/backend/backend/settings.py
+++ b/lumigator/backend/backend/settings.py
@@ -1,7 +1,9 @@
 import os
 import re
+import tomllib
 from collections.abc import Mapping
 from enum import Enum
+from pathlib import Path
 from typing import Final
 
 from lumigator_schemas.extras import DeploymentType
@@ -174,6 +176,23 @@ class BackendSettings(BaseSettings):
                 result.append(o)
 
         return result
+
+    @computed_field
+    @property
+    def PROJECT_ROOT(self) -> Path:  # noqa: N802
+        """Returns the root path of the Lumigator backend project."""
+        return Path(__file__).resolve().parent.parent
+
+    @computed_field
+    @property
+    def VERSION(self) -> str:  # noqa: N802
+        """Returns the version of the Lumigator backend."""
+        try:
+            with Path.open(Path(self.PROJECT_ROOT / "pyproject.toml"), "rb") as f:
+                data = tomllib.load(f)
+            return data["project"]["version"]
+        except Exception as e:
+            raise RuntimeError("Unable to retrieve Lumigator backend version.") from e
 
 
 settings = BackendSettings()

--- a/lumigator/backend/backend/tests/unit/test_settings.py
+++ b/lumigator/backend/backend/tests/unit/test_settings.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -89,3 +90,19 @@ def test_augment_ray_worker_env_vars(input_env_vars, mock_env_vars, ray_worker_e
         assert result == expected_result
         # Ensure the input dictionary is not mutated
         assert input_env_vars == input_copy
+
+
+def test_backend_project_root():
+    """Test to ensure we know the project root."""
+    from backend.settings import settings
+
+    # This test should be running from: lumigator/backend/backend/tests/unit
+    expected_path = Path(__file__).resolve().parent.parent.parent.parent
+    assert settings.PROJECT_ROOT == expected_path
+
+
+def test_backend_version():
+    """Test to ensure we know the current backend version."""
+    from backend.settings import settings
+
+    assert settings.VERSION == "0.1.3-alpha"

--- a/lumigator/backend/backend/tracking/mlflow.py
+++ b/lumigator/backend/backend/tracking/mlflow.py
@@ -82,7 +82,7 @@ class MLflowTrackingClient(TrackingClient):
             "task_definition": task_definition.model_dump_json(),
             "dataset": str(dataset),
             "max_samples": str(max_samples),
-            "lumigator_version": "0.2.1",
+            "lumigator_version": settings.VERSION,
         }
 
         # Try to create the experiment and handle any conflicts


### PR DESCRIPTION
# What's changing

* Version for Lumigator backend available in code at runtime
* Log version on startup
* MLFlow `create_experiment` uses accurate version as a tag

Closes" #1303 

# How to test it

Steps to test the changes:

1.
2.
3.

# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
