### PR TITLE
Ray: raise API auth errors from inference jobs

### DIFF
--- a/lumigator/backend/backend/services/jobs.py
+++ b/lumigator/backend/backend/services/jobs.py
@@ -84,15 +84,15 @@ JobSpecificRestrictedConfig = type[JobEvalConfig | JobInferenceConfig]
 class JobService:
     """Job service is responsible for managing jobs in Lumigator."""
 
-    NON_TERMINAL_STATUS = [
+    NON_TERMINAL_STATUS = {
         JobStatus.CREATED.value,
         JobStatus.PENDING.value,
         JobStatus.RUNNING.value,
-    ]
+    }
     """list: A list of non-terminal job statuses."""
 
     # TODO: rely on https://github.com/ray-project/ray/blob/7c2a200ef84f17418666dad43017a82f782596a3/python/ray/dashboard/modules/job/common.py#L53
-    TERMINAL_STATUS = [JobStatus.FAILED.value, JobStatus.SUCCEEDED.value, JobStatus.STOPPED.value]
+    TERMINAL_STATUS = {JobStatus.FAILED.value, JobStatus.SUCCEEDED.value, JobStatus.STOPPED.value}
     """list: A list of terminal job statuses."""
 
     SAFE_JOB_NAME_REGEX = re.compile(r"[^\w\-_.]")
@@ -540,7 +540,7 @@ class JobService:
             return JobResponse.model_validate(record)
 
         # get job status from ray
-        job_status = self.ray_client.get_job_status(job_id)
+        job_status = self.ray_client.get_job_status(str(job_id))
         loguru.logger.info(f"Obtaining info from ray for job {job_id}: {job_status}")
 
         # update job status in the DB if it differs from the current status

--- a/lumigator/backend/backend/tests/integration/api/routes/test_api_workflows.py
+++ b/lumigator/backend/backend/tests/integration/api/routes/test_api_workflows.py
@@ -55,10 +55,11 @@ def test_upload_data_launch_job(
     dialog_dataset,
     dependency_overrides_services,
 ):
+    logger.info("Running test: 'test_upload_data_launch_job'")
+
     response = local_client.get("/health")
     assert response.status_code == 200
 
-    logger.info("Running test...")
     # store how many ds are in the db before we start
     get_ds_response = local_client.get("/datasets/")
     assert get_ds_response.status_code == 200
@@ -80,8 +81,8 @@ def test_upload_data_launch_job(
     assert get_ds_before.total == get_ds.total + 1
 
     infer_payload = {
-        "name": "test_run_hugging_face",
-        "description": "Test run for Huggingface model",
+        "name": "test_upload_data_launch_job-inference",
+        "description": "Huggingface model inference",
         "dataset": str(created_dataset.id),
         "max_samples": 10,
         "job_config": {
@@ -113,8 +114,8 @@ def test_upload_data_launch_job(
     assert output_infer_job_response_model is not None
 
     eval_payload = {
-        "name": "test_run_hugging_face",
-        "description": "Test run for Huggingface model",
+        "name": "test_upload_data_launch_job-evaluation",
+        "description": "Huggingface model evaluation",
         "dataset": str(output_infer_job_response_model.id),
         "max_samples": 10,
         "job_config": {
@@ -172,7 +173,7 @@ def test_upload_data_no_gt_launch_annotation(
 
     annotation_payload = {
         "name": "test_annotate",
-        "description": "Test run for Huggingface model",
+        "description": "Annotation job to add ground truth",
         "dataset": str(created_dataset.id),
         "max_samples": 2,
         "job_config": {"job_type": JobType.ANNOTATION, "task": "summarization"},
@@ -446,7 +447,7 @@ async def test_full_experiment_launch(
 
     # Trigger experiment/workflows
     experiment_id = create_experiment(local_client, dataset.id, task_definition)
-    workflow_names = ["Workflow_1", "Workflow_2"]
+    workflow_names = ["Backend_Workflow_1", "Backend_Workflow_2"]
     workflows = [
         run_workflow(
             local_client=local_client,
@@ -609,6 +610,7 @@ async def wait_for_workflow_complete(local_client: TestClient, workflow_id: UUID
 def test_launch_job_with_secret(
     local_client: TestClient,
     dialog_dataset,
+    dependency_overrides_services,  # Required even if not used directly in the test
 ):
     logger.info("Running test: 'test_launch_job_with_secret'")
     secret_name = "MISTRAL_API_KEY"  # pragma: allowlist secret

--- a/lumigator/jobs/inference/model_clients/external_api_clients.py
+++ b/lumigator/jobs/inference/model_clients/external_api_clients.py
@@ -27,7 +27,7 @@ class LiteLLMModelClient(BaseModelClient):
         logger.info(f"LiteLLMModelClient initialized with config: {config}")
 
     @retry_with_backoff(max_retries=3)
-    def _make_completion_request(self, litellm_model: str, examples: list[dict[str, str]]) -> list[ModelResponse]:
+    def _make_completion_request(self, litellm_model: str, examples: list[list[dict[str, str]]]) -> list[ModelResponse]:
         """Make a request to the LLM with proper error handling"""
         return batch_completion(
             model=litellm_model,
@@ -44,6 +44,9 @@ class LiteLLMModelClient(BaseModelClient):
     def _create_prediction_result(self, response_with_index):
         index, response = response_with_index
         logger.info(response)
+        # Check if the response is an exception (e.g. litellm.exceptions.AuthenticationError).
+        if isinstance(response, Exception):
+            raise response
 
         # Extract and log cost. In the case of self-hosted models,
         # there is not a _hidden_params attribute in the response.

--- a/lumigator/sdk/tests/integration/test_scenarios.py
+++ b/lumigator/sdk/tests/integration/test_scenarios.py
@@ -286,7 +286,7 @@ def test_create_exp_workflow_check_results(
 
     # Create a workflow for the experiment
     request = WorkflowCreateRequest(
-        name="Workflow_1",
+        name="SDK_Workflow_1",
         description="Test workflow for inf and eval",
         model=model,
         provider="hf",
@@ -310,7 +310,7 @@ def test_create_exp_workflow_check_results(
 
     # Add another workflow to the experiment
     request = WorkflowCreateRequest(
-        name="Workflow_2",
+        name="SDK_Workflow_2",
         description="Test workflow for inf and eval",
         model=model,
         provider="hf",


### PR DESCRIPTION
# What's changing

Updated integration test that wasn't setting the correct config key for passing the API key/secret. 

The test was calling Ray for real and the jobs fail out with auth errors trying to contact Mistral's API. The test has been updated to remove some bits we didn't need and just check the test fails as expected. 

The inference job now also checks if any prediction responses are errors and raises them.

Summary:

* JobService: use sets and fix IDE warning
* conftest: improve wait_for_job code
* Inference: Raise errors in prediction results (Ray)
* Review test_launch_job_with_secret integration test

# How to test it

Steps to test the changes:

1.
2.
3.

# Additional notes for reviewers

Anything you'd like to add to help the reviewer understand the changes you're proposing.

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and [product documentation](https://mozilla-ai.github.io/lumigator) under `/docs`)
- [ ] Checked if a (backend) DB migration step was required and included it if required
