### PR TITLE
Fix: uv.lock file update (out of date)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1342,7 +1342,7 @@ wheels = [
 
 [[package]]
 name = "lumigator-schemas"
-version = "0.1.3a0"
+version = "0.1.4a0"
 source = { editable = "lumigator/schemas" }
 dependencies = [
     { name = "pydantic" },
@@ -1356,7 +1356,7 @@ dev = [{ name = "pytest", specifier = ">=8.3.3" }]
 
 [[package]]
 name = "lumigator-sdk"
-version = "0.1.3a0"
+version = "0.1.4a0"
 source = { directory = "lumigator/sdk" }
 dependencies = [
     { name = "loguru" },


### PR DESCRIPTION
# What's changing

Seems to have been missed (https://github.com/mozilla-ai/lumigator/pull/1325) but pre-commit picked it up and updated it when I ran this locally:

```
uv run pre-commit run --all-files
```

Refs https://github.com/mozilla-ai/lumigator/pull/1325

![image](https://github.com/user-attachments/assets/c8374062-cd0a-462f-a477-59cae5b0eb12)
