### PR TITLE
Remove BART large from annotation job in integration suite

### DIFF
--- a/lumigator/backend/backend/tests/integration/api/routes/test_api_workflows.py
+++ b/lumigator/backend/backend/tests/integration/api/routes/test_api_workflows.py
@@ -175,8 +175,15 @@ def test_upload_data_no_gt_launch_annotation(
         "description": "Test run for Huggingface model",
         "dataset": str(created_dataset.id),
         "max_samples": 2,
-        "job_config": {"job_type": JobType.ANNOTATION, "task": "summarization"},
+        "job_config": {
+            "job_type": JobType.ANNOTATION,
+            "task": "summarization",
+            "model": TEST_SEQ2SEQ_MODEL,
+            "provider": "hf",
+            "output_field": "ground_truth",
+        },
     }
+
     create_annotation_job_response = local_client.post("/jobs/annotate/", headers=POST_HEADER, json=annotation_payload)
     assert create_annotation_job_response.status_code == 201
 


### PR DESCRIPTION
# What's changing

In this PR I change the model use for annotation jobs during integration tests to use tiny random Bart version to speed up the suite. I don't think we need to test the actual output of the model and just that it produces something 


# How to test it

Steps to test the changes:

1. Integration suite runs ok

# I already...

- [X] Tested the changes in a working environment to ensure they work as expected
- [N/A] Added some tests for any new functionality
- [N/A ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [X] Checked if a (backend) DB migration step was required and included it if required
